### PR TITLE
Attempt to handle circular references

### DIFF
--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -45,23 +45,38 @@ module Raven
 
   private
 
-    def encode(event)
-      hash = event.to_hash
+    def safe_encode(event)
+      event_hash = event.to_hash
 
       # apply processors
-      hash = @processors.reduce(hash) do |memo, processor|
+      event_hash = @processors.reduce(event_hash) do |memo, processor|
         processor.process(memo)
       end
 
-
+      # We don't want the exception handler raising exceptions, or even worse
+      # crashing the process. Lets be safe and try to catch
       new_adapter = configuration.json_adapter
       begin
         old_adapter, MultiJson.adapter = MultiJson.adapter, new_adapter if new_adapter
-        MultiJson.encode(hash)
+        MultiJson.dump(event_hash, :limit => configuration.json_limit || 1000)
+      rescue SystemStackError => exception
+        original_event = event.to_hash
+        extras = original_event.delete('extra')
+        send(
+          Event.capture_exception(exception, :extra => {
+            :original_extra => extras.map(&:to_s),
+            :original_event => original_event,
+          })
+        )
+        event.extra = nil
+        safe_encode(event)
       ensure
         MultiJson.adapter = old_adapter if new_adapter
       end
+    end
 
+    def encode(event)
+      encoded = safe_encode(event)
       case self.configuration.encoding
       when 'gzip'
         gzipped = Zlib::Deflate.deflate(encoded)

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -65,6 +65,8 @@ module Raven
     # The JSON adapter to be used. When unset, use multi_json's
     # intelligent defaults.
     attr_accessor :json_adapter
+    # Configure the maximum stack depth for json processor, if supported.
+    attr_accessor :json_limit
 
     IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
                       'ActionController::RoutingError',


### PR DESCRIPTION
It's possible for a sentry Client to receive an object, passed in the
extra param, containing circular references.

The MultiJson gem blows up with a signal 11 (segfault) after exhausting
the available stack space.

The standard library JSON raises a CircularDatastructure exception.

We switched to the standard library so we can handle the exception. When
we encounter a circular reference we send the exception to the Sentry
server, including the offending object as an extra param, then nillify
the extra param and try encoding the event again.

Change-Id: I48ddd50de3f6350c2025cecdc447abc9eea6b2f0
Reviewed-on: https://gerrit.causes.com/21959
Reviewed-by: John Skopis john.skopis@causes.com
Tested-by: John Skopis john.skopis@causes.com
