### PR TITLE
Add ReplaceCircularReferences Processor

### DIFF
--- a/lib/raven/processors/replacecircularreferences.rb
+++ b/lib/raven/processors/replacecircularreferences.rb
@@ -1,0 +1,37 @@
+require 'raven/processor'
+
+module Raven
+  module Processor
+    class ReplaceCircularReferences < Processor
+      def process(data)
+        require 'set'
+        @seen = Set.new
+        replace(data)
+      end
+
+      private
+
+      def replace(value)
+        oid = value.object_id
+        return '<...>' if @seen.include? oid
+
+        @seen << oid
+        case value
+        when Hash
+          value.each.inject({}) do |memo, (k, v)|
+            memo[replace(k)] = replace(v)
+            memo
+          end
+        when Array
+          value.map do |v|
+            replace(v)
+          end
+        else
+          value
+        end.tap do
+          @seen.delete(oid)
+        end
+      end
+    end
+  end
+end

--- a/spec/raven/replacecircularreferences_processor_spec.rb
+++ b/spec/raven/replacecircularreferences_processor_spec.rb
@@ -1,0 +1,25 @@
+require File::expand_path('../../spec_helper', __FILE__)
+require 'raven/processors/replacecircularreferences'
+
+describe Raven::Processor::ReplaceCircularReferences do
+  before do
+    @client = double("client")
+    @processor = Raven::Processor::ReplaceCircularReferences.new(@client)
+  end
+
+  it 'should replace circular references with "<...>"' do
+    circular = {}
+    circular['circular'] = circular
+    data = {
+      'sentry.interfaces.Http' => {
+        'data' => circular
+      }
+    }
+
+    result = @processor.process(data)
+
+    vars = result["sentry.interfaces.Http"]["data"]
+    vars["circular"].should eq("<...>")
+  end
+
+end


### PR DESCRIPTION
If an Event's data contains circular references MultiJson will fail to
serialize it, and may even segfault for some (C extension) backends.

This processor traverses the event data and replaces circular references
with the string "<...>", just like raven-python's Serializer. Note that
the processor must appear before other processors that recursively
traverse data (like the existing SanitizeData) to prevent
SystemStackErrors.

Change-Id: I0e9ba969e3f52fcf384a9422f5913f1a0f5f58db
Reviewed-on: https://gerrit.causes.com/21858
Tested-by: Lann Martin lann@causes.com
Reviewed-by: Aiden Scandella aiden@causes.com
