### PR TITLE
Update example for clearing context

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Raven.rack_context(env)
 If you're using the Rack middleware, we've already taken care of cleanup for you, otherwise you'll need to ensure you perform it manually:
 
 ```ruby
-Raven.context.clear!
+Raven::Context.clear!
 ```
 
 Note: the rack and user context will perform a set operation, whereas tags and extra context will merge with any existing request context.


### PR DESCRIPTION
In ee77e94dfd8b86a7375414fa40f72d1a72e74bd0 the `clear!` method was
changed from an instance method to a class method.

`Raven.context` returns an instance, so Raven.context.clear! does not
work.
