### PR TITLE
Remove unused event attributes

### DIFF
--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -16,7 +16,7 @@ module Sentry
     REQUIRED_OPTION_KEYS = [:configuration].freeze
 
     ATTRIBUTES = %i(
-      event_id logger level time_spent timestamp
+      event_id logger level timestamp
       checksum release environment server_name modules
       message user tags contexts extra
       fingerprint breadcrumbs backtrace transaction

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -16,7 +16,7 @@ module Sentry
     REQUIRED_OPTION_KEYS = [:configuration].freeze
 
     ATTRIBUTES = %i(
-      event_id logger level timestamp
+      event_id level timestamp
       release environment server_name modules
       message user tags contexts extra
       fingerprint breadcrumbs backtrace transaction

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -17,7 +17,7 @@ module Sentry
 
     ATTRIBUTES = %i(
       event_id logger level timestamp
-      checksum release environment server_name modules
+      release environment server_name modules
       message user tags contexts extra
       fingerprint breadcrumbs backtrace transaction
       platform sdk
@@ -46,8 +46,6 @@ module Sentry
       @extra         = options.extra
       @contexts      = options.contexts
       @tags          = configuration.tags.merge(options.tags)
-
-      @checksum = options.checksum
 
       @fingerprint = options.fingerprint
 

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -21,7 +21,6 @@ module Sentry
       message user tags contexts extra
       fingerprint breadcrumbs backtrace transaction
       platform sdk
-      rack_env
     )
 
     attr_accessor(*ATTRIBUTES)

--- a/sentry-ruby/lib/sentry/event/options.rb
+++ b/sentry-ruby/lib/sentry/event/options.rb
@@ -4,16 +4,14 @@ module Sentry
       attr_reader :message,
         :user, :extra, :tags, :contexts,
         :backtrace, :level, :checksum, :fingerprint,
-        :server_name, :release, :environment,
-        :time_spent
+        :server_name, :release, :environment
 
       def initialize(
         message: "",
         user: {}, extra: {}, tags: {}, contexts: {},
         backtrace: [], level: :error, checksum: "", fingerprint: [],
         # nilable attributes because we'll fallback to the configuration's values
-        server_name: nil, release: nil, environment: nil,
-        time_spent: nil
+        server_name: nil, release: nil, environment: nil
       )
         @message = message || ""
         @user = user || {}
@@ -27,7 +25,6 @@ module Sentry
         @server_name = server_name
         @environment = environment
         @release = release
-        @time_spent = time_spent
       end
     end
   end

--- a/sentry-ruby/lib/sentry/event/options.rb
+++ b/sentry-ruby/lib/sentry/event/options.rb
@@ -3,13 +3,13 @@ module Sentry
     class Options
       attr_reader :message,
         :user, :extra, :tags, :contexts,
-        :backtrace, :level, :checksum, :fingerprint,
+        :backtrace, :level, :fingerprint,
         :server_name, :release, :environment
 
       def initialize(
         message: "",
         user: {}, extra: {}, tags: {}, contexts: {},
-        backtrace: [], level: :error, checksum: "", fingerprint: [],
+        backtrace: [], level: :error, fingerprint: [],
         # nilable attributes because we'll fallback to the configuration's values
         server_name: nil, release: nil, environment: nil
       )
@@ -21,7 +21,6 @@ module Sentry
         @backtrace = backtrace || []
         @fingerprint = fingerprint || []
         @level = level || :error
-        @checksum = checksum || ""
         @server_name = server_name
         @environment = environment
         @release = release

--- a/sentry-ruby/lib/sentry/rack.rb
+++ b/sentry-ruby/lib/sentry/rack.rb
@@ -7,10 +7,6 @@ module Sentry
   module Rack
     class << self
       def capture_exception(exception, env, **options)
-        if requested_at = env['sentry.requested_at']
-          options[:time_spent] = Time.now - requested_at
-        end
-
         Sentry.capture_exception(exception, **options) do |evt|
           evt.interface :http do |int|
             int.from_rack(env)

--- a/sentry-ruby/lib/sentry/rack/capture_exception.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exception.rb
@@ -16,7 +16,6 @@ module Sentry
           # there could be some breadcrumbs already stored in the top-level scope
           # and for request information, we don't need those breadcrumbs
           scope.clear_breadcrumbs
-          env['sentry.requested_at'] = Time.now
           env['sentry.client'] = Sentry.get_current_client
 
           scope.set_transaction_name(env["PATH_INFO"]) if env["PATH_INFO"]

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -84,7 +84,6 @@ RSpec.describe Sentry::Client do
   shared_examples "options" do
     let(:options) do
       {
-        checksum: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         release: '1.0',
         fingerprint: ['{{ default }}', 'foo'],
         backtrace: ["/path/to/some/file:22:in `function_name'", "/some/other/path:1412:in `other_function'"]
@@ -96,7 +95,6 @@ RSpec.describe Sentry::Client do
     end
 
     it 'takes and sets all available options' do
-      expect(event.checksum).to eq('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
       expect(event.release).to eq('1.0')
       expect(event.fingerprint).to eq(['{{ default }}', 'foo'])
     end


### PR DESCRIPTION
These attributes were inherited from the old sdk and [are not recognized by the Sentry server](https://develop.sentry.dev/sdk/event-payloads/).