### PR TITLE
Allow configuring default tags to be sent with every event

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,17 @@ Raven.configure do |config|
 end
 ```
 
+### Tags
+
+You can configure default tags to be sent with every event. These can be
+overridden in the context or event.
+
+```ruby
+Raven.configure do |config|
+  config.tags = { environment: Rails.env }
+end
+```
+
 ### SSL Verification
 
 By default SSL certificate verification is **disabled** in the client. This choice

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -68,6 +68,9 @@ module Raven
     # intelligent defaults.
     attr_accessor :json_adapter
 
+    # Default tags for events 
+    attr_accessor :tags
+
     IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
                       'ActionController::RoutingError',
                       'ActionController::InvalidAuthenticityToken',
@@ -87,6 +90,7 @@ module Raven
       self.encoding = 'json'
       self.timeout = 1
       self.open_timeout = 1
+      self.tags = {}
     end
 
     def server=(value)

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -52,7 +52,8 @@ module Raven
       @extra = options[:extra] || {}
       @extra.merge!(context.extra)
 
-      @tags = options[:tags] || {}
+      @tags = @configuration.tags
+      @tags.merge!(options[:tags] || {})
       @tags.merge!(context.tags)
 
       block.call(self) if block

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -173,6 +173,30 @@ describe Raven::Event do
     end
   end
 
+  context 'configuration tags specified' do
+    let(:hash) {
+      config = Raven::Configuration.new
+      config.tags = { 'key' => 'value' }
+
+      Raven::Event.new({
+        :level => 'warning',
+        :logger => 'foo',
+        :tags => {
+          'foo' => 'bar'
+        },
+        :server_name => 'foo.local',
+        :configuration => config
+      }).to_hash()
+    }
+
+    it 'merges tags data' do
+      hash['tags'].should == { 
+        'key' => 'value', 
+        'foo' => 'bar'
+      }
+    end
+  end
+
   describe '.capture_message' do
     let(:message) { 'This is a message' }
     let(:hash) { Raven::Event.capture_message(message).to_hash }


### PR DESCRIPTION
closes getsentry/raven-ruby#102
