### PR TITLE
Fixing uninitialized constant error when requiring raven in Rails 2.3

### DIFF
--- a/lib/raven/rails.rb
+++ b/lib/raven/rails.rb
@@ -1,3 +1,5 @@
+require 'raven/rails/controller_methods'
+
 module Raven
   module Rails
     def self.initialize


### PR DESCRIPTION
For some reason autoloading of Raven::Rails::ControllerMethods doesn't work in fresh Rails 2.3 app. I tested this with and without bundler.

Adding explicit require fixes the problem.
