### PR TITLE
Add user configurable sanitizer fields

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -83,6 +83,9 @@ module Raven
     # Provide a configurable callback to block or send events
     attr_accessor :should_send
 
+    # additional fields to sanitize
+    attr_accessor :sanitize_fields
+
     IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
                       'ActionController::RoutingError',
                       'ActionController::InvalidAuthenticityToken',
@@ -105,6 +108,7 @@ module Raven
       self.tags = {}
       self.async = false
       self.catch_debugged_exceptions = true
+      self.sanitize_fields = []
     end
 
     def server=(value)

--- a/lib/raven/processor.rb
+++ b/lib/raven/processor.rb
@@ -2,8 +2,11 @@ require 'json'
 
 module Raven
   class Processor
+    attr_accessor :sanitize_fields
+
     def initialize(client)
       @client = client
+      @sanitize_fields = client.configuration.sanitize_fields
     end
 
     def process(data)

--- a/lib/raven/processor/sanitizedata.rb
+++ b/lib/raven/processor/sanitizedata.rb
@@ -2,10 +2,12 @@ module Raven
   class Processor::SanitizeData < Processor
     STRING_MASK = '********'
     INT_MASK = 0
-    FIELDS_RE = /(authorization|password|passwd|secret|ssn|social(.*)?sec)/i
+    DEFAULT_FIELDS = %w(authorization password passwd secret ssn social(.*)?sec)
     VALUES_RE = /^\d{16}$/
 
     def process(value)
+      fields_re = /(#{(DEFAULT_FIELDS + @sanitize_fields).join("|")})/i
+
       value.inject(value) do |value,(k,v)|
         v = k if v.nil?
         if v.is_a?(Hash) || v.is_a?(Array)
@@ -13,9 +15,9 @@ module Raven
         elsif v.is_a?(String) && (json = parse_json_or_nil(v))
           #if this string is actually a json obj, convert and sanitize
           value = modify_in_place(value, [k,v], process(json).to_json)
-        elsif v.is_a?(Integer) && (VALUES_RE.match(v.to_s) || FIELDS_RE.match(k.to_s))
+        elsif v.is_a?(Integer) && (VALUES_RE.match(v.to_s) || fields_re.match(k.to_s))
           value = modify_in_place(value, [k,v], INT_MASK)
-        elsif VALUES_RE.match(v.to_s) || FIELDS_RE.match(k.to_s)
+        elsif VALUES_RE.match(v.to_s) || fields_re.match(k.to_s)
           value = modify_in_place(value, [k,v], STRING_MASK)
         else
           value

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -49,6 +49,10 @@ describe Raven::Configuration do
     it 'should catch_debugged_exceptions' do
       expect(subject[:catch_debugged_exceptions]).to eq(true)
     end
+
+    it 'should have no sanitize fields' do
+      expect(subject[:sanitize_fields]).to eq([])
+    end
   end
 
   context 'being initialized with a server string' do

--- a/spec/raven/removecirculareferences_spec.rb
+++ b/spec/raven/removecirculareferences_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 describe Raven::Processor::RemoveCircularReferences do
   before do
     @client = double("client")
+    allow(@client).to receive_message_chain(:configuration, :sanitize_fields) { [] }
     @processor = Raven::Processor::RemoveCircularReferences.new(@client)
   end
 

--- a/spec/raven/sanitizedata_processor_spec.rb
+++ b/spec/raven/sanitizedata_processor_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Raven::Processor::SanitizeData do
   before do
     @client = double("client")
+    allow(@client).to receive_message_chain(:configuration, :sanitize_fields) { ['user_field'] }
     @processor = Raven::Processor::SanitizeData.new(@client)
   end
 
@@ -17,7 +18,8 @@ describe Raven::Processor::SanitizeData do
           'mypasswd' => 'hello',
           'test' => 1,
           'ssn' => '123-45-6789',
-          'social_security_number' => 123456789
+          'social_security_number' => 123456789,
+          'user_field' => 'user'
         }
       }
     }
@@ -33,6 +35,7 @@ describe Raven::Processor::SanitizeData do
     expect(vars["test"]).to eq(1)
     expect(vars["ssn"]).to eq(Raven::Processor::SanitizeData::STRING_MASK)
     expect(vars["social_security_number"]).to eq(Raven::Processor::SanitizeData::INT_MASK)
+    expect(vars["user_field"]).to eq(Raven::Processor::SanitizeData::STRING_MASK)
   end
 
   it 'should filter json data' do
@@ -45,7 +48,8 @@ describe Raven::Processor::SanitizeData do
         'mypasswd' => 'hello',
         'test' => 1,
         'ssn' => '123-45-6789',
-        'social_security_number' => 123456789
+        'social_security_number' => 123456789,
+        'user_field' => 'user'
         }.to_json
       }
 
@@ -60,6 +64,7 @@ describe Raven::Processor::SanitizeData do
     expect(vars["test"]).to eq(1)
     expect(vars["ssn"]).to eq(Raven::Processor::SanitizeData::STRING_MASK)
     expect(vars["social_security_number"]).to eq(Raven::Processor::SanitizeData::INT_MASK)
+    expect(vars["user_field"]).to eq(Raven::Processor::SanitizeData::STRING_MASK)
   end
 
   it 'should filter json embedded in a ruby object' do

--- a/spec/raven/utf8conversion_spec.rb
+++ b/spec/raven/utf8conversion_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 describe Raven::Processor::UTF8Conversion do
   before do
     @client = double("client")
+    allow(@client).to receive_message_chain(:configuration, :sanitize_fields) { [] }
     @processor = Raven::Processor::UTF8Conversion.new(@client)
   end
 


### PR DESCRIPTION
Allow user to specify some additional fields to sanitize.  Replaces the values with the string mask (********)

``` ruby
Raven.configure do |config|
  config.sanitize_fields = %w(host User-Agent)
end
```
