### PR TITLE
Some backtraces don't have a :in `function'

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -17,7 +17,7 @@ module Raven
       "error" => 40,
     }
 
-    BACKTRACE_RE = /^(.+?):(\d+)(?::in `(.+?)')$/
+    BACKTRACE_RE = /^(.+?):(\d+)(?::in `(.+?)')?$/
 
     attr_reader :id
     attr_accessor :project, :message, :timestamp, :level


### PR DESCRIPTION
Some backtrace lines don't report a function, so when I was testing out this client I was getting an exception. Altered the regexp to make the third element optional, which also reflects what the code says.
