### PR TITLE
Resolve #126: Exception annotation.

### DIFF
--- a/lib/raven.rb
+++ b/lib/raven.rb
@@ -118,6 +118,32 @@ module Raven
       end
     end
 
+    # Provides extra context to the exception prior to it being handled by
+    # Raven. An exception can have multiple annotations, which are merged
+    # together.
+    #
+    # The options (annotation) is treated the same as the ``options``
+    # parameter to ``capture_exception`` or ``Event.from_exception``, and
+    # can contain the same ``:user``, ``:tags``, etc. options as these
+    # methods.
+    #
+    # These will be merged with the ``options`` parameter to
+    # ``Event.from_exception`` at the top of execution.
+    #
+    # @example
+    #   begin
+    #     raise "Hello"
+    #   rescue => exc
+    #     Raven.annotate_exception(exc, :user => { 'id' => 1,
+    #                              'email' => 'foo@example.com' })
+    #   end
+    def annotate_exception(exc, options = {})
+      notes = exc.instance_variable_get(:@__raven_context) || {}
+      notes.merge!(options)
+      exc.instance_variable_set(:@__raven_context, notes)
+      exc
+    end
+
     # Bind user context. Merges with existing context (if any).
     #
     # It is recommending that you send at least the ``id`` and ``email``
@@ -157,5 +183,7 @@ module Raven
     # For cross-language compat
     alias :captureException :capture_exception
     alias :captureMessage :capture_message
+    alias :annotateException :annotate_exception
+    alias :annotate :annotate_exception
   end
 end

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -118,6 +118,9 @@ module Raven
     end
 
     def self.from_exception(exc, options={}, &block)
+      notes = exc.instance_variable_get(:@__raven_context) || {}
+      options = notes.merge(options)
+
       configuration = options[:configuration] || Raven.configuration
       if exc.is_a?(Raven::Error)
         # Try to prevent error reporting loops

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -392,5 +392,10 @@ describe Raven::Event do
     it 'accepts an options hash' do
       Raven::Event.capture_exception(exception, {:logger => 'logger'}).logger.should == 'logger'
     end
+
+    it 'uses an annotation if one exists' do
+      Raven.annotate_exception(exception, :logger => 'logger')
+      expect(Raven::Event.capture_exception(exception).logger).to eq('logger')
+    end
   end
 end

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -40,4 +40,20 @@ describe Raven do
       expect { |b| Raven.capture_exception(exception, options, &b) }.to yield_with_args(event)
     end
   end
+
+  describe '.annotate_exception' do
+    let(:exception) { build_exception }
+
+    def ivars(object)
+      object.instance_variables.map { |name| name.to_s }
+    end
+
+    it 'adds an annotation to the exception' do
+      expect(ivars(exception)).not_to include("@__raven_context")
+      Raven.annotate_exception(exception, {})
+      expect(ivars(exception)).to include("@__raven_context")
+      expect(exception.instance_variable_get(:@__raven_context)).to \
+        be_kind_of Hash
+    end
+  end
 end


### PR DESCRIPTION
This implements Raven.annotate_exception as described in #126, capturing
the annotation as `@__raven_context`, which is treated the same as the
options parameter to Raven.capture_exception.
