### PR TITLE
Also capture Sinatra's errors

### DIFF
--- a/lib/raven/rack.rb
+++ b/lib/raven/rack.rb
@@ -33,8 +33,10 @@ module Raven
         raise
       end
 
-      if env['rack.exception']
-        evt = Event.capture_rack_exception(env['rack.exception'], env)
+      error = env['rack.exception'] || env['sinatra.error']
+
+      if error
+        evt = Event.capture_rack_exception(error, env)
         Raven.send(evt) if evt
       end
 

--- a/spec/raven/rack_spec.rb
+++ b/spec/raven/rack_spec.rb
@@ -40,4 +40,22 @@ describe Raven::Rack do
 
     stack.call(env)
   end
+
+  it 'should capture sinatra errors' do
+    exception = build_exception()
+    env = {}
+
+    Raven::Event.should_receive(:capture_rack_exception).with(exception, env)
+    Raven.should_receive(:send).with(@event)
+
+    app = lambda do |e|
+      e['sinatra.error'] = exception
+      [200, {}, ['okay']]
+    end
+
+    stack = Raven::Rack.new(app)
+
+    stack.call(env)
+  end
+
 end


### PR DESCRIPTION
Sinatra puts the errors in env['sinatra.error'], instead of the more
common env['rack.exception'].

Closes #26
