### PR TITLE
Sidekiq integration depends on the load order

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ Add ```use Raven::Rack``` to your ```config.ru``` (or other rackup file).
 
 Like any other Rack middleware, add ```use Raven::Rack``` to your Sinatra app.
 
+### Sidekiq
+
+Raven includes [Sidekiq middleware](https://github.com/mperham/sidekiq/wiki/Middleware) which takes
+care of reporting errors that occur in Sidekiq jobs. To use it, just require the middleware by doing
+
+```ruby
+require 'raven/sidekiq'
+```
+after you require Sidekiq. If you are using Sidekiq with Rails, just put this
+require somewhere in the initializers.
+
+
 ## Capturing Events
 
 Many implementations will automatically capture uncaught exceptions (such as Rails, Sidekiq or by using


### PR DESCRIPTION
If Raven loads before Sidekiq, then this line from `raven.rb` won't be executed and the integration middleware won't load.

``` ruby
require 'raven/sidekiq' if defined?(Sidekiq)
```

So far, the best way to make sure that the middleware is loaded is to load it explicitly. This patch notes this in README.md
