### PR TITLE
Properly clear user/tags/extra context after request.

### DIFF
--- a/lib/raven.rb
+++ b/lib/raven.rb
@@ -26,11 +26,8 @@ module Raven
     # values for all Raven configuration options. See Raven::Configuration.
     attr_writer :configuration
 
-    # Additional context for events
-    attr_writer :context
-
     def context
-      @context ||= Context.new
+      Context.current
     end
 
     def logger

--- a/lib/raven/context.rb
+++ b/lib/raven/context.rb
@@ -1,10 +1,10 @@
 module Raven
   class Context
-    def current
+    def self.current
       Thread.current[:sentry_context] ||= new
     end
     
-    def clear!
+    def self.clear!
       Thread.current[:sentry_context] = nil
     end
     

--- a/lib/raven/rack.rb
+++ b/lib/raven/rack.rb
@@ -32,7 +32,7 @@ module Raven
         Raven.send(evt)
         raise
       ensure
-        Raven.context.clear!
+        Context.clear!
       end
 
       error = env['rack.exception'] || env['sinatra.error']

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -3,7 +3,7 @@ require 'raven'
 
 describe Raven::Event do
   before do
-    Raven.context.clear!
+    Raven::Context.clear!
   end
 
   context 'a fully implemented event' do

--- a/spec/raven/rack_spec.rb
+++ b/spec/raven/rack_spec.rb
@@ -59,14 +59,14 @@ describe Raven::Rack do
   end
 
   it 'should clear context after app is called' do
-    Thread.current[:sentry_context] = { :foo => :bar }
+    Raven::Context.current.tags[:environment] = :test
 
     app = lambda { |env| ['response', {}, env] }
     stack = Raven::Rack.new(app)
 
     response = stack.call({})
 
-    Thread.current[:sentry_context].should eq(nil)
+    Raven::Context.current.tags.should eq({})
   end
 
 end


### PR DESCRIPTION
As brought up at https://github.com/getsentry/raven-ruby/commit/0bf46f9e957b179a5d0ce1295840eaff89d8146a#commitcomment-2775575.

Me 8 days ago:

> Either I'm crazy or `@context ||= Context.new` should be `Context.current`. Which is it?  :smile: 

Today:

> Worse even, I think we shouldn't be calling `Context.new` or `Raven.context` anywhere. We should only be accessing the context through `Context.current` (where `current` and `clear!` should become class methods), so clearing the context in `Raven:Rack` using `Context.clear!` will actually result in a new context being used when `Raven.context` or `Context.current` is called a subsequent time. I'll get a pull request up in a minute.
