### PR TITLE
Add configurable json_adapter

### DIFF
--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -53,7 +53,13 @@ module Raven
         processor.process(memo)
       end
 
-      encoded = MultiJson.encode(hash)
+      new_adapter = configuration.json_adapter
+      begin
+        old_adapter, MultiJson.adapter = MultiJson.adapter, new_adapter if new_adapter
+        encoded = MultiJson.encode(hash)
+      ensure
+        MultiJson.adapter = old_adapter if new_adapter
+      end
 
       case self.configuration.encoding
       when 'gzip'

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -62,6 +62,10 @@ module Raven
 
     attr_accessor :server_name
 
+    # The JSON adapter to be used. When unset, use multi_json's
+    # intelligent defaults.
+    attr_accessor :json_adapter
+
     IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
                       'ActionController::RoutingError',
                       'ActionController::InvalidAuthenticityToken',


### PR DESCRIPTION
In some cases the JSON adapter MultiJson chooses is inappropriate.

This commit adds a configuration paramter :json:adapter.

Setting the json_adapter configuration option to one of the adapters
MultiJson knows about, e.g. :json_gem, will allow raven to use that
JSON adapter.

Change-Id: I2c9865289dbf10a401902014a20ae05516057ee0
Reviewed-on: https://gerrit.causes.com/23368
Reviewed-by: Lann Martin lann@causes.com
Reviewed-by: John Skopis john.skopis@causes.com
Tested-by: John Skopis john.skopis@causes.com
