### PR TITLE
Cleanup invalid utf8 byte sequences in the sanitize data processor.

### DIFF
--- a/lib/raven/processors/sanitizedata.rb
+++ b/lib/raven/processors/sanitizedata.rb
@@ -32,10 +32,10 @@ module Raven
       def sanitize(key, value)
         if !value.is_a?(String) || value.empty?
           value
-        elsif VALUES_RE.match(value) or FIELDS_RE.match(key)
+        elsif VALUES_RE.match(clean_invalid_utf8_bytes(value)) or FIELDS_RE.match(key)
           MASK
         else
-          value
+          clean_invalid_utf8_bytes(value)
         end
       end
 
@@ -43,6 +43,17 @@ module Raven
         apply(data) do |key, value|
           sanitize(key, value)
         end
+      end
+
+      private
+      def clean_invalid_utf8_bytes(text)
+        text.encode(
+          'UTF-8',
+          'binary',
+          invalid: :replace,
+          undef: :replace,
+          replace: ''
+        )
       end
     end
   end

--- a/spec/raven/sanitizedata_processor_spec.rb
+++ b/spec/raven/sanitizedata_processor_spec.rb
@@ -54,4 +54,19 @@ describe Raven::Processor::SanitizeData do
     result['ary2'].should_not eq('[...]')
   end
 
+  it 'should not fail because of invalid byte sequence in UTF-8' do
+    data = {}
+    data['invalid'] = "invalid utf8 string goes here\255".force_encoding('UTF-8')
+
+    expect { @processor.process(data) }.not_to raise_error(ArgumentError)
+  end
+
+  it 'should cleanup invalid UTF-8 bytes' do
+    data = {}
+    data['invalid'] = "invalid utf8 string goes here\255".force_encoding('UTF-8')
+
+    results = @processor.process(data)
+    results['invalid'].should eq("invalid utf8 string goes here")
+  end
+
 end


### PR DESCRIPTION
As soon as we started using raven-sentry (replacing another service), Raven.capture_exception($!) started raising ArgumentError: "invalid byte sequence in UTF-8" coming from the sanitize data processor.

It came from our [Griddler](https://github.com/thoughtbot/griddler) endpoint, and [this post](http://robots.thoughtbot.com/post/42664369166/fight-back-utf-8-invalid-byte-sequences) by thoughtbot describes the issue that they ran into when developing Griddler, and provides a fix.

I went ahead and implemented a fix that cleans up invalid utf-8 byte sequences, including a spec for it.

We're currently running against my branch in production and haven't seen the issue again. Please let me know what you think.

On another note, my co-workers and I are under the impression that an exception logger seems like the sort of thing that should never throw an exception, under any conditions. In this case, the side-effects caused us to respond with 500's to SendGrid (could've been a user facing error as well), but we never got notified by sentry of this problem. Swallowing the exception from raven would've been just a good, if not better to prevent the user facing error.

Do you guys have thoughts on that, and would you be opened to receiving a patch?
