### PR TITLE
Enable in non-test environments by default

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -70,8 +70,8 @@ module Raven
     def initialize
       self.server = ENV['SENTRY_DSN'] if ENV['SENTRY_DSN']
       @context_lines = 3
-      self.environments = %w[ production ]
       self.current_environment = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+      self.environments = %W[ #{current_environment} ] unless current_environment == 'test'
       self.send_modules = true
       self.excluded_exceptions = IGNORE_DEFAULT
       self.processors = [Raven::Processor::SanitizeData]

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -8,6 +8,8 @@ describe Raven::Configuration do
   end
 
   shared_examples 'a complete configuration' do
+
+
     it 'should have a server' do
       subject[:server].should == 'http://sentry.localdomain/sentry'
     end
@@ -71,5 +73,18 @@ describe Raven::Configuration do
       Raven::Configuration.new
     end
     it_should_behave_like 'a complete configuration'
+  end
+
+  context 'being initialized in a non-test environment' do
+    it 'should send events' do
+      subject.send_in_current_environment?.should be_true
+    end
+  end
+
+  context 'being initialized in a test environment' do
+    it 'should not send events' do
+      subject.current_environment = 'test'
+      subject.send_in_current_environment?.should be_false
+    end
   end
 end


### PR DESCRIPTION
@einarj and I remote-paired on this one.

This enables Raven by default in all environments (except test) by default. The user can, of course, still set the `environments` variable on the configuration object to override this behavior.
