### PR TITLE
Avoid Hashie Dash Bug with Parameter Defaults leading to erroneous headers, env in Sentry events

### DIFF
--- a/lib/raven/interfaces/http.rb
+++ b/lib/raven/interfaces/http.rb
@@ -10,8 +10,14 @@ module Raven
     property :data
     property :query_string
     property :cookies
-    property :headers, :default => {}
-    property :env, :default => {}
+    property :headers
+    property :env
+
+    def initialize(*arguments)
+      self.headers = {}
+      self.env = {}
+      super(*arguments)
+    end
 
     def from_rack(env)
       require 'rack'

--- a/lib/raven/interfaces/message.rb
+++ b/lib/raven/interfaces/message.rb
@@ -6,8 +6,12 @@ module Raven
 
     name 'sentry.interfaces.Message'
     property :message, :required => true
-    property :params, :default => []
+    property :params
 
+    def initialize(*arguments)
+      self.params = []
+      super(*arguments)
+    end
   end
 
   register_interface :message => MessageInterface

--- a/lib/raven/interfaces/stack_trace.rb
+++ b/lib/raven/interfaces/stack_trace.rb
@@ -9,6 +9,11 @@ module Raven
     name 'sentry.interfaces.Stacktrace'
     property :frames, :default => []
 
+    def initialize(*arguments)
+      self.frames = []
+      super(*arguments)
+    end
+
     def to_hash
       data = super
       data['frames'] = data['frames'].map{|frame| frame.to_hash}
@@ -24,11 +29,18 @@ module Raven
       property :abs_path
       property :filename, :required => true
       property :function
-      property :vars, :default => {}
-      property :pre_context, :default => []
-      property :post_context, :default => []
+      property :vars
+      property :pre_context
+      property :post_context
       property :context_line
       property :lineno, :required => true
+
+      def initialize(*arguments)
+        self.vars= {}
+        self.pre_context = []
+        self.post_context = []
+        super(*arguments)
+      end
 
       def to_hash
         data = super


### PR DESCRIPTION
Hashie Dash defaults are evaluated at interpretation, not runtime, so hashes and array are shared amongst all instantiations.  The result of this is that sentry events can contain headers/env values from earlier, unrelated events.

This pull request manually initializes the interface defaults at instantiation/runtime.

See:  https://github.com/intridea/hashie/issues/53
