### PR TITLE
Don't add message param when capturing exceptions

### DIFF
--- a/sentry-sidekiq/lib/sentry/sidekiq/cleanup_middleware.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/cleanup_middleware.rb
@@ -10,7 +10,7 @@ module Sentry
           begin
             yield
           rescue => ex
-            Sentry.capture_exception(ex, message: ex.message)
+            Sentry.capture_exception(ex)
           end
         end
       end

--- a/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
@@ -12,7 +12,6 @@ module Sentry
           scope.set_transaction_name transaction_from_context(context)
           Sentry.capture_exception(
             ex,
-            message: ex.message,
             extra: { sidekiq: context }
           )
         end

--- a/sentry-sidekiq/spec/sentry/sidekiq/error_handler_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/error_handler_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Sentry::Sidekiq::ErrorHandler do
   it "should capture exceptions based on Sidekiq context" do
     exception = build_exception
     expected_options = {
-      :message => exception.message,
       :extra => { :sidekiq => context }
     }
 
@@ -41,7 +40,6 @@ RSpec.describe Sentry::Sidekiq::ErrorHandler do
     expected_context.delete("_aj_globalid")
     expected_context["globalid"] = "gid://app/model/id"
     expected_options = {
-      :message => exception.message,
       :extra => { :sidekiq => expected_context }
     }
     expect(Sentry).to receive(:capture_exception).with(exception, expected_options)


### PR DESCRIPTION
Sentry will automatically extract the message from the exception, so there's no need to manually adding the same message.
