### PR TITLE
Detect RAILS_ENV and default to development environment

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -28,7 +28,7 @@ module Raven
       self.server = ENV['SENTRY_DSN'] if ENV['SENTRY_DSN']
       @context_lines = 3
       self.environments = %w[ production ]
-      self.current_environment = ENV['RACK_ENV']
+      self.current_environment = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
     end
 
     def server=(value)


### PR DESCRIPTION
Even though RACK_ENV is generally preferred, RAILS_ENV still exists in some older apps.

As there was previously no default environment, the current_environment would be nil when RACK_ENV was missing, meaning that errors would be silently not sent. Adding development as the default environment resolves this.

Thanks!
