### PR TITLE
Handle Pathname objects in

### DIFF
--- a/lib/raven/interfaces/stack_trace.rb
+++ b/lib/raven/interfaces/stack_trace.rb
@@ -44,7 +44,7 @@ module Raven
       def filename
         return nil if self.abs_path.nil?
 
-        prefix = $LOAD_PATH.select { |s| self.abs_path.start_with?(s.to_s) }.sort_by { |s| s.to_s.length }.last
+        prefix = $LOAD_PATH.select { |s| self.abs_path.start_with?(s.to_s) }.sort_by { |s| s.to_s.length }.last.to_s
         prefix ? self.abs_path[prefix.chomp(File::SEPARATOR).length+1..-1] : self.abs_path
       end
 


### PR DESCRIPTION
Sometimes the $LOAD_PATH array contains Pathname objects. In this case, prefix may contain a Pathname instead of a string and prefix.chomp will fail (chomp isn't a method on Pathname). Simply forcing a to_s on the prefix fixes this.
