### PR TITLE
Mention the default excluded exceptions in the README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Raven.configure do |config|
 end
 ```
 
+You can find the list of exceptions that are excluded by default in [Raven::Configuration::IGNORE_DEFAULT](https://github.com/getsentry/raven-ruby/blob/master/lib/raven/configuration.rb#L74-L80). Remember you'll be overriding those defaults by setting this configuration.
+
 ### Tags
 
 You can configure default tags to be sent with every event. These can be


### PR DESCRIPTION
This is easy to miss, let's try to avoid that. :smiley: 
