### PR TITLE
Don't try to send events if no server config

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -160,11 +160,7 @@ module Raven
     end
 
     def send_in_current_environment?
-      if environments
-        environments.include?(current_environment)
-      else
-        true
-      end
+      !!server && (!environments || environments.include?(current_environment))
     end
 
     def log_excluded_environment_message

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -59,11 +59,9 @@ module Raven
 
       block.call(self) if block
 
-      if @configuration.send_in_current_environment?
-        if !self[:http] && context.rack_env
-          self.interface :http do |int|
-            int.from_rack(context.rack_env)
-          end
+      if !self[:http] && context.rack_env
+        self.interface :http do |int|
+          int.from_rack(context.rack_env)
         end
       end
 

--- a/spec/support/Rakefile
+++ b/spec/support/Rakefile
@@ -2,6 +2,10 @@ require 'rake'
 require 'rubygems'
 require 'raven'
 
+Raven.configure do |config|
+  config.dsn = 'http://12345:67890@sentry.localdomain/sentry/42'
+end
+
 task :raise_exception do
   1 / 0
 end


### PR DESCRIPTION
[This matches the README description.](https://github.com/getsentry/raven-ruby/wiki/Advanced-Configuration#environments)
- revert not compiling Rack context if we're not in a sending environment.

Fixes #219
