### PR TITLE
Refactor Rails patches

### DIFF
--- a/sentry-rails/lib/sentry/rails/controller_methods.rb
+++ b/sentry-rails/lib/sentry/rails/controller_methods.rb
@@ -2,11 +2,24 @@ module Sentry
   module Rails
     module ControllerMethods
       def capture_message(message, options = {})
-        Sentry::Rack.capture_message(message, request.env, options)
+        with_request_scope do
+          Sentry.capture_message(message, **options)
+        end
       end
 
       def capture_exception(exception, options = {})
-        Sentry::Rack.capture_exception(exception, request.env, options)
+        with_request_scope do
+          Sentry.capture_exception(exception, **options)
+        end
+      end
+
+      private
+
+      def with_request_scope
+        Sentry.with_scope do |scope|
+          scope.set_rack_env(request.env)
+          yield
+        end
       end
     end
   end

--- a/sentry-rails/lib/sentry/rails/overrides/debug_exceptions_catcher.rb
+++ b/sentry-rails/lib/sentry/rails/overrides/debug_exceptions_catcher.rb
@@ -5,25 +5,13 @@ module Sentry
         def render_exception(env_or_request, exception)
           begin
             env = env_or_request.respond_to?(:env) ? env_or_request.env : env_or_request
-            Sentry::Rack.capture_exception(exception, env)
+            Sentry.with_scope do |scope|
+              scope.set_rack_env(env)
+              Sentry.capture_exception(exception)
+            end
           rescue
           end
           super
-        end
-      end
-
-      module OldDebugExceptionsCatcher
-        def self.included(base)
-          base.send(:alias_method_chain, :render_exception, :raven)
-        end
-
-        def render_exception_with_raven(env_or_request, exception)
-          begin
-            env = env_or_request.respond_to?(:env) ? env_or_request.env : env_or_request
-            Sentry::Rack.capture_exception(exception, env)
-          rescue
-          end
-          render_exception_without_raven(env_or_request, exception)
         end
       end
     end

--- a/sentry-rails/spec/sentry/rails/controller_methods_spec.rb
+++ b/sentry-rails/spec/sentry/rails/controller_methods_spec.rb
@@ -3,25 +3,55 @@ require 'spec_helper'
 RSpec.describe Sentry::Rails::ControllerMethods do
   include described_class
 
-  let(:env) { { "foo" => "bar" } }
-  let(:request) { double('request', :env => env) }
-  let(:options) { double('options') }
+  def request
+    double(env: Rack::MockRequest.env_for("/test", {}))
+  end
+
+  before do
+    Sentry.init do |config|
+      config.logger = ::Logger.new(nil)
+      config.dsn = DUMMY_DSN
+      config.transport.transport_class = Sentry::DummyTransport
+    end
+  end
+
+  let(:options) do
+    { tags: { new_tag: true }}
+  end
+
+  let(:transport) do
+    Sentry.get_current_client.transport
+  end
+
+  after do
+    # make sure the scope isn't polluted
+    expect(Sentry.get_current_scope.tags).to eq({})
+    expect(Sentry.get_current_scope.rack_env).to eq({})
+  end
 
   describe "#capture_message" do
-    let(:message) { double('message') }
+    let(:message) { "foo" }
 
     it "captures a message with the request environment" do
-      expect(Sentry::Rack).to receive(:capture_message).with(message, env, options)
       capture_message(message, options)
+
+      event = transport.events.last
+      expect(event.message).to eq("foo")
+      expect(event.tags).to eq({ new_tag: true })
+      expect(event.to_hash.dig(:request, :url)).to eq("http://example.org/test")
     end
   end
 
   describe "#capture_exception" do
-    let(:exception) { double('exception') }
+    let(:exception) { ZeroDivisionError.new("divided by 0") }
 
     it "captures a exception with the request environment" do
-      expect(Sentry::Rack).to receive(:capture_exception).with(exception, env, options)
       capture_exception(exception, options)
+
+      event = transport.events.last
+      expect(event.tags).to eq({ new_tag: true })
+      expect(event.to_hash.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
+      expect(event.to_hash.dig(:request, :url)).to eq("http://example.org/test")
     end
   end
 end


### PR DESCRIPTION
1. Use temporary scope for passing request env
2. Don't use mock in tests 