### PR TITLE
Fix invalid call to logger

### DIFF
--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -33,7 +33,7 @@ module Raven
         transport.send(generate_auth_header(encoded_data), encoded_data,
                      :content_type => content_type)
       rescue
-        logger.error "Unable to record event with remote Sentry server"
+        Raven.logger.error "Unable to record event with remote Sentry server"
       end
     end
 


### PR DESCRIPTION
Fix invalid call to logger in raven client by prefixing it with Raven.logger
Fix #78
