### PR TITLE
Fix failing integration tests in master

### DIFF
--- a/spec/raven/integration_spec.rb
+++ b/spec/raven/integration_spec.rb
@@ -8,7 +8,7 @@ describe "Integration tests" do
   example "posting an exception" do
 
     stubs = Faraday::Adapter::Test::Stubs.new do |stub|
-      stub.post('/api/42/store') { [200, {}, 'ok'] }
+      stub.post('/api/42/store/') { [200, {}, 'ok'] }
     end
 
     Raven.configure do |config|
@@ -27,7 +27,7 @@ describe "Integration tests" do
   example "hitting quota limit shouldn't swallow exception" do
 
     stubs = Faraday::Adapter::Test::Stubs.new do |stub|
-      stub.post('/api/42/store') { [403, {}, 'Creation of this event was blocked'] }
+      stub.post('/api/42/store/') { [403, {}, 'Creation of this event was blocked'] }
     end
 
     Raven.configure do |config|


### PR DESCRIPTION
Tests are failing in master due to what looks like a minor change in URL format (stubs were missing trailing slashes).
