### PR TITLE
Fix typos in delayed_job.rb

### DIFF
--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -14,23 +14,23 @@ if defined?(Delayed)
             rescue Exception => exception
               # Log error to Sentry
               ::Raven.capture_exception(exception,
-                                        logger  => 'delayed_job',
-                                        tags    => {
-                                           delayed_job_queue => job.queue
+                                        :logger  => 'delayed_job',
+                                        :tags    => {
+                                           :delayed_job_queue => job.queue
                                         },
-                                        extra => {
-                                            delayed_job => {
-                                                id          => job.id,
-                                                priority    => job.priority,
-                                                attempts    => job.attempts,
-                                                handler     => job.handler,
-                                                last_error  => job.last_error,
-                                                run_at      => job.run_at,
-                                                locked_at   => job.locked_at,
+                                        :extra => {
+                                            :delayed_job => {
+                                                :id          => job.id,
+                                                :priority    => job.priority,
+                                                :attempts    => job.attempts,
+                                                :handler     => job.handler,
+                                                :last_error  => job.last_error,
+                                                :run_at      => job.run_at,
+                                                :locked_at   => job.locked_at,
                                                 #failed_at  => job.failed_at,
-                                                locked_by   => job.locked_by,
-                                                queue       => job.queue,
-                                                created_at  => job.created_at
+                                                :locked_by   => job.locked_by,
+                                                :queue       => job.queue,
+                                                :created_at  => job.created_at
                                             }
                                         })
 


### PR DESCRIPTION
These need to be symbols. There should probably be a test around this because it shouldn't have been released as it didn't work at all.

I have not tested this yet, I'm going to stick to 0.8.0 for now. You may want to consider pulling  0.9.0
