### PR TITLE
Use http_adapter configuration for setting Faraday adapter

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -51,6 +51,9 @@ module Raven
 
     attr_reader :current_environment
 
+    # The Faraday adapter to be used. Will default to Net::HTTP when not set.
+    attr_accessor :http_adapter
+
     IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
                       'ActionController::RoutingError',
                       'ActionController::InvalidAuthenticityToken',

--- a/lib/raven/transports/http.rb
+++ b/lib/raven/transports/http.rb
@@ -30,11 +30,15 @@ module Raven
             :url => self.configuration[:server],
             :ssl => {:verify => self.configuration.ssl_verification}
           ) do |builder|
-            builder.adapter Faraday.default_adapter
+            builder.adapter(*adapter)
             builder.options[:timeout] = self.configuration.timeout if self.configuration.timeout
             builder.options[:open_timeout] = self.configuration.open_timeout if self.configuration.open_timeout
           end
         end
+      end
+
+      def adapter
+        configuration.http_adapter || Faraday.default_adapter
       end
 
     end

--- a/spec/raven/integration_spec.rb
+++ b/spec/raven/integration_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'raven'
+
+describe "Integration tests" do
+
+  example "posting an exception" do
+
+    stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.post('/api/store') { [200, {}, 'ok'] }
+    end
+
+    Raven.configure do |config|
+      config.server = 'http://12345:67890@sentry.localdomain/sentry/42'
+      config.environments = [ "test" ]
+      config.current_environment = "test"
+      config.http_adapter = [ :test, stubs ]
+    end
+
+    Raven.capture_exception(build_exception)
+
+    stubs.verify_stubbed_calls
+
+  end
+
+end


### PR DESCRIPTION
This PR gives the user the ability to change the Faraday adapter:

``` ruby
Raven.configure do |config|
  config.http_adapter = [ :em_http ]
end
```

This opens the door for:
- Using Sentry in an Eventmachine application.
- Sending requests async when using Thin, with a technique like the one [described here](http://www.jonb.org/2013/01/25/async-rails.html).
- Providing stubs for testing.

I have no idea where to put the test for it, so I improvised.

I'm also not sure about the implementation. We could also yield the faraday builder object for maximum flexibility:

``` ruby
Raven.configure do |config|
  config.http_connection do |builder|
    builder.adapter :em_http
  end
end
```

Or just do nothing and keep on using the global adapter, so users are only able to change the adapter for every Faraday request in the app:

``` ruby
Faraday.default_adapter = :em_http
```

What do you think?
