### PR TITLE
Fix utf8 and symbols

### DIFF
--- a/lib/raven/processor/utf8conversion.rb
+++ b/lib/raven/processor/utf8conversion.rb
@@ -16,7 +16,7 @@ module Raven
     def clean_invalid_utf8_bytes(obj)
       if obj.respond_to?(:to_utf8)
         obj.to_utf8
-      elsif obj.respond_to?(:encoding)
+      elsif obj.respond_to?(:encoding) && obj.is_a?(String)
         obj.encode('UTF-16', :invalid => :replace, :undef => :replace, :replace => '').encode('UTF-8')
       else
         obj

--- a/spec/raven/processors/utf8conversion_spec.rb
+++ b/spec/raven/processors/utf8conversion_spec.rb
@@ -48,5 +48,12 @@ describe Raven::Processor::UTF8Conversion do
       results = @processor.process(data)
       expect(results[2][1]).to eq("invalid utf8 string goes here")
     end
+
+    it 'should not blow up on symbols' do
+      data = {:key => :value}
+
+      results = @processor.process(data)
+      expect(results[:key]).to eq(:value)
+    end
   end
 end


### PR DESCRIPTION
We should just be passing strings only to the Processor chain anyway, but this is a temporary fix. 
