### PR TITLE
Change Sentry 403 error to a logged event instead

### DIFF
--- a/lib/raven/transports/http.rb
+++ b/lib/raven/transports/http.rb
@@ -15,7 +15,7 @@ module Raven
           req.headers['X-Sentry-Auth'] = auth_header
           req.body = data
         end
-        raise Error.new("Error from Sentry server (#{response.status}): #{response.body}") unless response.status == 200
+        Raven.logger.warn "Error from Sentry server (#{response.status}): #{response.body}" unless response.status == 200
       end
 
     private

--- a/spec/raven/integration_spec.rb
+++ b/spec/raven/integration_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 require 'raven'
+require 'raven/error'
+require 'logger'
 
 describe "Integration tests" do
 
@@ -22,4 +24,23 @@ describe "Integration tests" do
 
   end
 
+  example "hitting quota limit shouldn't swallow exception" do
+
+    stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.post('/api/store') { [403, {}, 'Creation of this event was blocked'] }
+    end
+
+    Raven.configure do |config|
+      config.server = 'http://12345:67890@sentry.localdomain/sentry/42'
+      config.environments = [ "test" ]
+      config.current_environment = "test"
+      config.http_adapter = [ :test, stubs ]
+    end
+
+    Raven.logger.should_receive(:warn).exactly(1).times
+    expect { Raven.capture_exception(build_exception) }.not_to raise_error(Raven::Error)
+
+    stubs.verify_stubbed_calls
+
+  end
 end


### PR DESCRIPTION
Currently, if you get an error from Sentry (whether it's down, bad creds, or over quota), Raven swallows the error and displays its own Sentry error message.

This change makes it log a Sentry error instead of raising an exception, which should allow the underlying exception to come up.
