### PR TITLE
Add Ruby 2.1.0 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - jruby-19mode
   - rbx-19mode
   - 2.0.0
+  - 2.1.0
 notifications:
   irc:
     channels: "irc.freenode.org#sentry"


### PR DESCRIPTION
Hello,

I just want to be sure all will stay green with Ruby 2.1.

Cordially.
