### PR TITLE
Make Interface indifferent to hash access

### DIFF
--- a/lib/raven/interfaces.rb
+++ b/lib/raven/interfaces.rb
@@ -5,7 +5,7 @@ module Raven
   INTERFACES = {}
 
   class Interface < Hashie::Dash
-    include Hashie::Extensions::IndifferentAccess
+    include Hashie::Extensions::Dash::IndifferentAccess
 
     def initialize(attributes = {}, &block)
       @check_required = false


### PR DESCRIPTION
Fixes issue https://github.com/getsentry/raven-ruby/issues/123, whereby new Rails stack traces don't fit the old hash access. For backwards compatibility, I propose we just make the hash access indifferent.

For more context, see my comment here: https://github.com/getsentry/raven-ruby/issues/123#issuecomment-42764441

Using `Hashie::Extensions::Dash::IndifferentAccess` would be preferable, but this is just 6 days old. For now it's fine to use `Hashie::Extensions::IndifferentAccess`.
