### PR TITLE
Allow to override faraday's ssl config

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -52,6 +52,9 @@ module Raven
     # Should the SSL certificate of the server be verified?
     attr_accessor :ssl_verification
 
+    # Ssl settings passed direactly to faraday's ssl option
+    attr_accessor :ssl
+
     attr_reader :current_environment
 
     # The Faraday adapter to be used. Will default to Net::HTTP when not set.

--- a/lib/raven/transports/http.rb
+++ b/lib/raven/transports/http.rb
@@ -27,9 +27,12 @@ module Raven
 
           Raven.logger.debug "Raven HTTP Transport connecting to #{self.configuration.server}"
 
+          ssl_configuration = self.configuration.ssl || {}
+          ssl_configuration[:verify] = self.configuration.ssl_verification if self.configuration.ssl_verification
+
           conn = Faraday.new(
             :url => self.configuration[:server],
-            :ssl => {:verify => self.configuration.ssl_verification}
+            :ssl => ssl_configuration
           ) do |builder|
             builder.adapter(*adapter)
           end


### PR DESCRIPTION
In order to use HTTPS we need to override `ca_certificate`'s path in faraday's settings. This commit allows to override the entire `ssl` option for faraday.
