### PR TITLE
Rspec errors when calling Raven.rack_context()

### DIFF
--- a/spec/raven/rack_spec.rb
+++ b/spec/raven/rack_spec.rb
@@ -5,7 +5,7 @@ describe Raven::Rack do
   it 'should capture exceptions' do
     exception = build_exception()
     env = {}
-    
+
     Raven::Rack.should_receive(:capture_exception).with(exception, env)
 
     app = lambda do |e|
@@ -57,6 +57,12 @@ describe Raven::Rack do
     response = stack.call({})
 
     Raven::Context.current.tags.should eq({})
+  end
+
+  it 'should allow empty rack env in rspec tests' do
+    env = {} # the rack env is empty when running rails/rspec tests
+    Raven.rack_context(env)
+    expect { Raven.capture_exception(build_exception()) }.not_to raise_error
   end
 
   it 'should bind request context' do


### PR DESCRIPTION
We are getting an error in our spec tests for any spec that happens to trigger a call to `Raven.capture_excetion` after a call `Raven.rack_context` (even though sending is disabled).

Here is the callstack:

```
/gems/rack-1.4.5/lib/rack/request.rb:274:in`base_url'
/gems/rack-1.4.5/lib/rack/request.rb:287:in`url'
/gems/sentry-raven-0.6.0/lib/raven/interfaces/http.rb:25:in`from_rack'
/gems/sentry-raven-0.6.0/lib/raven/event.rb:63:in`block in initialize'
/gems/sentry-raven-0.6.0/lib/raven/interfaces.rb:11:in`call'
/gems/sentry-raven-0.6.0/lib/raven/interfaces.rb:11:in`initialize'
/gems/sentry-raven-0.6.0/lib/raven/interfaces/http.rb:19:in`initialize'
/gems/sentry-raven-0.6.0/lib/raven/event.rb:86:in`new'
/gems/sentry-raven-0.6.0/lib/raven/event.rb:86:in`interface'
/gems/sentry-raven-0.6.0/lib/raven/event.rb:62:in`initialize'
/gems/sentry-raven-0.6.0/lib/raven/event.rb:134:in`new'
/gems/sentry-raven-0.6.0/lib/raven/event.rb:134:in`from_exception'
/gems/sentry-raven-0.6.0/lib/raven.rb:108:in`capture_exception'
/swrve/dashboard/app/controllers/admin_controller.rb:97:in`rescue in start_copying_game_data'
/swrve/dashboard/app/controllers/admin_controller.rb:86:in`start_copying_game_data'
/gems/actionpack-3.2.13/lib/action_controller/metal/implicit_render.rb:4:in`send_action'
/gems/actionpack-3.2.13/lib/abstract_controller/base.rb:167:in`process_action'
/gems/actionpack-3.2.13/lib/action_controller/metal/rendering.rb:10:in`process_action'
/gems/actionpack-3.2.13/lib/abstract_controller/callbacks.rb:18:in`block in process_action'
/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:503:in`block in
_run__1439960585938450641__process_action__3956707369345029970__callbacks'
/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:215:in`block in _conditional_callback_around_2091'
/gems/marginalia-1.1.2/lib/marginalia/railtie.rb:30:in`record_query_comment'
/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:214:in`_conditional_callback_around_2091'
/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:425:in`_run__1439960585938450641__process_action__3956707369345029970__callbacks'
/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:405:in`__run_callback'
/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:385:in`_run_process_action_callbacks'
/gems/activesupport-3.2.13/lib/active_support/callbacks.rb:81:in`run_callbacks'
/gems/actionpack-3.2.13/lib/abstract_controller/callbacks.rb:17:in`process_action'
/gems/actionpack-3.2.13/lib/action_controller/metal/rescue.rb:29:in`process_action'
/gems/actionpack-3.2.13/lib/action_controller/metal/instrumentation.rb:30:in`block in process_action'
/gems/activesupport-3.2.13/lib/active_support/notifications.rb:123:in`block in instrument'
/gems/activesupport-3.2.13/lib/active_support/notifications/instrumenter.rb:20:in`instrument'
/gems/activesupport-3.2.13/lib/active_support/notifications.rb:123:in`instrument'
/gems/actionpack-3.2.13/lib/action_controller/metal/instrumentation.rb:29:in`process_action'
/gems/actionpack-3.2.13/lib/action_controller/metal/params_wrapper.rb:207:in`process_action'
/gems/activerecord-3.2.13/lib/active_record/railties/controller_runtime.rb:18:in`process_action'
/gems/actionpack-3.2.13/lib/abstract_controller/base.rb:121:in`process'
/gems/actionpack-3.2.13/lib/abstract_controller/rendering.rb:45:in`process'
/gems/rack-mini-profiler-0.1.26/Ruby/lib/mini_profiler/profiling_methods.rb:71:in`block in profile_method'
/gems/actionpack-3.2.13/lib/action_controller/metal/testing.rb:17:in`process_with_new_base_test'
/gems/actionpack-3.2.13/lib/action_controller/test_case.rb:475:in`process'
/gems/actionpack-3.2.13/lib/action_controller/test_case.rb:49:in`process'
/gems/actionpack-3.2.13/lib/action_controller/test_case.rb:397:in`post'
/swrve/dashboard/spec/controllers/admin_controller_spec.rb:104:in`block (3 levels) in <top (required)>'
/gems/rspec-core-2.13.1/lib/rspec/core/example.rb:114:in`instance_eval'
/gems/rspec-core-2.13.1/lib/rspec/core/example.rb:114:in`block in run'
/gems/rspec-rails-2.13.2/lib/rspec/rails/example/controller_example_group.rb:160:in`call'
/gems/rspec-rails-2.13.2/lib/rspec/rails/example/controller_example_group.rb:160:in`block (2 levels) in <module:ControllerExampleGroup>'
/gems/rspec-core-2.13.1/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_exec'
/gems/rspec-core-2.13.1/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
/gems/rspec-core-2.13.1/lib/rspec/core/example.rb:247:in `instance_eval_with_args'
/gems/rspec-core-2.13.1/lib/rspec/core/hooks.rb:87:in `block (2 levels) in run'
/gems/rspec-core-2.13.1/lib/rspec/core/hooks.rb:89:in `call'
/gems/rspec-core-2.13.1/lib/rspec/core/hooks.rb:89:in `run'
/gems/rspec-core-2.13.1/lib/rspec/core/hooks.rb:418:in `run_hook'
/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:329:in `run_around_each_hooks'
/gems/rspec-core-2.13.1/lib/rspec/core/example.rb:256:in `with_around_each_hooks'
/gems/rspec-core-2.13.1/lib/rspec/core/example.rb:111:in `run'
/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:390:in `block in run_examples'
/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:386:in `map'
/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:386:in `run_examples'
/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:371:in `run'
/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:372:in `block in run'
/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:372:in `map'
/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:372:in `run'
/gems/rspec-core-2.13.1/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
/gems/rspec-core-2.13.1/lib/rspec/core/command_line.rb:28:in `map'
/gems/rspec-core-2.13.1/lib/rspec/core/command_line.rb:28:in `block inn run'
/gems/rspec-core-2.13.1/lib/rspec/core/reporter.rb:34:in `report'
/gems/rspec-core-2.13.1/lib/rspec/core/command_line.rb:25:in `run'
/gems/rspec-core-2.13.1/lib/rspec/core/runner.rb:80:in `run'
```
