### PR TITLE
development as default environment

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -81,7 +81,7 @@ module Raven
     def initialize
       self.server = ENV['SENTRY_DSN'] if ENV['SENTRY_DSN']
       @context_lines = 3
-      self.current_environment = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'default'
+      self.current_environment = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
       self.send_modules = true
       self.excluded_exceptions = IGNORE_DEFAULT
       self.processors = [Raven::Processor::SanitizeData]

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -41,6 +41,10 @@ describe Raven::Configuration do
     it 'should have a project ID' do
       subject[:project_id].should == '42'
     end
+
+    it 'should have a environment' do
+      subject[:current_environment] == "development"
+    end
   end
 
   context 'being initialized with a server string' do
@@ -76,6 +80,9 @@ describe Raven::Configuration do
   end
 
   context 'being initialized in a non-test environment' do
+    before do
+      subject.current_environment= "production"
+    end
     it 'should send events' do
       subject.send_in_current_environment?.should be_true
     end

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -139,6 +139,10 @@ describe Raven::Event do
   context 'rack context specified' do
     require 'stringio'
 
+    before do
+      Raven.configuration.current_environment = "production"
+    end
+
     let(:hash) do
       Raven.rack_context({
         'REQUEST_METHOD' => 'POST',


### PR DESCRIPTION
Many projects - Rails, Rack when doesn't detect environment with ENV variables  ( RAILS_ENV, RACK_ENV ) then uses default "development" environment. I think that **raven** should also do it. 

It will fix issue #143 when raven is sending exceptions from local machines. 

I have also found that at beginning raven-ruby had there `'development'` environment set as default. See: e0c84a33
