### PR TITLE
Show the last 10 lines of the backtrace is sending raises an error

### DIFF
--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -37,6 +37,7 @@ module Raven
                      :content_type => content_type)
       rescue => e
         Raven.logger.error "Unable to record event with remote Sentry server (#{e.class} - #{e.message})"
+        e.backtrace[0..10].each { |line| Raven.logger.error(line) }
         return
       end
 


### PR DESCRIPTION
If sending an error breaks, you get a pretty cryptic error message. We got:

``` bash
Nov 13 14:20:28 appserver-staging-a staging.log:  ** [Raven] Raven HTTP Transport connecting to https://app.getsentry.com
Nov 13 14:20:28 appserver-staging-a staging.log:  ** [Raven] Unable to record event with remote Sentry server (NoMethodError - undefined method `[]=' for true:TrueClass)
```

We saw this in our staging logs. It ended up being user error (I added Raven.config.ssl = true, when that's not a thing). But having a small backtrace so I can `bundle open` locally would have been handy.
