### PR TITLE
Don't mutate configuration tags hash on event creation

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -52,7 +52,8 @@ module Raven
       @extra = options[:extra] || {}
       @extra.merge!(context.extra)
 
-      @tags = @configuration.tags
+      @tags = {}
+      @tags.merge!(@configuration.tags)
       @tags.merge!(options[:tags] || {})
       @tags.merge!(context.tags)
 

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -200,6 +200,31 @@ describe Raven::Event do
     end
   end
 
+  context 'configuration tags unspecified' do
+    it 'should not persist tags between unrelated events' do
+      config = Raven::Configuration.new
+
+      Raven::Event.new(
+        :level => 'warning',
+        :logger => 'foo',
+        :tags => {
+          'foo' => 'bar'
+        },
+        :server_name => 'foo.local',
+        :configuration => config
+      )
+
+      hash = Raven::Event.new(
+        :level => 'warning',
+        :logger => 'foo',
+        :server_name => 'foo.local',
+        :configuration => config
+      ).to_hash
+
+      expect(hash['tags']).to eq({})
+    end
+  end
+
   describe '.initialize' do
     it 'should not touch the env object for an ignored environment' do
       Raven.configure(true) do |config|


### PR DESCRIPTION
We often include a non-overlapping set of tags when reporting
different types of events. It turns out that Event.initialize
was mutating the Configuration object's state instead of creating
a local copy.
