### PR TITLE
fix: correct extra_context method name and ussage for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ Much of the usefulness of Sentry comes from additional context data with the eve
 ```ruby
 Raven.user_context email: 'foo@example.com'
 
-Raven.tags.merge!(interesting: 'yes')
+Raven.tags_context interesting: 'yes'
 
-Raven.extra.merge!(additional_info: 'foo')
+Raven.extra_context additional_info: 'foo'
 ```
 
 You can also use `tags_context` and `extra_context` to provide scoped information:


### PR DESCRIPTION
This is a Documentation fix. 

The README stated that `Raven.tags` (`Raven.respond_to? :tags => false`) and `Raven.extra` (`Raven.respond_to? :extra => false`) should be available to merge in additional details, but that seems to be false. Instead there are two methods that merge a passed in hash (defined at: `lib/raven/instance.rb` Line 194 and 209). 