### PR TITLE
Fix OKJson issue with exponent notation

### DIFF
--- a/lib/raven/okjson.rb
+++ b/lib/raven/okjson.rb
@@ -272,7 +272,7 @@ private
       elsif m[2]
         [:val, m[0], Float(m[0])]
       else
-        [:val, m[0], Integer(m[1])*(10**Integer(m[3][1..-1]))]
+        [:val, m[0], Integer(m[1])*(10**m[3][1..-1].to_i(10))]
       end
     else
       []

--- a/spec/raven/okjson_spec.rb
+++ b/spec/raven/okjson_spec.rb
@@ -20,4 +20,8 @@ describe Raven::OkJson do
     end
   end
 
+  it 'parses zero-leading exponent numbers correctly' do
+    expect(Raven::OkJson.decode("[123e090]")).to eq [123000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000]
+  end
+
 end


### PR DESCRIPTION
The JSON spec only supports numbers with exponent notation with a single exponent digit:

```
1234e7 #good
1234e9000 #not good
```

OKJson was trying to convert the latter into an integer, which fails if:

```
1234e090 #nope
```
