### PR TITLE
Remove ActiveJob keys for both Sidekiq and DelayedJob

### DIFF
--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -1,4 +1,5 @@
 require 'delayed_job'
+require 'raven/utils/context_filter'
 
 module Delayed
   module Plugins
@@ -29,7 +30,7 @@ module Delayed
             extra[:handler] = job.handler[0...1000] if job.handler
 
             if job.respond_to?('payload_object') && job.payload_object.respond_to?('job_data')
-              extra[:active_job] = job.payload_object.job_data
+              extra[:active_job] = Utils::ContextFilter.filter_context(job.payload_object.job_data)
             end
             ::Raven.capture_exception(e,
                                       :logger => 'delayed_job',

--- a/lib/raven/integrations/sidekiq/error_handler.rb
+++ b/lib/raven/integrations/sidekiq/error_handler.rb
@@ -1,4 +1,4 @@
-require 'raven/integrations/sidekiq/context_filter'
+require 'raven/utils/context_filter'
 
 module Raven
   module Sidekiq
@@ -6,7 +6,7 @@ module Raven
       SIDEKIQ_NAME = "Sidekiq".freeze
 
       def call(ex, context)
-        context = ContextFilter.filter_context(context)
+        context = Utils::ContextFilter.filter_context(context)
         Raven.context.transaction.push transaction_from_context(context)
         Raven.capture_exception(
           ex,

--- a/lib/raven/utils/context_filter.rb
+++ b/lib/raven/utils/context_filter.rb
@@ -1,8 +1,8 @@
 module Raven
-  module Sidekiq
+  module Utils
     module ContextFilter
       class << self
-        ACTIVEJOB_RESERVED_PREFIX = "_aj_".freeze
+        ACTIVEJOB_RESERVED_PREFIX_REGEX = /^_aj_/.freeze
         HAS_GLOBALID = const_defined?('GlobalID')
 
         # Once an ActiveJob is queued, ActiveRecord references get serialized into
@@ -25,7 +25,7 @@ module Raven
         private
 
         def filter_context_hash(key, value)
-          (key = key[3..-1]) if key [0..3] == ACTIVEJOB_RESERVED_PREFIX
+          key = key.to_s.sub(ACTIVEJOB_RESERVED_PREFIX_REGEX, "") if key.match(ACTIVEJOB_RESERVED_PREFIX_REGEX)
           [key, filter_context(value)]
         end
 

--- a/spec/raven/integrations/sidekiq/error_handler_spec.rb
+++ b/spec/raven/integrations/sidekiq/error_handler_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Raven::Sidekiq::ErrorHandler" do
     aj_context["_aj_globalid"] = GlobalID.new('gid://app/model/id')
     expected_context = aj_context.dup
     expected_context.delete("_aj_globalid")
-    expected_context["_globalid"] = "gid://app/model/id"
+    expected_context["globalid"] = "gid://app/model/id"
     expected_options = {
       :message => exception.message,
       :extra => { :sidekiq => expected_context }

--- a/spec/raven/utils/context_filter_spec.rb
+++ b/spec/raven/utils/context_filter_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+require "raven/utils/context_filter"
+
+RSpec.describe Raven::Utils::ContextFilter do
+  context "filters out ActiveJob keys from context" do
+    let(:context) do
+      { :_aj_globalid => "gid://app/model/id", :key => "value" }
+    end
+    let(:expected_context) do
+      { "globalid" => "gid://app/model/id", :key => "value" }
+    end
+
+    it "removes reserved keys" do
+      new_context = described_class.filter_context(context)
+
+      expect(new_context).to eq(expected_context)
+    end
+  end
+
+  context "filters out ActiveJob keys from nested context" do
+    let(:context) do
+      {
+        :_aj_globalid => "gid://app/model/id",
+        :arguments => { :key => "value", :_aj_symbol_keys => ["key"] }
+      }
+    end
+    let(:expected_context) do
+      {
+        "globalid" => "gid://app/model/id",
+        :arguments => { :key => "value", "symbol_keys" => ["key"] }
+      }
+    end
+
+    it "removes reserved keys" do
+      new_context = described_class.filter_context(context)
+
+      expect(new_context).to eq(expected_context)
+    end
+  end
+end


### PR DESCRIPTION
It's as same as https://github.com/getsentry/raven-ruby/pull/386 but for both Sidekiq and DelayedJob
> Once an ActiveJob is queued, ActiveRecord references get serialized into
some internal reserved keys, such as _aj_globalid.
The problem is, if this job in turn gets queued back into ActiveJob with
these magic reserved keys, ActiveJob will throw up and error. We want to
capture these and mutate the keys so we can sanely report it.

The difference is instead of rename the key I removed it, because this key will not be used.