### PR TITLE
Don't exclude ActionView::MissingTemplate error by default

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -211,7 +211,6 @@ module Raven
       'ActionController::UnknownFormat',
       'ActionController::UnknownHttpMethod',
       'ActionDispatch::Http::Parameters::ParseError',
-      'ActionView::MissingTemplate',
       'ActiveJob::DeserializationError', # Can cause infinite loops
       'ActiveRecord::RecordNotFound',
       'CGI::Session::CookieStore::TamperedWithCookie',

--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -22,7 +22,6 @@ module Sentry
       'ActionController::UnknownFormat',
       'ActionController::UnknownHttpMethod',
       'ActionDispatch::Http::Parameters::ParseError',
-      'ActionView::MissingTemplate',
       'ActiveJob::DeserializationError', # Can cause infinite loops
       'ActiveRecord::RecordNotFound'
     ].freeze


### PR DESCRIPTION
To some users, `ActionView::MissingTemplate` is usually raised because their users make requests in unexpected formats. In those cases, the error does feel like noise and can be excluded.

However, there could also be cases that the template is missing because of bugs in the client's apps. And in those cases, the error should be reported to Sentry. 

So putting the error in the default exclusion list is a bit too aggressive. This should be a decision made by customers, not the SDK. And this PR removes it from the list.

If you think it's causing noise in your app, you can either:

1. Use `respond_to` or `respond_with` to restrict the formats you want to accept. And any request in other formats will receive a 406 instead of causing an exception on your side.
2. Add the error back to excluded_exceptions manually

```ruby
  config.excluded_exceptions << "ActionView::MissingTemplate"
```