### PR TITLE
don't reverse exception backtrace when generating frames

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -103,7 +103,7 @@ module Raven
           int.module = class_parts.join('::')
         end
         evt.interface :stack_trace do |int|
-          int.frames = exc.backtrace.reverse.map do |trace_line|
+          int.frames = exc.backtrace.map do |trace_line|
             md = BACKTRACE_RE.match(trace_line)
             raise Error.new("Unable to parse backtrace line: #{trace_line.inspect}") unless md
             int.frame do |frame|


### PR DESCRIPTION
Not sure why that reverse call was there, but it causes stacktraces to be displayed least recent call first.
