### PR TITLE
Use multi_json instead of yajl-ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 PATH
   remote: .
   specs:
-    raven (0.1)
+    sentry-raven (0.3)
       faraday (~> 0.8.0.rc2)
       hashie
+      multi_json (~> 1.0)
       uuidtools
-      yajl-ruby
 
 GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.0.6)
     diff-lcs (1.1.3)
-    faraday (0.8.0.rc2)
+    faraday (0.8.1)
       multipart-post (~> 1.1)
     hashie (1.2.0)
     method_source (0.7.1)
@@ -36,8 +36,7 @@ GEM
       simplecov-html (~> 0.5.3)
     simplecov-html (0.5.3)
     slop (2.4.4)
-    uuidtools (2.1.2)
-    yajl-ruby (1.1.0)
+    uuidtools (2.1.3)
 
 PLATFORMS
   ruby
@@ -45,6 +44,6 @@ PLATFORMS
 DEPENDENCIES
   pry
   rake
-  raven!
   rspec
+  sentry-raven!
   simplecov

--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -1,6 +1,6 @@
 require 'openssl'
 require 'uri'
-require 'yajl'
+require 'multi_json'
 require 'faraday'
 
 require 'raven/version'
@@ -59,7 +59,7 @@ module Raven
       Raven.logger.debug "Sending event #{event.id} to Sentry"
       response = self.conn.post '/api/store/' do |req|
         req.headers['Content-Type'] = 'application/json'
-        req.body = Yajl::Encoder.encode(event.to_hash)
+        req.body = MultiJson.encode(event.to_hash)
         req.headers[AUTH_HEADER_KEY] = self.generate_auth_header(req.body)
       end
       raise Error.new("Error from Sentry server (#{response.status}): #{response.body}") unless response.status == 200

--- a/sentry-raven.gemspec
+++ b/sentry-raven.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir['lib/**/*']
   gem.add_dependency "faraday", "~> 0.8.0.rc2"
   gem.add_dependency "uuidtools"
-  gem.add_dependency "yajl-ruby"
+  gem.add_dependency "multi_json", "~> 1.0"
   gem.add_dependency "hashie"
 end


### PR DESCRIPTION
This will make sentry-raven compatible with jruby and others json implementations.
