### PR TITLE
Breadcrumb support

### DIFF
--- a/sentry-ruby/examples/rails-6.0/Gemfile
+++ b/sentry-ruby/examples/rails-6.0/Gemfile
@@ -23,8 +23,6 @@ gem 'jbuilder', '~> 2.7'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
-gem 'rack-timeout'
-
 gem 'sentry-ruby', path: "../../"
 
 # Use Active Storage variant

--- a/sentry-ruby/examples/rails-6.0/config/application.rb
+++ b/sentry-ruby/examples/rails-6.0/config/application.rb
@@ -23,6 +23,7 @@ module Rails60
     config.middleware.insert_after ActionDispatch::DebugExceptions, Sentry::Rack::CaptureException
 
     Sentry.init do |config|
+      config.breadcrumbs_logger = [:sentry_logger]
       config.dsn = 'https://2fb45f003d054a7ea47feb45898f7649@o447951.ingest.sentry.io/5434472'
     end
   end

--- a/sentry-ruby/examples/rails-6.0/config/unicorn.rb
+++ b/sentry-ruby/examples/rails-6.0/config/unicorn.rb
@@ -1,5 +1,5 @@
 worker_processes Integer(ENV["WEB_CONCURRENCY"] || 3)
-timeout 15
+timeout 200
 preload_app true
 
 before_fork do |server, worker|

--- a/sentry-ruby/lib/sentry.rb
+++ b/sentry-ruby/lib/sentry.rb
@@ -33,6 +33,10 @@ module Sentry
       configuration.logger
     end
 
+    def breadcrumbs
+      get_current_scope.breadcrumbs
+    end
+
     def configuration
       get_current_client.configuration
     end

--- a/sentry-ruby/lib/sentry.rb
+++ b/sentry-ruby/lib/sentry.rb
@@ -10,6 +10,8 @@ module Sentry
   class Error < StandardError
   end
 
+  LOGGER_PROGNAME = "sentry".freeze
+
   THREAD_LOCAL = :sentry_hub
 
   class << self

--- a/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb
@@ -1,0 +1,87 @@
+require 'logger'
+
+module Sentry
+  class Breadcrumb
+    module SentryLogger
+      LEVELS = {
+        ::Logger::DEBUG => 'debug',
+        ::Logger::INFO => 'info',
+        ::Logger::WARN => 'warn',
+        ::Logger::ERROR => 'error',
+        ::Logger::FATAL => 'fatal'
+      }.freeze
+
+      def add(*args, &block)
+        super
+        add_breadcrumb(*args, &block)
+      end
+
+      def add_breadcrumb(severity, message = nil, progname = nil)
+        # because the breadcrumbs now belongs to different Hub's Scope in different threads
+        # we need to make sure the current thread's Hub has been set before adding breadcrumbs
+        return unless Sentry.get_current_hub
+
+        category = "logger"
+
+        if message.nil?
+          if block_given?
+            message = yield
+            category = progname
+          else
+            message = progname
+          end
+        end
+        # see Logger#add's source code for above implementation
+
+        return if ignored_logger?(progname) || message.empty?
+
+        # some loggers will add leading/trailing space as they (incorrectly, mind you)
+        # think of logging as a shortcut to std{out,err}
+        message = message.to_s.strip
+
+        last_crumb = current_breadcrumbs.peek
+        # try to avoid dupes from logger broadcasts
+        if last_crumb.nil? || last_crumb.message != message
+          current_breadcrumbs.record do |crumb|
+            crumb.level = Sentry::Breadcrumb::SentryLogger::LEVELS.fetch(severity, nil)
+            crumb.category = category
+            crumb.message = message
+            crumb.type =
+              if severity >= 3
+                "error"
+              else
+                crumb.level
+              end
+          end
+        end
+      end
+
+      private
+
+      def ignored_logger?(progname)
+        progname == LOGGER_PROGNAME ||
+          Sentry.configuration.exclude_loggers.include?(progname)
+      end
+
+      def current_breadcrumbs
+        Sentry.breadcrumbs
+      end
+    end
+    module OldBreadcrumbsSentryLogger
+      def self.included(base)
+        base.class_eval do
+          include Sentry::Breadcrumbs::SentryLogger
+          alias_method :add_without_sentry, :add
+          alias_method :add, :add_with_sentry
+        end
+      end
+
+      def add_with_sentry(*args)
+        add_breadcrumb(*args)
+        add_without_sentry(*args)
+      end
+    end
+  end
+end
+
+::Logger.send(:prepend, Sentry::Breadcrumb::SentryLogger)

--- a/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb
@@ -23,6 +23,23 @@ module Sentry
 
         category = "logger"
 
+        # this is because the nature of Ruby Logger class:
+        #
+        # when given 1 argument, the argument will become both message and progname
+        #
+        # ```
+        # logger.info("foo")
+        # # message == progname == "foo"
+        # ```
+        #
+        # and to specify progname with a different message,
+        # we need to pass the progname as the argument and pass the message as a proc
+        #
+        # ```
+        # logger.info("progname") { "the message" }
+        # ```
+        #
+        # so the condition below is to replicate the similar behavior
         if message.nil?
           if block_given?
             message = yield
@@ -31,7 +48,6 @@ module Sentry
             message = progname
           end
         end
-        # see Logger#add's source code for above implementation
 
         return if ignored_logger?(progname) || message.empty?
 

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -66,7 +66,7 @@ module Sentry
 
       event = configuration.before_send.call(event, hint) if configuration.before_send
       if event.nil?
-        configuration.logger.info "Discarded event because before_send returned nil"
+        configuration.logger.info(LOGGER_PROGNAME) { "Discarded event because before_send returned nil" }
         return
       end
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -215,7 +215,7 @@ module Sentry
           Array(logger)
         end
 
-      require "raven/breadcrumbs/sentry_logger" if loggers.include?(:sentry_logger)
+      require "sentry/breadcrumb/sentry_logger" if loggers.include?(:sentry_logger)
 
       @breadcrumbs_logger = logger
     end
@@ -275,10 +275,10 @@ module Sentry
     def exception_class_allowed?(exc)
       if exc.is_a?(Sentry::Error)
         # Try to prevent error reporting loops
-        logger.debug "Refusing to capture Sentry error: #{exc.inspect}"
+        logger.debug(LOGGER_PROGNAME) { "Refusing to capture Sentry error: #{exc.inspect}" }
         false
       elsif excluded_exception?(exc)
-        logger.debug "User excluded error: #{exc.inspect}"
+        logger.debug(LOGGER_PROGNAME) { "User excluded error: #{exc.inspect}" }
         false
       else
         true
@@ -305,7 +305,7 @@ module Sentry
         detect_release_from_capistrano ||
         detect_release_from_heroku
     rescue => e
-      logger.error "Error detecting release: #{e.message}"
+      logger.error(LOGGER_PROGNAME) { "Error detecting release: #{e.message}" }
     end
 
     def excluded_exception?(incoming_exception)
@@ -341,7 +341,7 @@ module Sentry
     def detect_release_from_heroku
       return unless running_on_heroku?
       return if ENV['CI']
-      logger.warn(HEROKU_DYNO_METADATA_MESSAGE) && return unless ENV['HEROKU_SLUG_COMMIT']
+      logger.warn(LOGGER_PROGNAME) { HEROKU_DYNO_METADATA_MESSAGE } && return unless ENV['HEROKU_SLUG_COMMIT']
 
       ENV['HEROKU_SLUG_COMMIT']
     end

--- a/sentry-ruby/lib/sentry/rack/capture_exception.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exception.rb
@@ -13,6 +13,9 @@ module Sentry
         # this call creates an isolated scope for every request
         # it's essential for multi-process servers (e.g. unicorn)
         Sentry.with_scope do |scope|
+          # there could be some breadcrumbs already stored in the top-level scope
+          # and for request information, we don't need those breadcrumbs
+          scope.clear_breadcrumbs
           env['sentry.requested_at'] = Time.now
           env['sentry.client'] = Sentry.get_current_client
 

--- a/sentry-ruby/lib/sentry/rack/interface.rb
+++ b/sentry-ruby/lib/sentry/rack/interface.rb
@@ -65,7 +65,7 @@ module Sentry
           # Rails adds objects to the Rack env that can sometimes raise exceptions
           # when `to_s` is called.
           # See: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L134
-          Sentry.logger.warn("Error raised while formatting headers: #{e.message}")
+          Sentry.logger.warn(LOGGER_PROGNAME) { "Error raised while formatting headers: #{e.message}" }
           next
         end
       end

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -33,7 +33,7 @@ module Sentry
             # processors (esp ActiveJob) may not like weird types in the event hash
             configuration.async.call(event.to_json_compatible)
           rescue => e
-            configuration.logger.error("async event sending failed: #{e.message}")
+            configuration.logger.error(LOGGER_PROGNAME) { "async event sending failed: #{e.message}" }
             send_data(encoded_data, content_type: content_type)
           end
         else
@@ -73,7 +73,7 @@ module Sentry
       end
 
       event_id = event_hash[:event_id] || event_hash['event_id']
-      configuration.logger.info "Sending event #{event_id} to Sentry"
+      configuration.logger.info(LOGGER_PROGNAME) { "Sending event #{event_id} to Sentry" }
       encode(event_hash)
     end
 
@@ -90,17 +90,17 @@ module Sentry
 
     def failed_for_exception(e, event)
       @state.failure
-      configuration.logger.warn "Unable to record event with remote Sentry server (#{e.class} - #{e.message}):\n#{e.backtrace[0..10].join("\n")}"
+      configuration.logger.warn(LOGGER_PROGNAME) { "Unable to record event with remote Sentry server (#{e.class} - #{e.message}):\n#{e.backtrace[0..10].join("\n")}" }
       log_not_sending(event)
     end
 
     def failed_for_previous_failure(event)
-      configuration.logger.warn "Not sending event due to previous failure(s)."
+      configuration.logger.warn(LOGGER_PROGNAME) { "Not sending event due to previous failure(s)." }
       log_not_sending(event)
     end
 
     def log_not_sending(event)
-      configuration.logger.warn("Failed to submit event: #{Event.get_log_message(event.to_hash)}")
+      configuration.logger.warn(LOGGER_PROGNAME) { "Failed to submit event: #{Event.get_log_message(event.to_hash)}" }
     end
   end
 end

--- a/sentry-ruby/lib/sentry/transport/http_transport.rb
+++ b/sentry-ruby/lib/sentry/transport/http_transport.rb
@@ -12,7 +12,7 @@ module Sentry
 
     def send_data(data, options = {})
       unless configuration.sending_allowed?
-        logger.debug("Event not sent: #{configuration.error_messages}")
+        logger.debug(LOGGER_PROGNAME) { "Event not sent: #{configuration.error_messages}" }
       end
 
       project_id = @dsn.project_id
@@ -36,7 +36,7 @@ module Sentry
     def set_conn
       server = @dsn.server
 
-      configuration.logger.debug "Sentry HTTP Transport connecting to #{server}"
+      configuration.logger.debug(LOGGER_PROGNAME) { "Sentry HTTP Transport connecting to #{server}" }
 
       Faraday.new(server, :ssl => ssl_configuration, :proxy => @transport_configuration.proxy) do |builder|
         @transport_configuration.faraday_builder&.call(builder)

--- a/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+RSpec.describe "Sentry::Breadcrumbs::SentryLogger" do
+  before do
+    Sentry.init do |config|
+      config.dsn = DUMMY_DSN
+      config.breadcrumbs_logger = [:sentry_logger]
+    end
+  end
+
+  let(:logger) { ::Logger.new(nil) }
+  let(:breadcrumbs) { Sentry.breadcrumbs }
+
+  it "records the breadcrumb when logger is called" do
+    logger.info("foo")
+
+    breadcrumb = breadcrumbs.peek
+
+    expect(breadcrumb.level).to eq("info")
+    expect(breadcrumb.message).to eq("foo")
+  end
+
+  it "ignores traces with #{Sentry::LOGGER_PROGNAME}" do
+    logger.info(Sentry::LOGGER_PROGNAME) { "foo" }
+
+    expect(breadcrumbs.peek).to be_nil
+  end
+
+  describe "category assignment" do
+    it "assigned 'logger' by default" do
+      logger.info("foo")
+
+      expect(breadcrumbs.peek.category).to eq("logger")
+    end
+
+    it "assigns progname if provided" do
+      logger.info("test category") { "foo" }
+
+      expect(breadcrumbs.peek.category).to eq("test category")
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe Sentry::Configuration do
         it "returns nil + logs an warning if HEROKU_SLUG_COMMIT is not set" do
           logger = double("logger")
           expect(::Sentry::Logger).to receive(:new).and_return(logger)
-          expect(logger).to receive(:warn).with(described_class::HEROKU_DYNO_METADATA_MESSAGE)
+          expect(logger).to receive(:warn).with(Sentry::LOGGER_PROGNAME) { described_class::HEROKU_DYNO_METADATA_MESSAGE }
 
           expect(described_class.new.release).to eq(nil)
         end

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Sentry::Transport do
       end
 
       it "logs correct message" do
-        expect(logger).to receive(:info).with("Sending event #{event.id} to Sentry")
+        expect(logger).to receive(:info).with(Sentry::LOGGER_PROGNAME) { "Sending event #{event.id} to Sentry" }
 
         expect(subject.send_event(event)).to eq(event)
       end
@@ -74,8 +74,8 @@ RSpec.describe Sentry::Transport do
       end
 
       it "doesn't change the state" do
-        expect(logger).to receive(:warn).with("Not sending event due to previous failure(s).").ordered
-        expect(logger).to receive(:warn).with("Failed to submit event: ZeroDivisionError: divided by 0").ordered
+        expect(logger).to receive(:warn).with(Sentry::LOGGER_PROGNAME) { "Not sending event due to previous failure(s)." }.ordered
+        expect(logger).to receive(:warn).with(Sentry::LOGGER_PROGNAME) { "Failed to submit event: ZeroDivisionError: divided by 0" }.ordered
         expect(subject.state).not_to receive(:failure)
 
         expect(subject.send_event(event)).to eq(nil)
@@ -113,7 +113,7 @@ RSpec.describe Sentry::Transport do
         end
 
         it 'sends the result of Event.capture_exception via fallback' do
-          expect(logger).to receive(:error).with("async event sending failed: TypeError")
+          expect(logger).to receive(:error).with(Sentry::LOGGER_PROGNAME) { "async event sending failed: TypeError" }
           expect(configuration.async).to receive(:call).and_call_original
           expect(subject).to receive(:send_data)
 


### PR DESCRIPTION
This PR supports the`sentry_logger` breadcrumbs logger, which can be enabled with

```ruby
    Sentry.init do |config|
      config.breadcrumbs_logger = [:sentry_logger]
      config.dsn = DSN
    end
```

and the result would look like

<img width="916" alt="截圖 2020-10-16 下午9 06 11" src="https://user-images.githubusercontent.com/5079556/96261932-a7b41a80-0ff3-11eb-8d8f-6bade9bea97b.png">
