### PR TITLE
Allow configuration of app_dirs_pattern

### DIFF
--- a/lib/raven/backtrace.rb
+++ b/lib/raven/backtrace.rb
@@ -37,7 +37,8 @@ module Raven
       end
 
       def in_app
-        @in_app_pattern ||= Regexp.new("^(#{project_root}/)?#{APP_DIRS_PATTERN}")
+        app_dirs = Raven.configuration.app_dirs_pattern || APP_DIRS_PATTERN
+        @in_app_pattern ||= Regexp.new("^(#{project_root}/)?#{app_dirs}")
 
         if self.file =~ @in_app_pattern
           true

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -70,6 +70,9 @@ module Raven
     # Default tags for events
     attr_accessor :tags
 
+    # Exceptions from these directories to be ignored
+    attr_accessor :app_dirs_pattern
+
     IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
                       'ActionController::RoutingError',
                       'ActionController::InvalidAuthenticityToken',


### PR DESCRIPTION
This is used to configure reporting from other directories other than the default pattern.

```
 config.app_dirs_pattern =  /(bin|app|config|test)/
```
