### PR TITLE
Add support for custom backtrace cleaner

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -31,6 +31,9 @@ module Raven
     # Processors to run on data before sending upstream
     attr_accessor :processors
 
+    # The default backtrace cleaner to use
+    attr_accessor :backtrace_cleaner
+
     attr_reader :current_environment
 
     def initialize

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -97,6 +97,7 @@ module Raven
 
     def self.capture_exception(exc, options={}, &block)
       configuration = options[:configuration] || Raven.configuration
+      cleaner = configuration.backtrace_cleaner || Raven::BacktraceCleaner.new
       if exc.is_a?(Raven::Error)
         # Try to prevent error reporting loops
         Raven.logger.info "Refusing to capture Raven error: #{exc.inspect}"
@@ -112,7 +113,7 @@ module Raven
         evt.parse_exception(exc)
         if (exc.backtrace)
           evt.interface :stack_trace do |int|
-            int.frames = Raven::BacktraceCleaner.new.clean(exc.backtrace).map do |trace_line, in_app|
+            int.frames = cleaner.clean(exc.backtrace).map do |trace_line, in_app|
               int.frame { |frame| evt.parse_backtrace_line(trace_line, frame, in_app) }
             end
             evt.culprit = evt.get_culprit(int.frames)


### PR DESCRIPTION
This allows for a configuration-specific backtrace cleaner, so that
consumers of Raven-Ruby can define a backtrace cleaner than meets
their own needs.
