### PR TITLE
Add an option for delayed_job to report errors to Sentry until after …

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -169,6 +169,10 @@ module Raven
     # }
     attr_reader :before_send
 
+    # Set this option to true if you want Sentry to only capture the last job
+    # retry if it fails.
+    attr_accessor :report_after_job_retries
+
     # Errors object - an Array that contains error messages. See #
     attr_reader :errors
 
@@ -195,6 +199,33 @@ module Raven
       Raven::Processor::HTTPHeaders
     ].freeze
 
+    DEFAULT_CONFIGURATION_VALUES = {
+      :async => false,
+      :before_send => false,
+      :context_lines => 3,
+      :encoding => 'gzip',
+      :environments => [],
+      :exclude_loggers => [],
+      :excluded_exceptions => IGNORE_DEFAULT.dup,
+      :inspect_exception_causes_for_exclusion => false,
+      :open_timeout => 1,
+      :processors => DEFAULT_PROCESSORS.dup,
+      :rails_activesupport_breadcrumbs => false,
+      :rails_report_rescued_exceptions => true,
+      :report_after_job_retries => false,
+      :sample_rate => 1.0,
+      :sanitize_credit_cards => true,
+      :sanitize_fields => [],
+      :sanitize_fields_excluded => [],
+      :sanitize_http_headers => [],
+      :send_modules => true,
+      :should_capture => false,
+      :ssl_verification => true,
+      :tags => {},
+      :timeout => 2,
+      :transport_failure_callback => false
+    }
+
     HEROKU_DYNO_METADATA_MESSAGE = "You are running on Heroku but haven't enabled Dyno Metadata. For Sentry's "\
     "release detection to work correctly, please run `heroku labs:enable runtime-dyno-metadata`".freeze
 
@@ -202,36 +233,17 @@ module Raven
     MODULE_SEPARATOR = "::".freeze
 
     def initialize
-      self.async = false
-      self.context_lines = 3
+      DEFAULT_CONFIGURATION_VALUES.each do |attribute, default_value|
+        send("#{attribute}=", default_value)
+      end
+
       self.current_environment = current_environment_from_env
-      self.encoding = 'gzip'
-      self.environments = []
-      self.exclude_loggers = []
-      self.excluded_exceptions = IGNORE_DEFAULT.dup
-      self.inspect_exception_causes_for_exclusion = false
       self.linecache = ::Raven::LineCache.new
       self.logger = ::Raven::Logger.new(STDOUT)
-      self.open_timeout = 1
-      self.processors = DEFAULT_PROCESSORS.dup
       self.project_root = detect_project_root
-      self.rails_activesupport_breadcrumbs = false
-      self.rails_report_rescued_exceptions = true
       self.release = detect_release
-      self.sample_rate = 1.0
-      self.sanitize_credit_cards = true
-      self.sanitize_fields = []
-      self.sanitize_fields_excluded = []
-      self.sanitize_http_headers = []
-      self.send_modules = true
       self.server = ENV['SENTRY_DSN']
       self.server_name = server_name_from_env
-      self.should_capture = false
-      self.ssl_verification = true
-      self.tags = {}
-      self.timeout = 2
-      self.transport_failure_callback = false
-      self.before_send = false
     end
 
     def server=(value)

--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -11,34 +11,7 @@ module Delayed
 
           rescue Exception => exception
             # Log error to Sentry
-            extra = {
-              :delayed_job => {
-                :id          => job.id.to_s,
-                :priority    => job.priority,
-                :attempts    => job.attempts,
-                :run_at      => job.run_at,
-                :locked_at   => job.locked_at,
-                :locked_by   => job.locked_by,
-                :queue       => job.queue,
-                :created_at  => job.created_at
-              }
-            }
-            # last_error can be nil
-            extra[:last_error] = job.last_error[0...1000] if job.last_error
-            # handlers are YAML objects in strings, we definitely can't
-            # report all of that or the event will get truncated randomly
-            extra[:handler] = job.handler[0...1000] if job.handler
-
-            if job.respond_to?('payload_object') && job.payload_object.respond_to?('job_data')
-              extra[:active_job] = job.payload_object.job_data
-            end
-            ::Raven.capture_exception(exception,
-                                      :logger  => 'delayed_job',
-                                      :tags    => {
-                                        :delayed_job_queue => job.queue,
-                                        :delayed_job_id => job.id.to_s
-                                      },
-                                      :extra => extra)
+            RavenReporter.new(job).report(exception)
 
             # Make sure we propagate the failure!
             raise exception
@@ -47,6 +20,60 @@ module Delayed
             ::Raven::BreadcrumbBuffer.clear!
           end
         end
+      end
+    end
+
+    class RavenReporter
+      def initialize(job)
+        @job = job
+      end
+
+      def report(exception)
+        return unless should_report?
+        ::Raven.capture_exception(exception,
+                                  :logger =>  'delayed_job',
+                                  :tags =>    {
+                                    :delayed_job_queue => job.queue,
+                                    :delayed_job_id => job.id.to_s
+                                  },
+                                  :extra => extra_information)
+      end
+
+      private
+
+      attr_reader :job
+
+      def should_report?
+        return true unless ::Raven.configuration.report_after_job_retries
+
+        # We use the predecessor because the job's attempts haven't been increased to the new
+        # count at this point.
+        job.attempts >= Delayed::Worker.max_attempts.pred
+      end
+
+      def extra_information
+        extra = {
+          :delayed_job => {
+            :id =>          job.id.to_s,
+            :priority =>    job.priority,
+            :attempts =>    job.attempts,
+            :run_at =>      job.run_at,
+            :locked_at =>   job.locked_at,
+            :locked_by =>   job.locked_by,
+            :queue =>       job.queue,
+            :created_at =>  job.created_at
+          }
+        }
+        # last_error can be nil
+        extra[:last_error] = job.last_error[0...1000] if job.last_error
+        # handlers are YAML objects in strings, we definitely can't
+        # report all of that or the event will get truncated randomly
+        extra[:handler] = job.handler[0...1000] if job.handler
+
+        if job.respond_to?(:payload_object) && job.payload_object.respond_to?(:job_data)
+          extra[:active_job] = job.payload_object.job_data
+        end
+        extra
       end
     end
   end


### PR DESCRIPTION
…every retry has failed


I couldn't find contribution guidelines so please let me know if something needs to be added or changed.