### PR TITLE
Use latest sdk name format

### DIFF
--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -14,7 +14,7 @@ module Sentry
     MAX_MESSAGE_SIZE_IN_BYTES = 1024 * 8
     REQUIRED_OPTION_KEYS = [:configuration].freeze
 
-    SDK = { "name" => "sentry-ruby", "version" => Sentry::VERSION }.freeze
+    SDK = { "name" => "sentry.ruby", "version" => Sentry::VERSION }.freeze
 
     ATTRIBUTES = %i(
       event_id logger level time_spent timestamp


### PR DESCRIPTION
I noticed a few sample events with `sentry-ruby`.
The new SDK name format is: `sentry.lang`. With more specific stuff under it like `sentry.lang.framework`.