### PR TITLE
Support for hashie 3.0

### DIFF
--- a/lib/raven/interfaces.rb
+++ b/lib/raven/interfaces.rb
@@ -5,6 +5,10 @@ module Raven
   INTERFACES = {}
 
   class Interface < Hashie::Dash
+    if defined?(Hashie::Extensions::Dash::IndifferentAccess)
+      include Hashie::Extensions::Dash::IndifferentAccess
+    end
+
     def initialize(attributes = {}, &block)
       @check_required = false
       super(attributes)


### PR DESCRIPTION
This should support previous versions as well as the now-incompatible 3.x series.

Fixes GH-183, GH-182, GH-177
