### PR TITLE
raven doesn't need faraday 0.8

### DIFF
--- a/sentry-raven.gemspec
+++ b/sentry-raven.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.has_rdoc = true
   gem.extra_rdoc_files = ["README.md", "LICENSE"]
   gem.files = Dir['lib/**/*']
-  gem.add_dependency "faraday", "~> 0.8.0.rc2"
+  gem.add_dependency "faraday", ">= 0.7.6"
   gem.add_dependency "uuidtools"
   gem.add_dependency "multi_json", "~> 1.0"
   gem.add_dependency "hashie"


### PR DESCRIPTION
Hi,
Changes in faraday 0.8 are not needed by raven-ruby (see https://github.com/technoweenie/faraday/wiki/Changelog) and can conflict in Gemfile with other more conservative gem that still use faraday 0.7 (ex: https://rubygems.org/gems/koala)
Tests passes and we've been using raven-ruby with faraday 0.7 since once month without flaws, not sure what i can do more to test it.
regards
