### PR TITLE
Fix Delayed::Plugins::Raven when job raises exception

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ if rails_version.to_f != 0
   gem "rspec-rails", "~> 4.0"
 end
 
+gem "delayed_job"
 gem "sidekiq"
 
 gem "rack"

--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -30,7 +30,7 @@ module Delayed
             extra[:handler] = job.handler[0...1000] if job.handler
 
             if job.respond_to?('payload_object') && job.payload_object.respond_to?('job_data')
-              extra[:active_job] = Utils::ContextFilter.filter_context(job.payload_object.job_data)
+              extra[:active_job] = ::Raven::Utils::ContextFilter.filter_context(job.payload_object.job_data)
             end
             ::Raven.capture_exception(e,
                                       :logger => 'delayed_job',

--- a/spec/raven/integrations/delayed_job_spec.rb
+++ b/spec/raven/integrations/delayed_job_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'delayed/backend/base'
+require 'raven/integrations/delayed_job'
+
+module Delayed
+  module Plugins
+    class Raven
+      class SampleJob
+        include Delayed::Backend::Base
+
+        class << self
+          def db_time_now
+            Time.now
+          end
+        end
+
+        attr_accessor :attempts, :created_at, :error, :handler, :id, :last_error, :locked_at, :locked_by,
+                      :payload_object, :priority, :queue, :run_at
+
+        def initialize
+          super
+
+          self.attempts = 0
+        end
+
+        def save!; end
+      end
+
+      class RaiseErrorPayload
+        attr_accessor :job_data
+
+        def perform
+          raise 'error'
+        end
+      end
+    end
+  end
+end
+
+RSpec.describe Delayed::Plugins::Raven do
+  let(:worker) { Delayed::Worker.new }
+
+  context 'ActiveJob' do
+    context 'when payload#perform raises exception' do
+      let(:job) { Delayed::Plugins::Raven::SampleJob.new }
+
+      before do
+        allow(::Raven).to receive(:capture_exception)
+
+        job.payload_object = Delayed::Plugins::Raven::RaiseErrorPayload.new
+
+        worker.run(job)
+      end
+
+      it 'should capture exception' do
+        expect(::Raven).to have_received(:capture_exception)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR should fix `Delayed::Plugins::Raven` from raising `NameError: uninitialized constant Delayed::Plugins::Raven::Utils
` when job raises an exception during executing.

See #1041