### PR TITLE
Add config option to include extra request.env variables

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -59,6 +59,9 @@ module Raven
 
     attr_accessor :server_name
 
+    # request.env params to include in Environment
+    attr_accessor :extra_request_vars
+
     IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
                       'ActionController::RoutingError',
                       'ActionController::InvalidAuthenticityToken',
@@ -79,6 +82,7 @@ module Raven
       self.encoding = 'json'
       self.timeout = 1
       self.open_timeout = 1
+      self.extra_request_vars = []
     end
 
     def server=(value)

--- a/lib/raven/interfaces/http.rb
+++ b/lib/raven/interfaces/http.rb
@@ -26,6 +26,7 @@ module Raven
       self.method = req.request_method
       self.query_string = req.query_string
       env.each_pair do |key, value|
+        self.env[key] = value.to_s if Raven.configuration.extra_request_vars.include? key
         next unless key.upcase == key # Non-upper case stuff isn't either
         if key.start_with?('HTTP_')
           # Header

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -39,6 +39,17 @@ describe Raven::Configuration do
     it 'should have a project ID' do
       subject[:project_id].should == '42'
     end
+
+    it 'should have an empty extra_request_vars array' do
+      subject[:extra_request_vars].should eq []
+    end
+
+    shared_examples 'a request vars configuration' do
+      it 'should have extra_request_vars' do
+        subject[:extra_request_vars].should eq ["rack.session", "action_dispatch.request.params"]
+      end
+    end
+
   end
 
   context 'being initialized with a server string' do
@@ -71,5 +82,13 @@ describe Raven::Configuration do
       Raven::Configuration.new
     end
     it_should_behave_like 'a complete configuration'
+  end
+
+  context 'being initialized with extra_request_vars options' do
+    before do
+      subject.server = 'http://12345:67890@sentry.localdomain/sentry/42'
+      subject.extra_request_vars = %w[ rack.session action_dispatch.request.params ]
+    end
+    it_should_behave_like 'a request vars configuration'
   end
 end


### PR DESCRIPTION
Raven provides smart defaults for environment data that it reports to Sentry. This allows user to specify other request.env variables they may want reported to Sentry. For example rack.session, or action_dispatch.request.params
