### PR TITLE
Skip excluded environments before initializing events

### DIFF
--- a/lib/raven.rb
+++ b/lib/raven.rb
@@ -102,16 +102,24 @@ module Raven
     end
 
     def capture_exception(exception, options = {})
-      if evt = Event.from_exception(exception, options)
-        yield evt if block_given?
-        send(evt)
+      if @configuration.send_in_current_environment?
+        if evt = Event.from_exception(exception, options)
+          yield evt if block_given?
+          send(evt)
+        end
+      else
+        logger.debug "Event not sent due to excluded environment: #{@configuration.current_environment}"
       end
     end
 
     def capture_message(message, options = {})
-      if evt = Event.from_message(message, options)
-        yield evt if block_given?
-        send(evt)
+      if @configuration.send_in_current_environment?
+        if evt = Event.from_message(message, options)
+          yield evt if block_given?
+          send(evt)
+        end
+      else
+        logger.debug "Event not sent due to excluded environment: #{@configuration.current_environment}"
       end
     end
 


### PR DESCRIPTION
This is a quick and dirty attempt to fix the issue I recently described in getsentry/raven-ruby#146. I’m basically just duplicating [these few lines here](https://github.com/getsentry/raven-ruby/blob/master/lib/raven/client.rb#L25-L28), but doing the check before the actual `Event` gets created, which is what I believe to be causing the long delay in development. I’m sure there’s better ways to do this, so I’m open to alternative ideas :grin: 

@dcramer Not sure what the best way is to reduce the duplication here. Any suggestions?
