### PR TITLE
Support options; fixes #32

### DIFF
--- a/lib/raven.rb
+++ b/lib/raven.rb
@@ -66,14 +66,14 @@ module Raven
     #   Raven.capture do
     #     MyApp.run
     #   end
-    def capture(&block)
+    def capture(options={}, &block)
       if block
         begin
           block.call
         rescue Error => e
           raise # Don't capture Raven errors
         rescue Exception => e
-          self.captureException(e)
+          capture_exception(e, options)
           raise
         end
       else
@@ -81,19 +81,19 @@ module Raven
         at_exit do
           if $!
             logger.debug "Caught a post-mortem exception: #{$!.inspect}"
-            self.captureException($!)
+            capture_exception($!, options)
           end
         end
       end
     end
 
-    def capture_exception(exception)
-      evt = Event.capture_exception(exception)
+    def capture_exception(exception, options={})
+      evt = Event.capture_exception(exception, options)
       send(evt) if evt
     end
 
-    def capture_message(message)
-      evt = Event.capture_message(message)
+    def capture_message(message, options={})
+      evt = Event.capture_message(message, options)
       send(evt) if evt
     end
 

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -18,6 +18,10 @@ describe Raven::Event do
       it 'has level ERROR' do
         hash['level'].should == 40
       end
+
+      it 'accepts an options hash' do
+        Raven::Event.capture_message(message, {:logger => 'logger'}).logger.should == 'logger'
+      end
     end
   end
 
@@ -110,6 +114,9 @@ describe Raven::Event do
         end
       end
     end
-  end
 
+    it 'accepts an options hash' do
+      Raven::Event.capture_exception(exception, {:logger => 'logger'}).logger.should == 'logger'
+    end
+  end
 end

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -12,16 +12,19 @@ describe Raven do
 
   it 'captureMessage should send result of Event.capture_message' do
     message = "Test message"
-    Raven::Event.should_receive(:capture_message).with(message)
+    options = {}
+
+    Raven::Event.should_receive(:capture_message).with(message, options)
     Raven.should_receive(:send).with(@event)
 
-    Raven.captureMessage(message)
+    Raven.captureMessage(message, options)
   end
 
   it 'captureException should send result of Event.capture_exception' do
     exception = build_exception()
+    options   = {}
 
-    Raven::Event.should_receive(:capture_exception).with(exception)
+    Raven::Event.should_receive(:capture_exception).with(exception, options)
     Raven.should_receive(:send).with(@event)
 
     Raven.captureException(exception)


### PR DESCRIPTION
This changes the interface of Event.new, Event.capture_exception,
Event.capture_rack_exception, and Event.capture_message slightly,
but not in a way that breaks any existing specs or raven-ruby code,
so I'm assuming it's acceptable.
