### PR TITLE
Add configurable callback for deciding whether or not to send an event

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,16 @@ end
 
 You can find the list of exceptions that are excluded by default in [Raven::Configuration::IGNORE_DEFAULT](https://github.com/getsentry/raven-ruby/blob/master/lib/raven/configuration.rb). Remember you'll be overriding those defaults by setting this configuration.
 
+You can also use a configuration option to determine if an individual event should
+be sent to Sentry. Events are passed to the Proc or lambda you provide - returning
+`false` will stop the event from sending to Sentry:
+
+```ruby
+Raven.configure do |config|
+  config.should_send = Proc.new { |e| true unless e.contains_sensitive_info? }
+end
+```
+
 ### Tags
 
 You can configure default tags to be sent with every event. These can be

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -80,6 +80,9 @@ module Raven
     # ActionDispatch::ShowExceptions or ActionDispatch::DebugExceptions
     attr_accessor :catch_debugged_exceptions
 
+    # Provide a configurable callback to block or send events
+    attr_accessor :should_send
+
     IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
                       'ActionController::RoutingError',
                       'ActionController::InvalidAuthenticityToken',

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -70,6 +70,20 @@ describe Raven do
     end
   end
 
+  describe '.capture_exception with a should_send callback' do
+    let(:exception) { build_exception }
+
+    it 'sends the result of Event.capture_exception according to the result of should_send' do
+      expect(Raven).not_to receive(:send).with(event)
+
+      prior_should_send = Raven.configuration.should_send
+      Raven.configuration.should_send = Proc.new { |e| false }
+      expect(Raven.configuration.should_send).to receive(:call).with(exception)
+      Raven.capture_exception(exception, options)
+      Raven.configuration.should_send = prior_should_send
+    end
+  end
+
   describe '.annotate_exception' do
     let(:exception) { build_exception }
 


### PR DESCRIPTION
I'm struggling with the proper API for this - what should the config option be called? And how do we explain it? If the lambda/proc passed to the config option returns true given the event, it sends the event along. If it's false, it doesn't.
