### PR TITLE
Fallback to hostname when gethostbyname fails

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -34,7 +34,12 @@ module Raven
 
       @logger = options[:logger] || 'root'
       @culprit = options[:culprit]
-      @server_name = options[:server_name] || Socket.gethostname
+
+      # Sometimes OS X gets upset with Socket.gethostbyname, so fall back
+      # to plain old hostname if it fails.
+      hostname = Socket.gethostname
+      @server_name = options[:server_name] || Socket.gethostbyname(hostname) rescue hostname
+
       @modules = options[:modules] || Gem::Specification.each.inject({}){|memo, spec| memo[spec.name] = spec.version; memo}
       @extra = options[:extra]
 


### PR DESCRIPTION
As mentioned in the discussion on 9176e6b0667e585, `Socket.gethostbyname` sometimes fails on OS X. This adds the result of `Socket.gethostname` as a fallback for when `gethostbyname` does fail.

Thanks!
