### PR TITLE
Isolate Sidekiq's own context info into :extra

### DIFF
--- a/lib/raven/sidekiq.rb
+++ b/lib/raven/sidekiq.rb
@@ -22,6 +22,6 @@ if Sidekiq::VERSION < '3'
   end
 else
   Sidekiq.configure_server do |config|
-    config.error_handlers << Proc.new {|ex,context| Raven.capture_exception(ex, context) }
+    config.error_handlers << Proc.new {|ex,context| Raven.capture_exception(ex, :extra => {:sidekiq => context}) }
   end
 end


### PR DESCRIPTION
Sidekiq sometimes sends a :context key as part of its error handling context hash. However, it means something entirely different than Raven's own :context key in options. Move all of Sidekiq's exception context into :extra so it doesn't confuse Raven.
