### PR TITLE
Update Hashie method name

### DIFF
--- a/lib/raven/interfaces.rb
+++ b/lib/raven/interfaces.rb
@@ -14,10 +14,10 @@ module Raven
       super(attributes)
       block.call(self) if block
       @check_required = true
-      assert_required_properties_set!
+      assert_required_attributes_set!
     end
 
-    def assert_required_properties_set!
+    def assert_required_attributes_set!
       super if @check_required
     end
 

--- a/sentry-raven.gemspec
+++ b/sentry-raven.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "faraday", ">= 0.7.6"
   gem.add_dependency "uuidtools"
-  gem.add_dependency "hashie", ">= 1.1.0"
+  gem.add_dependency "hashie", ">= 3.1.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 2.10"


### PR DESCRIPTION
The method name changed in the latest version of Hashie, causing the following exception:

```
WARN: super: no superclass method `assert_required_properties_set!' for #<Raven::StacktraceInterface::Frame:0x00000002d9fe98
WARN: /var/lib/gems/2.0.0/gems/sentry-raven-0.9.3/lib/raven/interfaces.rb:21:in `assert_required_properties_set!'
(...)
```

This is one of three possible solutions. The other two are:
1. Put a pessimistic version constraint on `hashie`.
2. Check for both method names before making a call.
