### PR TITLE
Refactoring from #1040

### DIFF
--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -27,14 +27,13 @@ module Sentry
         end
     end
 
-    def event_from_exception(exception, message: nil, extra: {}, backtrace: [], checksum: nil, release: nil, fingerprint: [])
+    def event_from_exception(exception, message: '', extra: {}, backtrace: [], checksum: nil, release: nil, fingerprint: [])
       options = {
         message: message,
         extra: extra,
         backtrace: backtrace,
         checksum: checksum,
         fingerprint: fingerprint,
-        configuration: configuration,
         release: release
       }
 
@@ -51,20 +50,21 @@ module Sentry
 
       return unless @configuration.exception_class_allowed?(exception)
 
-      Event.new(**options) do |evt|
+      options = Event::Options.new(**options)
+
+      Event.new(configuration: configuration, options: options) do |evt|
         evt.add_exception_interface(exception)
       end
     end
 
     def event_from_message(message, extra: {}, backtrace: [], level: :error)
-      options = {
+      options = Event::Options.new(
         message: message,
         extra: extra,
         backtrace: backtrace,
-        configuration: configuration,
         level: level
-      }
-      Event.new(**options)
+      )
+      Event.new(configuration: configuration, options: options)
     end
 
     def generate_auth_header

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -42,9 +42,9 @@ module Sentry
       # Set some attributes with empty hashes to allow merging
       @interfaces        = {}
 
-      @user          = user || {}
-      @extra         = extra || {}
-      @tags          = configuration.tags.merge(tags || {})
+      @user          = user
+      @extra         = extra
+      @tags          = configuration.tags.merge(tags)
 
       @server_os     = {} # TODO: contexts
       @runtime       = {} # TODO: contexts
@@ -58,7 +58,7 @@ module Sentry
 
       # these 2 needs custom setter methods
       self.level         = level
-      self.message       = message
+      self.message       = message if message
 
       # Allow attributes to be set on the event at initialization
       yield self if block_given?
@@ -74,15 +74,10 @@ module Sentry
     end
 
     def message
-      @interfaces[:logentry]&.unformatted_message
+      @interfaces[:logentry]&.unformatted_message.to_s
     end
 
     def message=(message)
-      unless message.is_a?(String)
-        configuration.logger.debug("You're passing a non-string message")
-        message = message.to_s
-      end
-
       interface(:message) do |int|
         int.message = message.byteslice(0...MAX_MESSAGE_SIZE_IN_BYTES) # Messages limited to 10kb
       end

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -2,6 +2,7 @@
 
 require 'socket'
 require 'securerandom'
+require 'sentry/event/options'
 require 'sentry/interface'
 require 'sentry/backtrace'
 require 'sentry/utils/deep_merge'
@@ -23,13 +24,7 @@ module Sentry
 
     attr_reader :level, :timestamp, :time_spent
 
-    def initialize(
-      configuration:,
-      message: nil,
-      user: {}, extra: {}, tags: {},
-      backtrace: [], level: :error, checksum: nil, fingerprint: [],
-      server_name: nil, release: nil, environment: nil
-    )
+    def initialize(options:, configuration:)
       # this needs to go first because some setters rely on configuration
       @configuration = configuration
 
@@ -42,31 +37,31 @@ module Sentry
       # Set some attributes with empty hashes to allow merging
       @interfaces        = {}
 
-      @user          = user
-      @extra         = extra
-      @tags          = configuration.tags.merge(tags)
+      @user          = options.user
+      @extra         = options.extra
+      @tags          = configuration.tags.merge(options.tags)
 
       @server_os     = {} # TODO: contexts
       @runtime       = {} # TODO: contexts
 
-      @checksum = checksum
-      @fingerprint = fingerprint
+      @checksum = options.checksum
+      @fingerprint = options.fingerprint
 
-      @server_name = server_name
-      @environment = environment
-      @release = release
+      @server_name = options.server_name
+      @environment = options.environment
+      @release = options.release
 
       # these 2 needs custom setter methods
-      self.level         = level
-      self.message       = message if message
+      self.level         = options.level
+      self.message       = options.message if options.message
 
       # Allow attributes to be set on the event at initialization
       yield self if block_given?
       # options.each_pair { |key, val| public_send("#{key}=", val) unless val.nil? }
 
-      if !backtrace.empty?
+      if !options.backtrace.empty?
         interface(:stacktrace) do |int|
-          int.frames = stacktrace_interface_from(backtrace)
+          int.frames = stacktrace_interface_from(options.backtrace)
         end
       end
 

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -189,19 +189,19 @@ module Sentry
       interface :http do |int|
         int.from_rack(context.rack_env)
       end
-      context.user[:ip_address] = calculate_real_ip_from_rack
+      # context.user[:ip_address] = calculate_real_ip_from_rack
     end
 
     # When behind a proxy (or if the user is using a proxy), we can't use
     # REMOTE_ADDR to determine the Event IP, and must use other headers instead.
-    def calculate_real_ip_from_rack
-      Utils::RealIp.new(
-        :remote_addr => context.rack_env["REMOTE_ADDR"],
-        :client_ip => context.rack_env["HTTP_CLIENT_IP"],
-        :real_ip => context.rack_env["HTTP_X_REAL_IP"],
-        :forwarded_for => context.rack_env["HTTP_X_FORWARDED_FOR"]
-      ).calculate_ip
-    end
+    # def calculate_real_ip_from_rack
+    #   Utils::RealIp.new(
+    #     :remote_addr => context.rack_env["REMOTE_ADDR"],
+    #     :client_ip => context.rack_env["HTTP_CLIENT_IP"],
+    #     :real_ip => context.rack_env["HTTP_X_REAL_IP"],
+    #     :forwarded_for => context.rack_env["HTTP_X_FORWARDED_FOR"]
+    #   ).calculate_ip
+    # end
 
     def list_gem_specs
       # Older versions of Rubygems don't support iterating over all specs

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -31,32 +31,34 @@ module Sentry
       server_name: nil, release: nil, environment: nil
     )
       # this needs to go first because some setters rely on configuration
-      self.configuration = configuration
+      @configuration = configuration
 
       # Set some simple default values
-      self.id            = SecureRandom.uuid.delete("-")
-      self.timestamp     = Time.now.utc
-      self.level         = level
-      self.platform      = :ruby
-      self.sdk           = SDK
+      @id            = SecureRandom.uuid.delete("-")
+      @timestamp     = Time.now.utc
+      @platform      = :ruby
+      @sdk           = SDK
 
       # Set some attributes with empty hashes to allow merging
       @interfaces        = {}
 
-      self.user          = user || {}
-      self.extra         = extra || {}
-      self.tags          = configuration.tags.merge(tags || {})
+      @user          = user || {}
+      @extra         = extra || {}
+      @tags          = configuration.tags.merge(tags || {})
 
+      @server_os     = {} # TODO: contexts
+      @runtime       = {} # TODO: contexts
+
+      @checksum = checksum
+      @fingerprint = fingerprint
+
+      @server_name = server_name
+      @environment = environment
+      @release = release
+
+      # these 2 needs custom setter methods
+      self.level         = level
       self.message       = message
-      self.server_os     = {} # TODO: contexts
-      self.runtime       = {} # TODO: contexts
-
-      self.checksum = checksum
-      self.fingerprint = fingerprint
-
-      self.server_name = server_name
-      self.environment = environment
-      self.release = release
 
       # Allow attributes to be set on the event at initialization
       yield self if block_given?
@@ -177,10 +179,10 @@ module Sentry
     private
 
     def set_core_attributes_from_configuration
-      self.server_name ||= configuration.server_name
-      self.release     ||= configuration.release
-      self.modules       = list_gem_specs if configuration.send_modules
-      self.environment ||= configuration.current_environment
+      @server_name ||= configuration.server_name
+      @release     ||= configuration.release
+      @modules       = list_gem_specs if configuration.send_modules
+      @environment ||= configuration.current_environment
     end
 
     def add_rack_context

--- a/sentry-ruby/lib/sentry/event/options.rb
+++ b/sentry-ruby/lib/sentry/event/options.rb
@@ -1,0 +1,27 @@
+module Sentry
+  class Event
+    class Options
+      attr_reader :message, :user, :extra, :tags, :backtrace, :level, :checksum, :fingerprint, :server_name, :release, :environment
+      def initialize(
+        message: "",
+        user: {}, extra: {}, tags: {},
+        backtrace: [], level: :error, checksum: "", fingerprint: [],
+        # nilable attributes because we'll fallback to the configuration's values
+        server_name: nil, release: nil, environment: nil
+      )
+        @message = message || ""
+        @user = user || {}
+        @extra = extra || {}
+        @tags = tags || {}
+        @backtrace = backtrace || []
+        @fingerprint = fingerprint || []
+        @level = level || :error
+        @checksum = checksum || ""
+        @server_name = server_name
+        @environment = environment
+        @release = release
+      end
+    end
+  end
+end
+

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -229,13 +229,6 @@ RSpec.describe Sentry::Client do
         event = subject.event_from_exception(ExceptionWithContext.new, message: "MSG" * 3000)
         expect(event.message.length).to eq(8192)
       end
-
-      it "converts non-string message into string" do
-        expect(configuration.logger).to receive(:debug).with("You're passing a non-string message")
-
-        event = subject.event_from_exception(ExceptionWithContext.new, message: { foo: "bar" })
-        expect(event.message).to eq("{:foo=>\"bar\"}")
-      end
     end
 
     context 'for a nested exception type' do

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -69,28 +69,6 @@ RSpec.describe Sentry::Event do
     end
   end
 
-  context 'parameter entries are nil' do
-    let(:hash) do
-      Sentry::Event.new(
-        message: 'test',
-        level: 'warn',
-        tags: nil,
-        extra: nil,
-        user: nil,
-        server_name: 'foo.local',
-        release: '721e41770371db95eee98ca2707686226b993eda',
-        environment: 'production',
-        configuration: configuration
-      ).to_hash
-    end
-
-    it "skips nil values" do
-      expect(hash[:extra]).to eq({})
-      expect(hash[:user]).to eq({})
-      expect(hash[:tags]).to eq({})
-    end
-  end
-
   context 'configuration tags specified' do
     let(:hash) do
       config = Sentry::Configuration.new

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -2,22 +2,17 @@ require 'spec_helper'
 
 RSpec.describe Sentry::Event do
   let(:configuration) { Sentry::Configuration.new }
-  let(:essential_options) do
-    {
-      configuration: configuration
-    }
-  end
 
   describe "#initialize" do
     it "initializes a Event when all required keys are provided" do
-      expect(described_class.new(essential_options)).to be_a(described_class)
+      options = Sentry::Event::Options.new
+      expect(described_class.new(configuration: configuration, options: options)).to be_a(described_class)
     end
   end
 
   context 'a fully implemented event' do
-    let(:hash) do
-      Sentry::Event.new(
-        configuration: configuration,
+    let(:options) do
+      Sentry::Event::Options.new(
         message: 'test',
         level: 'warn',
         tags: {
@@ -29,6 +24,12 @@ RSpec.describe Sentry::Event do
         server_name: 'foo.local',
         release: '721e41770371db95eee98ca2707686226b993eda',
         environment: 'production'
+      )
+    end
+    let(:hash) do
+      Sentry::Event.new(
+        configuration: configuration,
+        options: options
       ).to_hash
     end
 
@@ -70,6 +71,15 @@ RSpec.describe Sentry::Event do
   end
 
   context 'configuration tags specified' do
+    let(:options) do
+      Sentry::Event::Options.new(
+        level: 'warning',
+        tags: {
+          'foo' => 'bar'
+        },
+        server_name: 'foo.local',
+      )
+    end
     let(:hash) do
       config = Sentry::Configuration.new
       config.tags = { 'key' => 'value' }
@@ -77,12 +87,8 @@ RSpec.describe Sentry::Event do
       config.current_environment = "custom"
 
       Sentry::Event.new(
-        level: 'warning',
-        tags: {
-          'foo' => 'bar'
-        },
-        server_name: 'foo.local',
         configuration: config,
+        options: options
       ).to_hash
     end
 
@@ -96,19 +102,24 @@ RSpec.describe Sentry::Event do
     it 'does not persist tags between unrelated events' do
       config = Sentry::Configuration.new
       config.logger = Logger.new(nil)
-
-      Sentry::Event.new(
+      options = Sentry::Event::Options.new(
         level: 'warning',
         tags: {
           'foo' => 'bar'
         },
         server_name: 'foo.local',
-        configuration: config
+      )
+
+      Sentry::Event.new(
+        configuration: config,
+        options: options
       )
 
       hash = Sentry::Event.new(
-        level: 'warning',
-        server_name: 'foo.local',
+        options: Sentry::Event::Options.new(
+          level: 'warning',
+          server_name: 'foo.local',
+        ),
         configuration: config
       ).to_hash
 
@@ -159,12 +170,15 @@ RSpec.describe Sentry::Event do
 
   describe '#to_json_compatible' do
     subject do
-      Sentry::Event.new(
+      options = Sentry::Event::Options.new(
         extra: {
           'my_custom_variable' => 'value',
           'date' => Time.utc(0),
           'anonymous_module' => Class.new
         },
+      )
+      Sentry::Event.new(
+        options: options,
         configuration: configuration
       )
     end


### PR DESCRIPTION
These changes were initially made in #1040. But since we're won't use sorbet anymore, I picked them to this new branch.

And the reason to have `Event::Options` class is to centralize our event payload's parameters. It will make us perform type/value checking more neatly.