### PR TITLE
Fix Rails 3.2 gemfile for Ruby 1.8, remove Rails 4.0 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ rvm:
   - ree
   - 1.8.7
   - 1.9.3
-  - 2.0.0
   - 2.1.2
+  - 2.2.0
   - ruby-head
 
 gemfile:
@@ -31,11 +31,7 @@ matrix:
       gemfile: gemfiles/rails42.gemfile
     - rvm: 1.8.7
       gemfile: gemfiles/rails41.gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/rails40.gemfile
     - rvm: ree
       gemfile: gemfiles/rails42.gemfile
     - rvm: ree
       gemfile: gemfiles/rails41.gemfile
-    - rvm: ree
-      gemfile: gemfiles/rails40.gemfile

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
 
 gem "rails", "~> 3.2.6"
+gem "i18n", "~> 0.6.0"
 gem "rspec"
 gem "simplecov"
 

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -1,7 +1,0 @@
-source "http://rubygems.org"
-
-gem "rails", "~> 4.0.0"
-gem "rspec"
-gem "simplecov"
-
-gemspec :path => "../"

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "rails", '4.2.0.rc1'
+gem "rails", '4.2.0'
 gem "rspec"
 gem "simplecov"
 


### PR DESCRIPTION
With the release of 4.2.0, this 4.0 tests are far enough behind that we don't have to test that version specifically anymore.
