### PR TITLE
Ensure Processor::Cookie can run after Processor::RemoveCircularReferences

### DIFF
--- a/lib/raven/processor/cookies.rb
+++ b/lib/raven/processor/cookies.rb
@@ -30,7 +30,7 @@ module Raven
     end
 
     def generate_masked_cookies(cookies)
-      cookies.merge(cookies) { STRING_MASK }
+      cookies.merge(cookies) { STRING_MASK } if cookies.respond_to?(:merge)
     end
   end
 end

--- a/lib/raven/processor/removecircularreferences.rb
+++ b/lib/raven/processor/removecircularreferences.rb
@@ -1,7 +1,8 @@
 module Raven
   class Processor::RemoveCircularReferences < Processor
+    ELISION_STRING = "(...)".freeze
     def process(value, visited = [])
-      return "(...)" if visited.include?(value.__id__)
+      return ELISION_STRING if visited.include?(value.__id__)
 
       visited << value.__id__ if value.is_a?(Array) || value.is_a?(Hash)
 

--- a/spec/raven/processors/cookies_spec.rb
+++ b/spec/raven/processors/cookies_spec.rb
@@ -45,4 +45,19 @@ RSpec.describe Raven::Processor::Cookies do
     expect(result["request"]["some_other_data"]).to eq("still_here")
     expect(result["request"]["headers"]["AnotherHeader"]).to eq("still_here")
   end
+
+  it 'does not fail if it runs after Processor::RemoveCircularReferences' do
+    test_data = {
+      :request => {
+        :headers => {
+          "Cookie" => Raven::Processor::RemoveCircularReferences::ELISION_STRING,
+          "AnotherHeader" => "still_here"
+        },
+        :cookies => Raven::Processor::RemoveCircularReferences::ELISION_STRING,
+        :some_other_data => "still_here"
+      }
+    }
+
+    @processor.process(test_data)
+  end
 end


### PR DESCRIPTION
## Background

This commit seems to have introduced a bug: https://github.com/getsentry/raven-ruby/commit/ad440b952de0f62b62c42433882887c2cb678caf

`Processor::RemoveCircularReferences` replaces elements of the event with the string `(...)`, but `Processor::Cookies#generate_masked_cookies` assumes that its param implements `#merge` (`String` does not). Previously, `Processor::Cookies` was not run in `Raven::Event#async_json_processors`.

~Unfortunately I wasn't able to get the test suite running locally (getting an error about requiring `rails`), so apologies if I've accidentally added a failing spec~ Fixed!

## Impact

This exception (`undefined method 'merge' for "(...)":String`) would be [rescued](https://github.com/getsentry/raven-ruby/blob/c2902908011a1f104cb252ecd6ace683d7738b81/lib/raven/instance.rb#L119-L126), but could cause a large number of events to be sent synchronously instead of asynchronously.