### PR TITLE
Fix typo: much -> must for Raven::Event

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -38,7 +38,7 @@ module Raven
       self.tags          = {} # TODO: contexts
 
       unless REQUIRED_OPTION_KEYS.all? { |key| options.key?(key) }
-        raise "you much provide configuration, context, and breadcrumbs when initializing a Raven::Event"
+        raise "you must provide configuration, context, and breadcrumbs when initializing a Raven::Event"
       end
 
       self.configuration = options[:configuration]

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Raven::Event do
 
         expect do
           described_class.new(essential_options)
-        end.to raise_error("you much provide configuration, context, and breadcrumbs when initializing a Raven::Event")
+        end.to raise_error("you must provide configuration, context, and breadcrumbs when initializing a Raven::Event")
       end
     end
   end


### PR DESCRIPTION
## Description

Fixes a typo on exception message.