### PR TITLE
Add config for Faraday/HTTP timeout

### DIFF
--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -31,6 +31,8 @@ module Raven
 
       @conn ||=  Faraday.new(:url => self.configuration[:server]) do |builder|
         builder.adapter  Faraday.default_adapter
+        builder.options[:timeout] = self.configuration.timeout if self.configuration.timeout
+        builder.options[:open_timeout] = self.configuration.open_timeout if self.configuration.open_timeout
       end
     end
 

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -31,6 +31,12 @@ module Raven
     # Processors to run on data before sending upstream
     attr_accessor :processors
 
+    # Timeout when waiting for the server to return data in seconds
+    attr_accessor :timeout
+
+    # Timeout waiting for the connection to open in seconds
+    attr_accessor :open_timeout
+
     attr_reader :current_environment
 
     def initialize


### PR DESCRIPTION
This commit adds configuration options for open-timeout and
read-timeout on the connection. This enables users to configure Raven
to ensure maximum responsiveness even when Sentry server is down.

Fixes issue #53.
