### PR TITLE
Use e.to_s as fallback for e.message

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -190,7 +190,7 @@ module Raven
     def parse_exception(exception)
       interface(:exception) do |int|
         int.type = exception.class.to_s
-        int.value = exception.message
+        int.value = exception.to_s
         int.module = exception.class.to_s.split('::')[0...-1].join('::')
       end
     end


### PR DESCRIPTION
Some exception have nil for it's message, and it makes it unserializable

In this case, you can see exception like below

```
ArgumentError: The property 'value' is required for this Dash.
    from .../ruby/2.0.0/gems/hashie-2.0.5/lib/hashie/dash.rb:165:in `assert_property_required!'
    from .../ruby/2.0.0/gems/hashie-2.0.5/lib/hashie/dash.rb:125:in `[]='
    from (eval):6:in `value='
    from .../ruby/2.0.0/gems/sentry-raven-0.7.1/lib/raven/event.rb:194:in `block in parse_exception'
    from .../ruby/2.0.0/gems/sentry-raven-0.7.1/lib/raven/interfaces.rb:11:in `call'
    from .../ruby/2.0.0/gems/sentry-raven-0.7.1/lib/raven/interfaces.rb:11:in `initialize'
    from .../ruby/2.0.0/gems/sentry-raven-0.7.1/lib/raven/event.rb:88:in `new'
    from .../ruby/2.0.0/gems/sentry-raven-0.7.1/lib/raven/event.rb:88:in `interface'
    from .../ruby/2.0.0/gems/sentry-raven-0.7.1/lib/raven/event.rb:192:in `parse_exception'
    from .../ruby/2.0.0/gems/sentry-raven-0.7.1/lib/raven/event.rb:142:in `block in from_exception'
    from .../ruby/2.0.0/gems/sentry-raven-0.7.1/lib/raven/event.rb:59:in `call'
    from .../ruby/2.0.0/gems/sentry-raven-0.7.1/lib/raven/event.rb:59:in `initialize'
    from .../ruby/2.0.0/gems/sentry-raven-0.7.1/lib/raven/event.rb:139:in `new'
    from .../ruby/2.0.0/gems/sentry-raven-0.7.1/lib/raven/event.rb:139:in `from_exception'
    from .../ruby/2.0.0/gems/sentry-raven-0.7.1/lib/raven.rb:108:in `capture_exception'
```
