### PR TITLE
Pathname objects may be in the LOAD_PATH, causing a crash on #chomp

### DIFF
--- a/lib/raven/interfaces/stack_trace.rb
+++ b/lib/raven/interfaces/stack_trace.rb
@@ -45,7 +45,7 @@ module Raven
         return nil if self.abs_path.nil?
 
         prefix = $LOAD_PATH.select { |s| self.abs_path.start_with?(s.to_s) }.sort_by { |s| s.to_s.length }.last
-        prefix ? self.abs_path[prefix.chomp(File::SEPARATOR).length+1..-1] : self.abs_path
+        prefix ? self.abs_path[prefix.to_s.chomp(File::SEPARATOR).length+1..-1] : self.abs_path
       end
 
       def to_hash(*args)


### PR DESCRIPTION
I had this exception occurring when manually reporting an exception.

```
undefined method `chomp' for #<Pathname:/home/apps/user/releases/20140520085231/lib>
```

It appears that while every other effort is made to ensure a string is made available, the final call may be calling `chomp` on something such as a `Pathname`. This PR ensures the prefix is brought down to a String before calling `chomp`.
