### PR TITLE
Fix UTF sanitization and specs

### DIFF
--- a/lib/raven/processors/sanitizedata.rb
+++ b/lib/raven/processors/sanitizedata.rb
@@ -74,12 +74,13 @@ module Raven
         if RUBY_VERSION <= '1.8.7'
           text
         else
-          text.encode(
-            'UTF-8',
+          utf16 = text.encode(
+            'UTF-16',
             :invalid => :replace,
             :undef => :replace,
             :replace => ''
           )
+          utf16.encode('UTF-8')
         end
       end
     end

--- a/spec/raven/sanitizedata_processor_spec.rb
+++ b/spec/raven/sanitizedata_processor_spec.rb
@@ -1,3 +1,5 @@
+# Encoding: utf-8
+
 require File.expand_path('../../spec_helper', __FILE__)
 require 'raven/processors/sanitizedata'
 


### PR DESCRIPTION
Since encoding was already forced to UTF-8, re-encoding as UTF-8 was a noop and did not properly sanitize.
Per [this StackOverflow](http://stackoverflow.com/questions/11375342/stringencode-not-fixing-invalid-byte-sequence-in-utf-8-error) we first sanitize and encode into UTF-16 and then encode back to UTF-8.

Also added the proper magic comment for UTF-8 encoding the spec file.
