### PR TITLE
Alias capture{Message,Exception} to underscored names

### DIFF
--- a/lib/raven.rb
+++ b/lib/raven.rb
@@ -87,15 +87,18 @@ module Raven
       end
     end
 
-    def captureException(exception)
+    def capture_exception(exception)
       evt = Event.capture_exception(exception)
       send(evt) if evt
     end
 
-    def captureMessage(message)
+    def capture_message(message)
       evt = Event.capture_message(message)
       send(evt) if evt
     end
 
+    # For cross-language compat
+    alias :captureException :capture_exception
+    alias :captureMessage :capture_message
   end
 end

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -168,7 +168,7 @@ module Raven
 
     # For cross-language compat
     class << self
-      alias :captionException :capture_exception
+      alias :captureException :capture_exception
       alias :captureMessage :capture_message
     end
 


### PR DESCRIPTION
Also correct a typo in similar aliasing in Event.
