### PR TITLE
Add detail about environment whitelisting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ end
 
 ### Environments
 
-By default, events will be sent to Sentry in all environments. If you do not wish
+As of [v0.10.0](https://github.com/getsentry/raven-ruby/blob/21cb3164e0d0ab91394ba98b78195c4f6342b4bb/changelog.md#0100), events will be sent to Sentry in all environments. If you do not wish
 to send events in an environment, we suggest you unset the ```SENTRY_DSN```
 variable in that environment.
 


### PR DESCRIPTION
`raven-ruby` began sending events to Sentry in all environments at [version 0.10.0](https://github.com/getsentry/raven-ruby/blob/21cb3164e0d0ab91394ba98b78195c4f6342b4bb/changelog.md#0100). It might be helpful to include this information in the README — it took me a decent amount of time to figure out why this default behavior wasn't actually the default in my environment (which was stuck on version 0.9.4).
