### PR TITLE
Support sending events in envelope format with HTTPEnvelopeTransport

### DIFF
--- a/sentry-ruby/examples/rails-6.0/config/application.rb
+++ b/sentry-ruby/examples/rails-6.0/config/application.rb
@@ -25,6 +25,7 @@ module Rails60
     Sentry.init do |config|
       config.breadcrumbs_logger = [:sentry_logger]
       config.dsn = 'https://2fb45f003d054a7ea47feb45898f7649@o447951.ingest.sentry.io/5434472'
+      config.transport.transport_class = Sentry::HTTPEnvelopeTransport
     end
   end
 end

--- a/sentry-ruby/lib/sentry/dsn.rb
+++ b/sentry-ruby/lib/sentry/dsn.rb
@@ -37,5 +37,13 @@ module Sentry
       server += path
       server
     end
+
+    def store_endpoint
+      "#{path}/api/#{project_id}/store/"
+    end
+
+    def envelope_endpoint
+      "#{path}/api/#{project_id}/envelope/"
+    end
   end
 end

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -154,14 +154,6 @@ module Sentry
       data
     end
 
-    def to_envelope
-      <<~ENVELOPE
-        {"event_id":"#{id}","dsn":"#{configuration.dsn.to_s}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{DateTime.now.rfc3339}"}
-        {"type":"event","content_type":"application/json"}
-        #{to_hash.to_json}
-      ENVELOPE
-    end
-
     def to_json_compatible
       JSON.parse(JSON.generate(to_hash))
     end

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -154,6 +154,14 @@ module Sentry
       data
     end
 
+    def to_envelope
+      <<~ENVELOPE
+        {"event_id":"#{id}","dsn":"#{configuration.dsn.to_s}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{DateTime.now.rfc3339}"}
+        {"type":"event","content_type":"application/json"}
+        #{to_hash.to_json}
+      ENVELOPE
+    end
+
     def to_json_compatible
       JSON.parse(JSON.generate(to_hash))
     end

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -107,3 +107,4 @@ end
 
 require "sentry/transport/dummy_transport"
 require "sentry/transport/http_transport"
+require "sentry/transport/http_envelope_transport"

--- a/sentry-ruby/lib/sentry/transport/http_envelope_transport.rb
+++ b/sentry-ruby/lib/sentry/transport/http_envelope_transport.rb
@@ -1,0 +1,16 @@
+require 'faraday'
+
+module Sentry
+  class HTTPEnvelopeTransport < HTTPTransport
+    attr_accessor :conn, :adapter
+
+    def initialize(*args)
+      super
+      @endpoint = @dsn.envelope_endpoint
+    end
+
+    def prepare_encoded_event(event)
+      [CONTENT_TYPE, event.to_envelope]
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/transport/http_envelope_transport.rb
+++ b/sentry-ruby/lib/sentry/transport/http_envelope_transport.rb
@@ -9,8 +9,16 @@ module Sentry
       @endpoint = @dsn.envelope_endpoint
     end
 
-    def prepare_encoded_event(event)
-      [CONTENT_TYPE, event.to_envelope]
+    def encode(event_hash)
+      event_id = event_hash[:event_id] || event_hash['event_id']
+
+      envelope = <<~ENVELOPE
+        {"event_id":"#{event_id}","dsn":"#{configuration.dsn.to_s}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{DateTime.now.rfc3339}"}
+        {"type":"event","content_type":"application/json"}
+        #{event_hash.to_json}
+      ENVELOPE
+
+      [CONTENT_TYPE, envelope]
     end
   end
 end

--- a/sentry-ruby/spec/sentry/dsn_spec.rb
+++ b/sentry-ruby/spec/sentry/dsn_spec.rb
@@ -1,11 +1,13 @@
 require "spec_helper"
 
 RSpec.describe Sentry::DSN do
-  it "initializes with correct attributes set" do
-    subject = described_class.new(
+  subject do
+    described_class.new(
       "http://12345:67890@sentry.localdomain:3000/sentry/42"
     )
+  end
 
+  it "initializes with correct attributes set" do
     expect(subject.project_id).to eq("42")
     expect(subject.public_key).to eq("12345")
     expect(subject.secret_key).to eq("67890")
@@ -16,5 +18,17 @@ RSpec.describe Sentry::DSN do
     expect(subject.path).to       eq("/sentry")
 
     expect(subject.to_s).to     eq("http://12345:67890@sentry.localdomain:3000/sentry/42")
+  end
+
+  describe "#store_endpoint" do
+    it "assembles correct store endpoint" do
+      expect(subject.store_endpoint).to eq("/sentry/api/42/store/")
+    end
+  end
+
+  describe "#envelope_endpoint" do
+    it "assembles correct envelope endpoint" do
+      expect(subject.envelope_endpoint).to eq("/sentry/api/42/envelope/")
+    end
   end
 end

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -81,51 +81,6 @@ RSpec.describe Sentry::Event do
     end
   end
 
-  describe "#to_envelope" do
-    let(:options) do
-      Sentry::Event::Options.new(
-        message: 'test',
-        level: 'warn',
-        tags: {
-          'foo' => 'bar'
-        },
-        extra: {
-          'my_custom_variable' => 'value'
-        },
-        contexts: {
-          os: { name: "mac" }
-        },
-        server_name: 'foo.local',
-        release: '721e41770371db95eee98ca2707686226b993eda',
-        environment: 'production'
-      )
-    end
-    let(:event) do
-      Sentry::Event.new(
-        configuration: configuration,
-        options: options
-      )
-    end
-
-    it "generates correct envelope content" do
-      result = event.to_envelope
-
-      envelope_header, item_header, item = result.split("\n")
-
-      expect(envelope_header).to eq(
-        <<~ENVELOPE_HEADER.chomp
-          {"event_id":"#{event.id}","dsn":"#{DUMMY_DSN}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{DateTime.now.rfc3339}"}
-        ENVELOPE_HEADER
-      )
-
-      expect(item_header).to eq(
-        '{"type":"event","content_type":"application/json"}'
-      )
-
-      expect(item).to eq(event.to_hash.to_json)
-    end
-  end
-
   context 'rack context specified' do
     require 'stringio'
 

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -1,7 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe Sentry::Event do
-  let(:configuration) { Sentry::Configuration.new }
+  let(:configuration) do
+    Sentry::Configuration.new.tap do |config|
+      config.dsn = DUMMY_DSN
+    end
+  end
 
   describe "#initialize" do
     it "initializes a Event when all required keys are provided" do
@@ -74,6 +78,51 @@ RSpec.describe Sentry::Event do
 
     it 'has SDK' do
       expect(hash[:sdk]).to eq("name" => "sentry.ruby", "version" => Sentry::VERSION)
+    end
+  end
+
+  describe "#to_envelope" do
+    let(:options) do
+      Sentry::Event::Options.new(
+        message: 'test',
+        level: 'warn',
+        tags: {
+          'foo' => 'bar'
+        },
+        extra: {
+          'my_custom_variable' => 'value'
+        },
+        contexts: {
+          os: { name: "mac" }
+        },
+        server_name: 'foo.local',
+        release: '721e41770371db95eee98ca2707686226b993eda',
+        environment: 'production'
+      )
+    end
+    let(:event) do
+      Sentry::Event.new(
+        configuration: configuration,
+        options: options
+      )
+    end
+
+    it "generates correct envelope content" do
+      result = event.to_envelope
+
+      envelope_header, item_header, item = result.split("\n")
+
+      expect(envelope_header).to eq(
+        <<~ENVELOPE_HEADER.chomp
+          {"event_id":"#{event.id}","dsn":"#{DUMMY_DSN}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{DateTime.now.rfc3339}"}
+        ENVELOPE_HEADER
+      )
+
+      expect(item_header).to eq(
+        '{"type":"event","content_type":"application/json"}'
+      )
+
+      expect(item).to eq(event.to_hash.to_json)
     end
   end
 

--- a/sentry-ruby/spec/sentry/transport/http_envelope_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_envelope_transport_spec.rb
@@ -1,21 +1,39 @@
 require 'spec_helper'
 
 RSpec.describe Sentry::HTTPEnvelopeTransport do
-  let(:config) do
-    Sentry::Configuration.new.tap do |c|
-      c.dsn = 'http://12345@sentry.localdomain/sentry/42'
-      c.transport.http_adapter = [:test, stubs]
-      c.transport.transport_class = described_class
+  let(:client) { Sentry::Client.new(Sentry.configuration) }
+  let(:event) { client.event_from_message("test") }
+  subject { described_class.new(Sentry.configuration) }
+
+  describe "#encode" do
+    before do
+      Sentry.init do |config|
+        config.dsn = DUMMY_DSN
+      end
+    end
+
+    it "generates correct envelope content" do
+      _, result = subject.encode(event.to_hash)
+
+      envelope_header, item_header, item = result.split("\n")
+
+      expect(envelope_header).to eq(
+        <<~ENVELOPE_HEADER.chomp
+          {"event_id":"#{event.id}","dsn":"#{DUMMY_DSN}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{DateTime.now.rfc3339}"}
+        ENVELOPE_HEADER
+      )
+
+      expect(item_header).to eq(
+        '{"type":"event","content_type":"application/json"}'
+      )
+
+      expect(item).to eq(event.to_hash.to_json)
     end
   end
 
-  let(:client) { Sentry::Client.new(config) }
-  let(:event) { client.event_from_message("test") }
-  subject { described_class.new(config) }
-
   describe "customizations" do
-    let(:config) do
-      Sentry::Configuration.new.tap do |c|
+    before do
+      Sentry.init do |c|
         c.dsn = 'http://12345@sentry.localdomain/sentry/42'
       end
     end
@@ -27,7 +45,7 @@ RSpec.describe Sentry::HTTPEnvelopeTransport do
     it 'allows to customise faraday' do
       builder = spy('faraday_builder')
       expect(Faraday).to receive(:new).and_yield(builder)
-      config.transport.faraday_builder = proc { |b| b.request :instrumentation }
+      Sentry.configuration.transport.faraday_builder = proc { |b| b.request :instrumentation }
 
       subject
 
@@ -35,45 +53,54 @@ RSpec.describe Sentry::HTTPEnvelopeTransport do
     end
   end
 
-  context "receive 4xx responses" do
-    let(:stubs) do
-      Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post('sentry/api/42/envelope/') { [404, {}, 'not found'] }
+  describe "failed request handling" do
+    before do
+      Sentry.init do |c|
+        c.dsn = 'http://12345@sentry.localdomain/sentry/42'
+        c.transport.http_adapter = [:test, stubs]
+        c.transport.transport_class = described_class
+      end
+    end
+    context "receive 4xx responses" do
+      let(:stubs) do
+        Faraday::Adapter::Test::Stubs.new do |stub|
+          stub.post('sentry/api/42/envelope/') { [404, {}, 'not found'] }
+        end
+      end
+
+      it 'raises an error' do
+        expect { subject.send_data(event.to_hash) }.to raise_error(Sentry::Error, /the server responded with status 404/)
+
+        stubs.verify_stubbed_calls
       end
     end
 
-    it 'raises an error' do
-      expect { subject.send_data(event.to_hash) }.to raise_error(Sentry::Error, /the server responded with status 404/)
+    context "receive 5xx responses" do
+      let(:stubs) do
+        Faraday::Adapter::Test::Stubs.new do |stub|
+          stub.post('sentry/api/42/envelope/') { [500, {}, 'error'] }
+        end
+      end
 
-      stubs.verify_stubbed_calls
-    end
-  end
+      it 'raises an error' do
+        expect { subject.send_data(event.to_hash) }.to raise_error(Sentry::Error, /the server responded with status 500/)
 
-  context "receive 5xx responses" do
-    let(:stubs) do
-      Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post('sentry/api/42/envelope/') { [500, {}, 'error'] }
+        stubs.verify_stubbed_calls
       end
     end
 
-    it 'raises an error' do
-      expect { subject.send_data(event.to_hash) }.to raise_error(Sentry::Error, /the server responded with status 500/)
-
-      stubs.verify_stubbed_calls
-    end
-  end
-
-  context "receive error responses with headers" do
-    let(:stubs) do
-      Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post('sentry/api/42/envelope/') { [400, { 'x-sentry-error' => 'error_in_header' }, 'error'] }
+    context "receive error responses with headers" do
+      let(:stubs) do
+        Faraday::Adapter::Test::Stubs.new do |stub|
+          stub.post('sentry/api/42/envelope/') { [400, { 'x-sentry-error' => 'error_in_header' }, 'error'] }
+        end
       end
-    end
 
-    it 'raises an error with header' do
-      expect { subject.send_data(event.to_hash) }.to raise_error(Sentry::Error, /error_in_header/)
+      it 'raises an error with header' do
+        expect { subject.send_data(event.to_hash) }.to raise_error(Sentry::Error, /error_in_header/)
 
-      stubs.verify_stubbed_calls
+        stubs.verify_stubbed_calls
+      end
     end
   end
 end

--- a/sentry-ruby/spec/sentry/transport/http_envelope_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_envelope_transport_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+RSpec.describe Sentry::HTTPEnvelopeTransport do
+  let(:config) do
+    Sentry::Configuration.new.tap do |c|
+      c.dsn = 'http://12345@sentry.localdomain/sentry/42'
+      c.transport.http_adapter = [:test, stubs]
+      c.transport.transport_class = described_class
+    end
+  end
+
+  let(:client) { Sentry::Client.new(config) }
+  let(:event) { client.event_from_message("test") }
+  subject { described_class.new(config) }
+
+  describe "customizations" do
+    let(:config) do
+      Sentry::Configuration.new.tap do |c|
+        c.dsn = 'http://12345@sentry.localdomain/sentry/42'
+      end
+    end
+
+    it 'sets a custom User-Agent' do
+      expect(subject.conn.headers[:user_agent]).to eq("sentry-ruby/#{Sentry::VERSION}")
+    end
+
+    it 'allows to customise faraday' do
+      builder = spy('faraday_builder')
+      expect(Faraday).to receive(:new).and_yield(builder)
+      config.transport.faraday_builder = proc { |b| b.request :instrumentation }
+
+      subject
+
+      expect(builder).to have_received(:request).with(:instrumentation)
+    end
+  end
+
+  context "receive 4xx responses" do
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.post('sentry/api/42/envelope/') { [404, {}, 'not found'] }
+      end
+    end
+
+    it 'raises an error' do
+      expect { subject.send_data(event.to_hash) }.to raise_error(Sentry::Error, /the server responded with status 404/)
+
+      stubs.verify_stubbed_calls
+    end
+  end
+
+  context "receive 5xx responses" do
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.post('sentry/api/42/envelope/') { [500, {}, 'error'] }
+      end
+    end
+
+    it 'raises an error' do
+      expect { subject.send_data(event.to_hash) }.to raise_error(Sentry::Error, /the server responded with status 500/)
+
+      stubs.verify_stubbed_calls
+    end
+  end
+
+  context "receive error responses with headers" do
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.post('sentry/api/42/envelope/') { [400, { 'x-sentry-error' => 'error_in_header' }, 'error'] }
+      end
+    end
+
+    it 'raises an error with header' do
+      expect { subject.send_data(event.to_hash) }.to raise_error(Sentry::Error, /error_in_header/)
+
+      stubs.verify_stubbed_calls
+    end
+  end
+end


### PR DESCRIPTION
Short intro of the envelopes format:

> Envelopes are a data format similar to HTTP form data, comprising common Headers and a set of Items with their own headers and payloads. Envelopes are optimized for fast parsing and human readability.

[Specficiation for the envelopes format](https://develop.sentry.dev/sdk/envelopes/)

Usage:

```ruby
Sentry.init do |config|
  # set dsn & other options
  config.transport.transport_class = Sentry::HTTPEnvelopeTransport
end
```

[Example event](https://sentry.io/organizations/sentry-sdks/issues/1975583398/?project=5434472&query=is%3Aunresolved) & its payload

```
{"event_id":"18f765a8018042b491daf99515542212","dsn":"https://2fb45f003d054a7ea47feb45898f7649@o447951.ingest.sentry.io/5434472","sdk":{"name":"sentry.ruby","version":"0.1.0"},"sent_at":"2020-10-25T23:17:57+08:00"}
{"type":"event","content_type":"application/json"}
{"event_id":"18f765a8018042b491daf99515542212","level":"error","timestamp":"2020-10-25T15:17:57.312Z","checksum":"","environment":"development","server_name":"MacBook-Pro-2","modules":{"rake":"13.0.1","concurrent-ruby":"1.1.7","i18n":"1.8.5","minitest":"5.14.2","thread_safe":"0.3.6","tzinfo":"1.2.7","zeitwerk":"2.4.0","activesupport":"6.0.3.3","builder":"3.2.4","erubi":"1.9.0","mini_portile2":"2.4.0","nokogiri":"1.10.10","rails-dom-testing":"2.0.3","crass":"1.0.6"," ....}
```

This is for #1062 