### PR TITLE
Fix rake raven:test error

### DIFF
--- a/lib/raven/tasks.rb
+++ b/lib/raven/tasks.rb
@@ -4,7 +4,10 @@ require 'raven/cli'
 
 namespace :raven do
   desc "Send a test event to the remote Sentry server"
-  task :test, [:dsn] => :environment do |t, args|
+  task :test, [:dsn] do |t, args|
+    if defined? Rails
+      Rake::Task["environment"].invoke
+    end
     Raven::CLI::test(args.dsn)
   end
 end


### PR DESCRIPTION
I was getting "Your client is not configured!" (issue #115) when running `rake raven:test` becouse my initializers was not loaded.

Running `environment` rake task loads all initializers before `raven:test` task is loaded.
