### PR TITLE
Remove circular dependency in transport/http.rb

### DIFF
--- a/lib/raven/transports/http.rb
+++ b/lib/raven/transports/http.rb
@@ -1,7 +1,5 @@
 require 'faraday'
 
-require 'raven/transports'
-
 module Raven
   module Transports
     class HTTP < Transport


### PR DESCRIPTION
This is causing a warning when we load the gem

Thanks for your Pull Request 🎉 

**Please keep these instructions in mind so we can review it more efficiently:**

- **We're restructuring our SDK for the 4.0 version on the master branch. So make sure your PR is based on [v3-1-stable](https://github.com/getsentry/raven-ruby/tree/v3-1-stable)**
- Add the references of all the related issues/PRs in the description
- Whether it's a new feature or a bug fix, make sure they're covered by new test cases
- If this PR contains any refactoring work, please give it its own commit(s)


**Other Notes**
- We squash all commits before merging
- We generally review new PRs within a week
- If you have any question, you can ask for feedback in our [discord community](https://discord.gg/Ww9hbqr) first

## Description
Describe your changes:
