### PR TITLE
Internal backtrace

### DIFF
--- a/lib/raven/backtrace.rb
+++ b/lib/raven/backtrace.rb
@@ -9,7 +9,7 @@ module Raven
     class Line
 
       # regexp (optionnally allowing leading X: for windows support)
-      INPUT_FORMAT = %r{^((?:[a-zA-Z]:)?[^:]+):(\d+)(?::in `([^']+)')?$}.freeze
+      INPUT_FORMAT = %r{^((?:[a-zA-Z]:)?[^:]+|<.*>):(\d+)(?::in `([^']+)')?$}.freeze
 
       APP_DIRS_PATTERN = /^(bin|app|config|lib|test)/
 

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -289,6 +289,20 @@ describe Raven::Event do
         hash['sentry.interfaces.Stacktrace']['frames'][1]['filename'].should eq('/path/to/some/file')
       end
 
+      context 'with internal backtrace' do
+        let(:exception) do
+          e = Exception.new(message)
+          e.stub(:backtrace).and_return(["<internal:prelude>:10:in `synchronize'"])
+          e
+        end
+
+        it 'marks filename and in_app correctly' do
+          hash['sentry.interfaces.Stacktrace']['frames'][0]['lineno'].should eq(10)
+          hash['sentry.interfaces.Stacktrace']['frames'][0]['function'].should eq("synchronize")
+          hash['sentry.interfaces.Stacktrace']['frames'][0]['filename'].should eq("<internal:prelude>")
+        end
+      end
+
       context 'in a rails environment' do
 
         before do


### PR DESCRIPTION
These kinds of backtraces come from e.g. Passenger:

```
/usr/local/ruby_1.9.3-p194/lib/ruby/gems/1.9.1/gems/passenger-3.0.15/lib/phusion_passenger/abstract_server_collection.rb:82:in `block in synchronize'
<internal:prelude>:10:in `synchronize'
/usr/local/ruby_1.9.3-p194/lib/ruby/gems/1.9.1/gems/passenger-3.0.15/lib/phusion_passenger/abstract_server_collection.rb:79:in `synchronize'
/usr/local/ruby_1.9.3-p194/lib/ruby/gems/1.9.1/gems/passenger-3.0.15/lib/phusion_passenger/spawn_manager.rb:244:in `spawn_rack_application'
/usr/local/ruby_1.9.3-p194/lib/ruby/gems/1.9.1/gems/passenger-3.0.15/lib/phusion_passenger/spawn_manager.rb:137:in `spawn_application'
/usr/local/ruby_1.9.3-p194/lib/ruby/gems/1.9.1/gems/passenger-3.0.15/lib/phusion_passenger/spawn_manager.rb:275:in `handle_spawn_application'
/usr/local/ruby_1.9.3-p194/lib/ruby/gems/1.9.1/gems/passenger-3.0.15/lib/phusion_passenger/abstract_server.rb:357:in `server_main_loop'
/usr/local/ruby_1.9.3-p194/lib/ruby/gems/1.9.1/gems/passenger-3.0.15/lib/phusion_passenger/abstract_server.rb:206:in `start_synchronously'
/usr/local/ruby_1.9.3-p194/lib/ruby/gems/1.9.1/gems/passenger-3.0.15/helper-scripts/passenger-spawn-server:99:in `<main>'
```

The regexp might have to be more strict in the matching.
