### PR TITLE
Support specifying custom transport class

### DIFF
--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -7,13 +7,18 @@ module Sentry
 
     def initialize(configuration)
       @configuration = configuration
-      @transport =
-        case configuration.dsn&.scheme
-        when 'http', 'https'
-          HTTPTransport.new(configuration)
-        else
-          DummyTransport.new(configuration)
-        end
+
+      if transport_class = configuration.transport.transport_class
+        @transport = transport_class.new(configuration)
+      else
+        @transport =
+          case configuration.dsn&.scheme
+          when 'http', 'https'
+            HTTPTransport.new(configuration)
+          else
+            DummyTransport.new(configuration)
+          end
+      end
     end
 
     def capture_exception(exception, scope:, **options, &block)

--- a/sentry-ruby/lib/sentry/transport/configuration.rb
+++ b/sentry-ruby/lib/sentry/transport/configuration.rb
@@ -1,7 +1,7 @@
 module Sentry
   class Transport
     class Configuration
-      attr_accessor :timeout, :open_timeout, :proxy, :ssl, :ssl_ca_file, :ssl_verification, :encoding, :http_adapter, :faraday_builder
+      attr_accessor :timeout, :open_timeout, :proxy, :ssl, :ssl_ca_file, :ssl_verification, :encoding, :http_adapter, :faraday_builder, :transport_class
 
       def initialize
         @ssl_verification = true
@@ -14,6 +14,14 @@ module Sentry
         raise(Error, 'Unsupported encoding') unless %w(gzip json).include? encoding
 
         @encoding = encoding
+      end
+
+      def transport_class=(klass)
+        unless klass.is_a?(Class)
+          raise Sentry::Error.new("config.transport.transport_class must a class. got: #{klass.class}")
+        end
+
+        @transport_class = klass
       end
     end
   end

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -49,21 +49,34 @@ RSpec.describe Sentry::Client do
   end
 
   describe "#transport" do
-    context "when dsn is not set" do
-      subject { described_class.new(Sentry::Configuration.new) }
+    context "when transport.transport_class is provided" do
+      before do
+        configuration.dsn = DUMMY_DSN
+        configuration.transport.transport_class = Sentry::DummyTransport
+      end
 
-      it "returns dummy transport object" do
+      it "uses that class regardless if dsn is set" do
         expect(subject.transport).to be_a(Sentry::DummyTransport)
       end
     end
 
-    context "when dsn is set" do
-      before do
-        configuration.dsn = DUMMY_DSN
+    context "when transport.transport_class is not provided" do
+      context "when dsn is not set" do
+        subject { described_class.new(Sentry::Configuration.new) }
+
+        it "returns dummy transport object" do
+          expect(subject.transport).to be_a(Sentry::DummyTransport)
+        end
       end
 
-      it "returns HTTP transport object" do
-        expect(subject.transport).to be_a(Sentry::HTTPTransport)
+      context "when dsn is set" do
+        before do
+          configuration.dsn = DUMMY_DSN
+        end
+
+        it "returns HTTP transport object" do
+          expect(subject.transport).to be_a(Sentry::HTTPTransport)
+        end
       end
     end
   end

--- a/sentry-ruby/spec/sentry/transport/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/configuration_spec.rb
@@ -11,4 +11,16 @@ RSpec.describe Sentry::Transport::Configuration do
       expect(subject.encoding).to eq("json")
     end
   end
+
+  describe "#transport_class=" do
+    it "doesn't accept non-class argument" do
+      expect { subject.transport_class = "foo" }.to raise_error(Sentry::Error, "config.transport.transport_class must a class. got: String")
+    end
+
+    it "accepts class argument" do
+      subject.transport_class = Sentry::DummyTransport
+
+      expect(subject.transport_class).to eq(Sentry::DummyTransport)
+    end
+  end
 end


### PR DESCRIPTION
```ruby
Sentry.init do |config|
  config.transport.transport_class = MyTransportClass
end
```

This closes #1066 