### PR TITLE
Add new workflow for releasing new sdks

### DIFF
--- a/.github/workflows/sentry_release.yml
+++ b/.github/workflows/sentry_release.yml
@@ -1,0 +1,35 @@
+name: sentry release
+
+on:
+  push:
+    branches:
+      - release-*/**
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6 # Not needed with a .ruby-version file
+    - name: Capture sdk name
+      uses: actions-ecosystem/action-regex-match@v2
+      id: regex-match
+      with:
+        text: ${{ github.ref }}
+        regex: 'refs\/heads\/release-(sentry-\w+)\/.*'
+    - name: Set sdk-directory path
+      run: echo ${{format('sdk-directory={0}', steps.regex-match.outputs.group1)}} >> $GITHUB_ENV
+    - name: Build gem source
+      working-directory: ${{env.sdk-directory}}
+      run: |
+        bundle install
+        gem build *.gemspec
+    - name: Archive Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.sha }}
+        path: ${{env.sdk-directory}}/*.gemspec

--- a/sentry-rails/sentry-rails.gemspec
+++ b/sentry-rails/sentry-rails.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.platform = Gem::Platform::RUBY
   spec.required_ruby_version = '>= 2.4'
-  spec.extra_rdoc_files = ["README.md", "LICENSE"]
+  spec.extra_rdoc_files = ["README.md", "LICENSE.txt"]
   spec.files = `git ls-files | grep -Ev '^(spec|benchmarks|examples)'`.split("\n")
 
   spec.metadata["homepage_uri"] = spec.homepage

--- a/sentry-ruby/sentry-ruby.gemspec
+++ b/sentry-ruby/sentry-ruby.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.platform = Gem::Platform::RUBY
   spec.required_ruby_version = '>= 2.4'
-  spec.extra_rdoc_files = ["README.md", "LICENSE"]
+  spec.extra_rdoc_files = ["README.md", "LICENSE.txt"]
   spec.files = `git ls-files | grep -Ev '^(spec|benchmarks|examples)'`.split("\n")
 
   spec.metadata["homepage_uri"] = spec.homepage

--- a/sentry-sidekiq/sentry-sidekiq.gemspec
+++ b/sentry-sidekiq/sentry-sidekiq.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.platform = Gem::Platform::RUBY
   spec.required_ruby_version = '>= 2.4'
-  spec.extra_rdoc_files = ["README.md", "LICENSE"]
+  spec.extra_rdoc_files = ["README.md", "LICENSE.txt"]
   spec.files = `git ls-files | grep -Ev '^(spec|benchmarks|examples)'`.split("\n")
 
   spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
See the [example build](https://github.com/getsentry/sentry-ruby/runs/1362414489?check_suite_focus=true) for the likely result.