### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ end
 ## Sanitizing Data (Processors)
 
 If you need to sanitize or pre-process (before its sent to the server) data, you can do so using the Processors
-implementation. By default, a single processor is installed (Raven::Processors::SanitizeData), which will attempt to
+implementation. By default, a single processor is installed (Raven::Processor::SanitizeData), which will attempt to
 sanitize keys that match various patterns (e.g. password) and values that resemble credit card numbers.
 
 To specify your own (or to remove the defaults), simply pass them with your configuration:
@@ -181,7 +181,7 @@ require 'raven'
 
 Raven.configure do |config|
   config.dsn = 'http://public:secret@example.com/project-id'
-  config.processors = [Raven::Processors::SanitizeData]
+  config.processors = [Raven::Processor::SanitizeData]
 end
 ```
 


### PR DESCRIPTION
Fix typo in `Raven::Processor` example
