### PR TITLE
Undefined #length method call on Pathname in StacktraceInterface

### DIFF
--- a/lib/raven/interfaces/stack_trace.rb
+++ b/lib/raven/interfaces/stack_trace.rb
@@ -45,7 +45,7 @@ module Raven
       def filename
         return nil if self.abs_path.nil?
 
-        prefix = $:.select {|s| self.abs_path.start_with?(s.to_s)}.sort_by {|s| s.length}.last
+        prefix = $:.select {|s| self.abs_path.start_with?(s.to_s)}.sort_by {|s| s.to_s.length}.last
         prefix ? self.abs_path[prefix.chomp(File::SEPARATOR).length+1..-1] : self.abs_path
       end
 


### PR DESCRIPTION
This started happening after updating rspec in one of the projects I am using sentry-raven. Rspec adds a a Pathname object to the Path which caused the error to be raised.

Similar to 82136aed
