### PR TITLE
Setting minimum version of Hashie

### DIFF
--- a/sentry-raven.gemspec
+++ b/sentry-raven.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "faraday", ">= 0.7.6"
   gem.add_dependency "uuidtools"
   gem.add_dependency "multi_json", "~> 1.0"
-  gem.add_dependency "hashie"
+  gem.add_dependency "hashie", ">= 1.1.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 2.10"


### PR DESCRIPTION
Sentry needs at least v1.1.0 of Hashie, or the specs won't pass.

See: https://github.com/getsentry/raven-ruby/issues/89
