### PR TITLE
Transport options

### DIFF
--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -1,5 +1,6 @@
 require "sentry/utils/exception_cause_chain"
 require "sentry/dsn"
+require "sentry/transport/configuration"
 require "sentry/linecache"
 
 module Sentry
@@ -25,9 +26,6 @@ module Sentry
     # RACK_ENV by default.
     attr_reader :current_environment
 
-    # Encoding type for event bodies. Must be :json or :gzip.
-    attr_reader :encoding
-
     # Whitelist of environments that will send notifications to Sentry. Array of Strings.
     attr_accessor :environments
 
@@ -42,13 +40,6 @@ module Sentry
     attr_accessor :inspect_exception_causes_for_exclusion
     alias inspect_exception_causes_for_exclusion? inspect_exception_causes_for_exclusion
 
-    # The Faraday adapter to be used. Will default to Net::HTTP when not set.
-    attr_accessor :http_adapter
-
-    # A Proc yeilding the faraday builder allowing for further configuration
-    # of the faraday adapter
-    attr_accessor :faraday_builder
-
     # You may provide your own LineCache for matching paths with source files.
     # This may be useful if you need to get source code from places other than
     # the disk. See Sentry::LineCache for the required interface you must implement.
@@ -58,15 +49,9 @@ module Sentry
     # Sentry provides its own Sentry::Logger.
     attr_accessor :logger
 
-    # Timeout waiting for the Sentry server connection to open in seconds
-    attr_accessor :open_timeout
-
     # Project directory root for in_app detection. Could be Rails root, etc.
     # Set automatically for Rails.
     attr_reader :project_root
-
-    # Proxy information to pass to the HTTP adapter (via Faraday)
-    attr_accessor :proxy
 
     # Turns on ActiveSupport breadcrumbs integration
     attr_reader :rails_activesupport_breadcrumbs
@@ -116,20 +101,10 @@ module Sentry
     # Silences ready message when true.
     attr_accessor :silence_ready
 
-    # SSL settings passed directly to Faraday's ssl option
-    attr_accessor :ssl
-
-    # The path to the SSL certificate file
-    attr_accessor :ssl_ca_file
-
-    # Should the SSL certificate of the server be verified?
-    attr_accessor :ssl_verification
-
     # Default tags for events. Hash.
     attr_accessor :tags
 
-    # Timeout when waiting for the server to return data in seconds.
-    attr_accessor :timeout
+    attr_reader :transport
 
     # Optional Proc, called before sending an event to the server/
     # E.g.: lambda { |event, hint| event }
@@ -184,14 +159,12 @@ module Sentry
       self.breadcrumbs_logger = []
       self.context_lines = 3
       self.current_environment = current_environment_from_env
-      self.encoding = 'gzip'
       self.environments = []
       self.exclude_loggers = []
       self.excluded_exceptions = IGNORE_DEFAULT.dup
       self.inspect_exception_causes_for_exclusion = false
       self.linecache = ::Sentry::LineCache.new
       self.logger = ::Sentry::Logger.new(STDOUT)
-      self.open_timeout = 1
       self.project_root = detect_project_root
       @rails_activesupport_breadcrumbs = false
 
@@ -202,9 +175,8 @@ module Sentry
       self.dsn = ENV['SENTRY_DSN']
       self.server_name = server_name_from_env
       self.should_capture = false
-      self.ssl_verification = true
       self.tags = {}
-      self.timeout = 2
+      @transport = Transport::Configuration.new
       self.before_send = false
     end
 
@@ -216,11 +188,6 @@ module Sentry
 
     alias server= dsn=
 
-    def encoding=(encoding)
-      raise(Error, 'Unsupported encoding') unless %w(gzip json).include? encoding
-
-      @encoding = encoding
-    end
 
     def async=(value)
       unless value == false || value.respond_to?(:call)

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -12,6 +12,8 @@ module Sentry
 
     def initialize(configuration)
       @configuration = configuration
+      @transport_configuration = configuration.transport
+      @dsn = configuration.dsn
       @state = State.new
     end
 
@@ -53,9 +55,9 @@ module Sentry
         'sentry_version' => PROTOCOL_VERSION,
         'sentry_client' => USER_AGENT,
         'sentry_timestamp' => now,
-        'sentry_key' => configuration.dsn.public_key
+        'sentry_key' => @dsn.public_key
       }
-      fields['sentry_secret'] = configuration.dsn.secret_key if configuration.dsn.secret_key
+      fields['sentry_secret'] = @dsn.secret_key if @dsn.secret_key
       'Sentry ' + fields.map { |key, value| "#{key}=#{value}" }.join(', ')
     end
 
@@ -78,7 +80,7 @@ module Sentry
     def encode(event)
       encoded = JSON.fast_generate(event.to_hash)
 
-      case configuration.encoding
+      case @transport_configuration.encoding
       when 'gzip'
         ['application/octet-stream', Base64.strict_encode64(Zlib::Deflate.deflate(encoded))]
       else

--- a/sentry-ruby/lib/sentry/transport/configuration.rb
+++ b/sentry-ruby/lib/sentry/transport/configuration.rb
@@ -1,0 +1,20 @@
+module Sentry
+  class Transport
+    class Configuration
+      attr_accessor :timeout, :open_timeout, :proxy, :ssl, :ssl_ca_file, :ssl_verification, :encoding, :http_adapter, :faraday_builder
+
+      def initialize
+        @ssl_verification = true
+        @open_timeout = 1
+        @timeout = 2
+        @encoding = 'gzip'
+      end
+
+      def encoding=(encoding)
+        raise(Error, 'Unsupported encoding') unless %w(gzip json).include? encoding
+
+        @encoding = encoding
+      end
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -20,13 +20,14 @@ RSpec.describe Sentry::Configuration do
     end
   end
 
-  it "doesnt accept invalid encodings" do
-    expect { subject.encoding = "apple" }.to raise_error(Sentry::Error, 'Unsupported encoding')
-  end
-
-  it "has hashlike attribute accessors" do
-    expect(subject.encoding).to   eq("gzip")
-    expect(subject[:encoding]).to eq("gzip")
+  describe "#transport" do
+    it "returns an initialized Transport::Configuration object" do
+      transport_config = subject.transport
+      expect(transport_config.encoding).to eq("gzip")
+      expect(transport_config.timeout).to eq(2)
+      expect(transport_config.open_timeout).to eq(1)
+      expect(transport_config.ssl_verification).to eq(true)
+    end
   end
 
   context 'configuring for async' do

--- a/sentry-ruby/spec/sentry/transport/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/configuration_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe Sentry::Transport::Configuration do
+  describe "#encoding=" do
+    it "doesnt accept invalid encodings" do
+      expect { subject.encoding = "apple" }.to raise_error(Sentry::Error, 'Unsupported encoding')
+    end
+    it "sets encoding" do
+      subject.encoding = "json"
+
+      expect(subject.encoding).to eq("json")
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Sentry::HTTPTransport do
   let(:config) do
     Sentry::Configuration.new.tap do |c|
       c.dsn = 'http://12345@sentry.localdomain/sentry/42'
-      c.http_adapter = [:test, stubs]
+      c.transport.http_adapter = [:test, stubs]
     end
   end
 
@@ -26,7 +26,7 @@ RSpec.describe Sentry::HTTPTransport do
     it 'allows to customise faraday' do
       builder = spy('faraday_builder')
       expect(Faraday).to receive(:new).and_yield(builder)
-      config.faraday_builder = proc { |b| b.request :instrumentation }
+      config.transport.faraday_builder = proc { |b| b.request :instrumentation }
 
       subject
 


### PR DESCRIPTION
Config options including `encoding`, `http_adapter`, `faraday_builder`, `open_timeout`, `timeout`, `proxy`, `ssl*` are all transport related. So this PR adds a new `TransportConfiguration` class and move all of them into it. You should now can configure them with

```ruby
Sentry.init do |config|
  config.transport.encoding = "json"
  config.transport.timeout = 2
end
```