### PR TITLE
Add Scope setters

### DIFF
--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -2,7 +2,9 @@ require "sentry/breadcrumb_buffer"
 
 module Sentry
   class Scope
-    attr_accessor :transactions, :contexts, :extra, :tags, :user, :level, :breadcrumbs, :fingerprint
+    ATTRIBUTES = [:transactions, :contexts, :extra, :tags, :user, :level, :breadcrumbs, :fingerprint]
+
+    attr_reader(*ATTRIBUTES)
 
     def initialize
       @breadcrumbs = BreadcrumbBuffer.new
@@ -95,6 +97,11 @@ module Sentry
 
       @fingerprint = fingerprint
     end
+
+    protected
+
+    # for duplicating scopes internally
+    attr_writer(*ATTRIBUTES)
 
     private
 

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -2,18 +2,17 @@ require "sentry/breadcrumb_buffer"
 
 module Sentry
   class Scope
-    attr_accessor :transactions, :contexts, :extra, :rack_env, :tags, :user, :level, :breadcrumbs, :fingerprint
+    attr_accessor :transactions, :contexts, :extra, :tags, :user, :level, :breadcrumbs, :fingerprint
 
     def initialize
-      self.breadcrumbs = BreadcrumbBuffer.new
-      self.contexts = { :os => self.class.os_context, :runtime => self.class.runtime_context }
-      self.extra = {}
-      self.rack_env = nil
-      self.tags = {}
-      self.user = {}
-      self.level = :error
-      self.fingerprint = []
-      self.transactions = []
+      @breadcrumbs = BreadcrumbBuffer.new
+      @contexts = { :os => self.class.os_context, :runtime => self.class.runtime_context }
+      @extra = {}
+      @tags = {}
+      @user = {}
+      @level = :error
+      @fingerprint = []
+      @transactions = []
     end
 
     def apply_to_event(event)
@@ -32,7 +31,7 @@ module Sentry
     end
 
     def clear_breadcrumbs
-      self.breadcrumbs = BreadcrumbBuffer.new
+      @breadcrumbs = BreadcrumbBuffer.new
     end
 
     def dup
@@ -45,6 +44,64 @@ module Sentry
       copy.transactions = transactions.deep_dup
       copy.fingerprint = fingerprint.deep_dup
       copy
+    end
+
+    def set_user(user_hash)
+      check_argument_type!(user_hash, Hash)
+      @user = user_hash
+    end
+
+    def set_extras(extras_hash)
+      check_argument_type!(extras_hash, Hash)
+      @extra = extras_hash
+    end
+
+    def set_extra(key, value)
+      @extra.merge!(key => value)
+    end
+
+    def set_tags(tags_hash)
+      check_argument_type!(tags_hash, Hash)
+      @tags = tags_hash
+    end
+
+    def set_tag(key, value)
+      @tags.merge!(key => value)
+    end
+
+    def set_contexts(contexts_hash)
+      check_argument_type!(contexts_hash, Hash)
+      @contexts = contexts_hash
+    end
+
+    def set_context(key, value)
+      @contexts.merge!(key => value)
+    end
+
+    def set_level(level)
+      @level = level
+    end
+
+    def set_transaction(transaction)
+      @transactions << transaction
+    end
+
+    def transaction
+      @transactions.last
+    end
+
+    def set_fingerprint(fingerprint)
+      check_argument_type!(fingerprint, Array)
+
+      @fingerprint = fingerprint
+    end
+
+    private
+
+    def check_argument_type!(argument, expected_type)
+      unless argument.is_a?(expected_type)
+        raise ArgumentError, "expect the argument to be a #{expected_type}, got #{argument.class} (#{argument})"
+      end
     end
 
     class << self

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -50,10 +50,10 @@ RSpec.describe Sentry::Hub do
   describe "#with_scope" do
     it "builds a temporary scope" do
       inner_event = nil
-      scope.tags = { level: 1 }
+      scope.set_tags({ level: 1 })
 
       subject.with_scope do |scope|
-        scope.tags = { level: 2 }
+        scope.set_tags({ level: 2 })
         inner_event = subject.capture_message("Inner event")
       end
 
@@ -65,7 +65,7 @@ RSpec.describe Sentry::Hub do
 
     it "doesn't leak data mutation" do
       inner_event = nil
-      scope.tags = { level: 1 }
+      scope.set_tags({ level: 1 })
 
       subject.with_scope do |scope|
         scope.tags[:level] = 2
@@ -136,7 +136,7 @@ RSpec.describe Sentry::Hub do
     end
 
     it "clones the new scope from the current scope" do
-      scope.tags = { foo: "bar" }
+      scope.set_tags({ foo: "bar" })
 
       expect(subject.current_scope).to eq(scope)
 
@@ -152,7 +152,7 @@ RSpec.describe Sentry::Hub do
         expect(subject.current_scope).to eq(nil)
       end
       it "creates a new scope" do
-        scope.tags = { foo: "bar" }
+        scope.set_tags({ foo: "bar" })
 
         subject.push_scope
 

--- a/sentry-ruby/spec/sentry/scope/setters_spec.rb
+++ b/sentry-ruby/spec/sentry/scope/setters_spec.rb
@@ -1,0 +1,137 @@
+require "spec_helper"
+
+RSpec.describe Sentry::Scope do
+  let(:new_breadcrumb) do
+    new_breadcrumb = Sentry::Breadcrumb.new
+    new_breadcrumb.message = "foo"
+    new_breadcrumb
+  end
+
+  describe "#set_user" do
+    it "raises error when passed non-hash argument" do
+      expect do
+        subject.set_user(1)
+      end.to raise_error(ArgumentError)
+    end
+
+    it "sets the user" do
+      subject.set_user({id: 1, name: "Jack"})
+
+      expect(subject.user).to eq({id: 1, name: "Jack"})
+    end
+
+    it "unsets user when given empty data" do
+      subject.user = {id: 1, name: "Jack"}
+
+      subject.set_user({})
+
+      expect(subject.user).to eq({})
+    end
+  end
+
+  describe "#set_extras" do
+    it "raises error when passed non-hash argument" do
+      expect do
+        subject.set_extras(1)
+      end.to raise_error(ArgumentError)
+    end
+
+    it "replaces the extra hash" do
+      subject.extra = {bar: "baz"}
+
+      subject.set_extras({foo: "bar"})
+
+      expect(subject.extra).to eq({foo: "bar"})
+    end
+  end
+
+  describe "#set_extra" do
+    it "merges the key value with existing extra" do
+      subject.extra = {bar: "baz"}
+
+      subject.set_extra(:foo, "bar")
+
+      expect(subject.extra).to eq({foo: "bar", bar: "baz"})
+    end
+  end
+
+  describe "#set_contexts" do
+    it "raises error when passed non-hash argument" do
+      expect do
+        subject.set_contexts(1)
+      end.to raise_error(ArgumentError)
+    end
+
+    it "replaces the context hash" do
+      subject.contexts = {bar: "baz"}
+
+      subject.set_contexts({foo: "bar"})
+
+      expect(subject.contexts).to eq({foo: "bar"})
+    end
+  end
+
+  describe "#set_context" do
+    it "merges the key value with existing context" do
+      subject.contexts = {bar: "baz"}
+
+      subject.set_context(:foo, "bar")
+
+      expect(subject.contexts).to eq({foo: "bar", bar: "baz"})
+    end
+  end
+
+  describe "#set_tags" do
+    it "raises error when passed non-hash argument" do
+      expect do
+        subject.set_tags(1)
+      end.to raise_error(ArgumentError)
+    end
+
+    it "replaces the tag hash" do
+      subject.tags = {bar: "baz"}
+
+      subject.set_tags({foo: "bar"})
+
+      expect(subject.tags).to eq({foo: "bar"})
+    end
+  end
+
+  describe "#set_tag" do
+    it "merges the key value with existing tag" do
+      subject.tags = {bar: "baz"}
+
+      subject.set_tag(:foo, "bar")
+
+      expect(subject.tags).to eq({foo: "bar", bar: "baz"})
+    end
+  end
+
+  describe "#set_level" do
+    it "sets the scope's level" do
+      subject.set_level(:info)
+
+      expect(subject.level).to eq(:info)
+    end
+  end
+
+  describe "#set_transaction" do
+    it "pushes the transaction to transactions stack" do
+      subject.set_transaction("WelcomeController#home")
+
+      expect(subject.transaction).to eq("WelcomeController#home")
+    end
+  end
+
+  describe "#set_fingerprint" do
+    it "replaces the fingerprint" do
+      subject.set_fingerprint(["foo"])
+
+      expect(subject.fingerprint).to eq(["foo"])
+
+      subject.set_fingerprint(["bar"])
+
+      expect(subject.fingerprint).to eq(["bar"])
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/scope/setters_spec.rb
+++ b/sentry-ruby/spec/sentry/scope/setters_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Sentry::Scope do
     end
 
     it "unsets user when given empty data" do
-      subject.user = {id: 1, name: "Jack"}
+      subject.set_user({id: 1, name: "Jack"})
 
       subject.set_user({})
 
@@ -37,17 +37,17 @@ RSpec.describe Sentry::Scope do
     end
 
     it "replaces the extra hash" do
-      subject.extra = {bar: "baz"}
+      subject.set_extras({bar: "baz"})
+      expect(subject.extra).to eq({bar: "baz"})
 
       subject.set_extras({foo: "bar"})
-
       expect(subject.extra).to eq({foo: "bar"})
     end
   end
 
   describe "#set_extra" do
     it "merges the key value with existing extra" do
-      subject.extra = {bar: "baz"}
+      subject.set_extras({bar: "baz"})
 
       subject.set_extra(:foo, "bar")
 
@@ -63,17 +63,17 @@ RSpec.describe Sentry::Scope do
     end
 
     it "replaces the context hash" do
-      subject.contexts = {bar: "baz"}
+      subject.set_contexts({foo: "baz"})
+      expect(subject.contexts).to eq({foo: "baz"})
 
       subject.set_contexts({foo: "bar"})
-
       expect(subject.contexts).to eq({foo: "bar"})
     end
   end
 
   describe "#set_context" do
     it "merges the key value with existing context" do
-      subject.contexts = {bar: "baz"}
+      subject.set_contexts({bar: "baz"})
 
       subject.set_context(:foo, "bar")
 
@@ -89,17 +89,17 @@ RSpec.describe Sentry::Scope do
     end
 
     it "replaces the tag hash" do
-      subject.tags = {bar: "baz"}
+      subject.set_tags({foo: "baz"})
+      expect(subject.tags).to eq({foo: "baz"})
 
       subject.set_tags({foo: "bar"})
-
       expect(subject.tags).to eq({foo: "bar"})
     end
   end
 
   describe "#set_tag" do
     it "merges the key value with existing tag" do
-      subject.tags = {bar: "baz"}
+      subject.set_tags({bar: "baz"})
 
       subject.set_tag(:foo, "bar")
 

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -70,11 +70,11 @@ RSpec.describe Sentry::Scope do
   describe "#apply_to_event" do
     subject do
       scope = described_class.new
-      scope.tags = {foo: "bar"}
-      scope.extra = {additional_info: "hello"}
-      scope.user = {id: 1}
-      scope.transactions = ["WelcomeController#index"]
-      scope.fingerprint = ["foo"]
+      scope.set_tags({foo: "bar"})
+      scope.set_extras({additional_info: "hello"})
+      scope.set_user({id: 1})
+      scope.set_transaction("WelcomeController#index")
+      scope.set_fingerprint(["foo"])
       scope
     end
     let(:client) do


### PR DESCRIPTION
This PR adds the [standard setter APIs](https://develop.sentry.dev/sdk/unified-api/#scope) to the `Scope` class.