### PR TITLE
Locking Hashie to < Version 3.0.

### DIFF
--- a/sentry-raven.gemspec
+++ b/sentry-raven.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "faraday", ">= 0.7.6"
   gem.add_dependency "uuidtools"
-  gem.add_dependency "hashie", ">= 1.1.0"
+  gem.add_dependency "hashie", ">= 1.1.0", '< 3.0'
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 2.10"


### PR DESCRIPTION
Hey,
Hashie released version 3.0 on Tuesday. It breaks sentry.

Issue is on line 18 `/lib/raven/interfaces/stack_trace.rb`.

New version of Hashie is making each key in the data hash a symbol instead of a string.

So data['frame'] = nil
But data[:frame] has correct data.

Stack trace.

I've locked hashie to 2.1.1 in all my projects to fix for now.

```
undefined method `map' for nil:NilClass 
/home/rails/mc/releases/20140604184757/vendor/bundle/ruby/1.9.1/gems/sentry-raven-0.8.0/lib/raven/interfaces/stack_trace.rb:18:in `to_hash' 
/home/rails/mc/releases/20140604184757/vendor/bundle/ruby/1.9.1/gems/sentry-raven-0.8.0/lib/raven/event.rb:116:in `block in to_hash' 
/home/rails/mc/releases/20140604184757/vendor/bundle/ruby/1.9.1/gems/sentry-raven-0.8.0/lib/raven/event.rb:115:in `each_pair' 
/home/rails/mc/releases/20140604184757/vendor/bundle/ruby/1.9.1/gems/sentry-raven-0.8.0/lib/raven/event.rb:115:in `to_hash' 
/home/rails/mc/releases/20140604184757/vendor/bundle/ruby/1.9.1/gems/sentry-raven-0.8.0/lib/raven/client.rb:50:in `encode' 
/home/rails/mc/releases/20140604184757/vendor/bundle/ruby/1.9.1/gems/sentry-raven-0.8.0/lib/raven/client.rb:34:in `send' 
/home/rails/mc/releases/20140604184757/vendor/bundle/ruby/1.9.1/gems/sentry-raven-0.8.0/lib/raven/base.rb:69:in `send' 
/home/rails/mc/releases/20140604184757/vendor/bundle/ruby/1.9.1/gems/sentry-raven-0.8.0/lib/raven/base.rb:107:in `block in capture_exception' 
/home/rails/mc/releases/20140604184757/vendor/bundle/ruby/1.9.1/gems/sentry-raven-0.8.0/lib/raven/base.rb:128:in `send_or_skip' 
/home/rails/mc/releases/20140604184757/vendor/bundle/ruby/1.9.1/gems/sentry-raven-0.8.0/lib/raven/base.rb:101:in `capture_exception' 
```
