### PR TITLE
Exception classes that redefine == cause problems on Ruby 1.8.7

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -123,7 +123,7 @@ module Raven
         Raven.logger.info "Refusing to capture Raven error: #{exc.inspect}"
         return nil
       end
-      if configuration[:excluded_exceptions].any? { |x| x === exc || x == exc.class.name }
+      if configuration[:excluded_exceptions].any? { |x| (x === exc rescue false) || x == exc.class.name }
         Raven.logger.info "User excluded error: #{exc.inspect}"
         return nil
       end


### PR DESCRIPTION
Here's the code to reproduce:

``` ruby
Raven.configuration.excluded_exceptions = ["SomeException"]

class E < Exception
  def ==(other)
    other.some_inexistant_method
  end
end

e = E.new

Raven.capture_exception e
# NoMethodError: undefined method `some_inexistant_method' for "SomeException":String
```

The bug is triggered when checking whether exception should be excluded or not https://github.com/getsentry/raven-ruby/blob/86852be2fcd3bcd51c871dd0e2a15675365af551/lib/raven/event.rb#L126), more precisely by `x === exc` (here `x` is `"SomeException"` string).

In Ruby 1.8.7 calling `===` on a `String` invokes `==` method. Since the `String` doesn't know how to compare itself with an instance of `E` it invokes `e == self` (maybe `e` knows how to compare itself with a `String`). (more on this of you're interested: http://stackoverflow.com/questions/16994398/how-does-equals-work-under-the-hood-in-ruby-1-8)

Now, this can lead to problems when `E` class redefines `==` method and makes certain assumptions on the `other` object (here assuming `other` implements `some_inexistant_method`).

An example of such case is `LibXML::XML::Error`.

In Ruby 1.9+ `String` implements it's own `===` method and this bug is gone.

Since it would be wrong to simply ignore `x === exc` for strings in Ruby 1.8.7 (as it causes problems only in some situations) I chose the approach to just swallow all exceptions this invokation raises.
