### PR TITLE
Add send_default_pii config option

### DIFF
--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -80,6 +80,8 @@ module Sentry
     # Include module versions in reports - boolean.
     attr_accessor :send_modules
 
+    attr_accessor :send_default_pii
+
     attr_accessor :server_name
 
     # Provide a configurable callback to determine event capture.
@@ -151,6 +153,7 @@ module Sentry
       self.release = detect_release
       self.sample_rate = 1.0
       self.send_modules = true
+      self.send_default_pii = false
       self.dsn = ENV['SENTRY_DSN']
       self.server_name = server_name_from_env
       self.should_capture = false

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -119,7 +119,7 @@ module Sentry
           int.from_rack(env)
         end
 
-        if ip = calculate_real_ip_from_rack(env.dup)
+        if configuration.send_default_pii && ip = calculate_real_ip_from_rack(env.dup)
           user[:ip_address] = ip
         end
       end

--- a/sentry-ruby/lib/sentry/rack/interface.rb
+++ b/sentry-ruby/lib/sentry/rack/interface.rb
@@ -8,8 +8,11 @@ module Sentry
       self.url = req.scheme && req.url.split('?').first
       self.method = req.request_method
       self.query_string = req.query_string
-      self.data = read_data_from(req)
-      self.cookies = req.cookies
+
+      if Sentry.configuration.send_default_pii
+        self.data = read_data_from(req)
+        self.cookies = req.cookies
+      end
 
       self.headers = format_headers_for_sentry(env_hash)
       self.env     = format_env_for_sentry(env_hash)


### PR DESCRIPTION
Because the new SDK won't perform data sanitization anymore, by default it shouldn't send any sensitive data. So this PR removes some information from the request information:

1. the user's IP address
2. the request's body/form data
3. the cookies

But this behavior can be changed with the new `send_default_pii` config option. If the SDK users still want to receive sensitive data for debugging purpose, `config.send_default_pii = true` will resume the behavior.