### PR TITLE
Proposal: add Faraday middleware breadcrumb recorder

### DIFF
--- a/lib/raven/integrations/faraday/breadcrumb.rb
+++ b/lib/raven/integrations/faraday/breadcrumb.rb
@@ -1,0 +1,20 @@
+require 'faraday/middleware'
+
+module Raven
+  class Faraday
+    # Faraday Middleware. Records a Raven breadcrumb every time
+    # an HTTP request is completed by Faraday.
+    class Breadcrumb < Faraday::Middleware
+      def call(request_env)
+        @app.call(request_env).on_complete do |response_env|
+          Raven.breadcrumbs.record do |crumb|
+            crumb.data = { response_env: response_env }
+            crumb.category = "faraday"
+            crumb.timestamp = Time.now.to_i
+            crumb.message = "Completed request to #{request_env[:url]}"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The breadcrumb middleware for Faraday from the documentation is quite useful. So useful in fact that it seems more DRY to offer this from the Raven gem, as opposed to writing this for every separate Ruby app.

If you think it's a useful addition, I will add tests and register the middleware with Faraday and add documentation on how to use it.