### PR TITLE
Don't subclass `Exception`.

### DIFF
--- a/lib/raven/error.rb
+++ b/lib/raven/error.rb
@@ -1,6 +1,6 @@
 module Raven
 
-  class Error < Exception
+  class Error < StandardError
   end
 
 end


### PR DESCRIPTION
Most errors should subclass `StandardError`.  A bare rescue will not catch `Exception`-subclassed errors; that's by design because `Exception`-subclassed errors are intended for situations like signals (e.g. when a user halts a script with "ctrl-c") or fatal situations like out-of-memory.

See http://www.codeotaku.com/blog/2009-08/ruby-standard-error/index for more info on the design of Ruby's exception hierarchy.

(BTW, I also submitted a PR to coderanger/raven-ruby#1, but I noticed that the other PRs had been submitted and pulled in from getsentry/raven-ruby, so I'm resubmitting this. I'm a bit confused about coderanger/raven-ruby vs getsentry/raven-ruby as they both seem to have recent activity from @dcramer).
