### PR TITLE
Add sidekiq_report_type config option

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -156,6 +156,8 @@ module Raven
     # e.g. lambda { |exc_or_msg| exc_or_msg.some_attr == false }
     attr_reader :should_capture
 
+    attr_accessor :sidekiq_report_type
+
     # Silences ready message when true.
     attr_accessor :silence_ready
 
@@ -274,6 +276,7 @@ module Raven
       self.server = ENV['SENTRY_DSN']
       self.server_name = server_name_from_env
       self.should_capture = false
+      self.sidekiq_report_type = :error
       self.ssl_verification = true
       self.tags = {}
       self.timeout = 2

--- a/lib/raven/integrations/sidekiq.rb
+++ b/lib/raven/integrations/sidekiq.rb
@@ -2,12 +2,26 @@ require 'time'
 require 'sidekiq'
 require 'raven/integrations/sidekiq/cleanup_middleware'
 require 'raven/integrations/sidekiq/error_handler'
+require 'raven/integrations/sidekiq/death_handler'
 
-if Sidekiq::VERSION > '3'
-  Sidekiq.configure_server do |config|
-    config.error_handlers << Raven::Sidekiq::ErrorHandler.new
-    config.server_middleware do |chain|
-      chain.add Raven::Sidekiq::CleanupMiddleware
+module Raven
+  module Sidekiq
+    def self.inject
+      ::Sidekiq.configure_server do |config|
+        if Raven.configuration.sidekiq_report_type == :error
+          config.error_handlers << Raven::Sidekiq::ErrorHandler.new
+        elsif Raven.configuration.sidekiq_report_type == :death
+          config.death_handlers << Raven::Sidekiq::DeathHandler.new
+        end
+
+        config.server_middleware do |chain|
+          chain.add Raven::Sidekiq::CleanupMiddleware
+        end
+      end
     end
   end
+end
+
+if Sidekiq::VERSION > '3'
+  Raven::Sidekiq.inject
 end

--- a/lib/raven/integrations/sidekiq/death_handler.rb
+++ b/lib/raven/integrations/sidekiq/death_handler.rb
@@ -1,0 +1,17 @@
+module Raven
+  module Sidekiq
+    class DeathHandler < ErrorHandler
+      def call(job, ex)
+        context = ContextFilter.filter_context(job)
+        Raven.context.transaction.push transaction_from_context(context)
+        Raven.capture_exception(
+          ex,
+          :message => ex.message,
+          :extra => { :sidekiq => context }
+        )
+        Context.clear!
+        BreadcrumbBuffer.clear!
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,16 @@ RSpec.configure do |config|
   config.raise_errors_for_deprecations!
   config.disable_monkey_patching!
   Kernel.srand config.seed
+
+  config.before(:all, :sidekiq) do
+    Sidekiq.logger = Logger.new(nil)
+  end
+
+  config.after(:all, :sidekiq) do
+    # those test jobs will go into the real Redis and be visiable to other sidekiq processes
+    # this can affect local testing and development, so we should clear them after each test
+    Sidekiq::RetrySet.new.clear
+  end
 end
 
 RSpec.shared_examples "Raven default capture behavior" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,10 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   Kernel.srand config.seed
 
+  config.after(:each) do
+    Raven.client.transport.events.clear
+  end
+
   config.before(:all, :sidekiq) do
     Sidekiq.logger = Logger.new(nil)
   end


### PR DESCRIPTION

Sidekiq takes 2 types of handlers to deal with failed jobs:
- error handler - which will be called every time a job failed
- death handler - which will only be called when the job is dead (no
  retries remained)

And currently, our sidekiq integration is based on the error handler. So
if a job failed repeatedly, the exception will be sent multiple times.

There have been some requests on "only sending events when there's no
retry left" and I think this can be a solution for them.