### PR TITLE
Sensible defaults for timeouts

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -69,6 +69,8 @@ module Raven
       self.processors = [Raven::Processor::SanitizeData]
       self.ssl_verification = true
       self.encoding = 'json'
+      self.timeout = 1
+      self.open_timeout = 1
     end
 
     def server=(value)


### PR DESCRIPTION
This nearly killed out prod servers, it was taking 10-20 seconds for GetSentry to respond and there was no http timeout. It slowly hung all the workers.
