### PR TITLE
Contexts passed to the Event initializer may not be Raven Contexts

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -47,14 +47,14 @@ module Raven
       @modules = options[:modules]
 
       @user = options[:user] || {}
-      @user.merge!(context.user)
+      @user.merge!(context.user) if context.respond_to?(:user)
 
       @extra = options[:extra] || {}
-      @extra.merge!(context.extra)
+      @extra.merge!(context.extra) if context.respond_to?(:extra)
 
       @tags = @configuration.tags
       @tags.merge!(options[:tags] || {})
-      @tags.merge!(context.tags)
+      @tags.merge!(context.tags) if context.respond_to?(:tags)
 
       block.call(self) if block
 


### PR DESCRIPTION
I was using raven with Sidekiq (and that works fine). When you add SideTiq to the mix, it calls SideKiqs handle_exception with a String context that is passed on to Raven. Something like so:

`handle_exception(e, context: "Sidetiq::Handler#dispatch")`

This causes the event initializer to blow up when the String doesn't respond to the user method. I don't think it's safe to assume whatever context passed in is a raven context. This solution solved this particular case, but still isn't ideal. I think namespacing the options might be safer.
