### PR TITLE
Use Rack middleware in older versions of Rails 3 (3.1.3 for example)

### DIFF
--- a/lib/raven/railtie.rb
+++ b/lib/raven/railtie.rb
@@ -15,6 +15,8 @@ module Raven
       if defined?(::ActionDispatch::DebugExceptions)
         require 'raven/rails/middleware/debug_exceptions_catcher'
         ::ActionDispatch::DebugExceptions.send(:include, Raven::Rails::Middleware::DebugExceptionsCatcher)
+      else
+        Rails.configuration.middleware.use "Raven::Rack"
       end
     end
   end


### PR DESCRIPTION
I have no idea what I'm doing, but in my head this fixes things.
