### PR TITLE
Fix `rake raven:test`

### DIFF
--- a/lib/raven/cli.rb
+++ b/lib/raven/cli.rb
@@ -19,7 +19,8 @@ module Raven
 
       # wipe out env settings to ensure we send the event
       if !Raven.configuration.send_in_current_environment? then
-        env_name = Raven.coniguration.environments[0]
+        environments = Raven.configuration.environments
+        env_name = (environments && environments[0]) || 'production'
         puts "Setting environment to #{env_name}"
         Raven.configuration.current_environment = env_name
       end


### PR DESCRIPTION
There was a typo "coniguration" -> "configuration"

But even with that corrected, if no environments are configured, `Raven.configuration.environments[0]` blows up cause the array is nil.

So this uses 'production' when nothing defined.
