### PR TITLE
Support transaction (part 1)

### DIFF
--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -30,7 +30,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-
+    - name: Install sqlite
+      run: |
+        # See https://github.community/t5/GitHub-Actions/ubuntu-latest-Apt-repository-list-issues/td-p/41122/page/2
+        for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
+        sudo apt-get update
+        sudo apt-get install libsqlite3-dev
     - name: Set up Ruby ${{ matrix.ruby_version }}
       uses: ruby/setup-ruby@v1
       with:

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -6,6 +6,10 @@ gemspec
 rails_version = ENV["RAILS_VERSION"]
 rails_version = "6.0" if rails_version.nil?
 
+gem 'activerecord-jdbcmysql-adapter', platform: :jruby
+gem "jdbc-sqlite3", platform: :jruby
+gem "sqlite3", platform: :ruby
+
 gem "rails", "~> #{rails_version}"
 gem "rspec-rails", "~> 4.0"
 gem "codecov"

--- a/sentry-rails/examples/rails-6.0/config/application.rb
+++ b/sentry-rails/examples/rails-6.0/config/application.rb
@@ -23,6 +23,7 @@ module Rails60
     Sentry.init do |config|
       config.breadcrumbs_logger = [:sentry_logger]
       config.send_default_pii = true
+      config.traces_sample_rate = 1.0
       config.dsn = 'https://2fb45f003d054a7ea47feb45898f7649@o447951.ingest.sentry.io/5434472'
     end
   end

--- a/sentry-rails/lib/sentry/rails.rb
+++ b/sentry-rails/lib/sentry/rails.rb
@@ -1,6 +1,7 @@
 require "sentry-ruby"
 require "sentry/rails/configuration"
 require "sentry/rails/railtie"
+require "sentry/rails/tracing"
 
 module Sentry
   module Rails

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -10,6 +10,7 @@ module Sentry
   class Railtie < ::Rails::Railtie
     initializer "sentry.use_rack_middleware" do |app|
       app.config.middleware.insert 0, Sentry::Rails::CaptureException
+      app.config.middleware.insert 0, Sentry::Rack::Tracing
     end
 
     initializer 'sentry.action_controller' do
@@ -49,6 +50,10 @@ module Sentry
         end
 
         exceptions_class.send(:prepend, Sentry::Rails::Overrides::DebugExceptionsCatcher)
+      end
+
+      if Sentry.configuration.traces_sample_rate.to_f > 0.0
+        Sentry::Rails::Tracing.subscribe_tracing_events
       end
     end
 

--- a/sentry-rails/lib/sentry/rails/tracing.rb
+++ b/sentry-rails/lib/sentry/rails/tracing.rb
@@ -1,0 +1,17 @@
+require "sentry/rails/tracing/abstract_subscriber"
+require "sentry/rails/tracing/active_record_subscriber"
+
+module Sentry
+  module Rails
+    module Tracing
+      def self.subscribe_tracing_events
+        # need to avoid duplicated subscription
+        return if @subscribed
+
+        Tracing::ActiveRecordSubscriber.subscribe!
+
+        @subscribed = true
+      end
+    end
+  end
+end

--- a/sentry-rails/lib/sentry/rails/tracing/abstract_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/abstract_subscriber.rb
@@ -1,0 +1,29 @@
+module Sentry
+  module Rails
+    module Tracing
+      class AbstractSubscriber
+
+        def self.subscribe!
+          raise NotImplementedError
+        end
+
+        def self.subscribe_to_event(event_name)
+          if ::Rails.version.to_i == 5
+            ActiveSupport::Notifications.subscribe(event_name) do |_, start, finish, _, payload|
+              next unless Sentry.get_transaction
+
+              duration = finish.to_f - start.to_f
+              yield(event_name, duration, payload)
+            end
+          else
+            ActiveSupport::Notifications.subscribe(event_name) do |event|
+              next unless Sentry.get_transaction
+
+              yield(event_name, event.duration, event.payload)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
@@ -11,7 +11,7 @@ module Sentry
               timestamp = Time.now.utc.to_f
               start_timestamp = timestamp - duration.to_f
 
-              new_span = Sentry.get_transaction.start_child(op: event_name, description: payload[:sql], start_timestamp: start_timestamp, timestamp: timestamp)
+              new_span = get_current_transaction.start_child(op: event_name, description: payload[:sql], start_timestamp: start_timestamp, timestamp: timestamp)
               new_span.set_data(:name, payload[:name])
               new_span.set_data(:connection_id, payload[:connection_id])
             end

--- a/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
@@ -1,0 +1,23 @@
+module Sentry
+  module Rails
+    module Tracing
+      class ActiveRecordSubscriber < AbstractSubscriber
+        EVENT_NAME = "sql.active_record".freeze
+        EXCLUDED_EVENTS = ["SCHEMA", "TRANSACTION"].freeze
+
+        def self.subscribe!
+          subscribe_to_event(EVENT_NAME) do |event_name, duration, payload|
+            if !EXCLUDED_EVENTS.include? payload[:name]
+              timestamp = Time.now.utc.to_f
+              start_timestamp = timestamp - duration.to_f
+
+              new_span = Sentry.get_transaction.start_child(op: event_name, description: payload[:sql], start_timestamp: start_timestamp, timestamp: timestamp)
+              new_span.set_data(:name, payload[:name])
+              new_span.set_data(:connection_id, payload[:connection_id])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+
+RSpec.describe Sentry::Rails::Tracing, type: :request do
+  let(:transport) do
+    Sentry.get_current_client.transport
+  end
+
+  let(:event) do
+    transport.events.last.to_json_compatible
+  end
+
+  after do
+    transport.events = []
+  end
+
+  context "with traces_sample_rate set" do
+    before do
+      expect(described_class).to receive(:subscribe_tracing_events).and_call_original
+
+      make_basic_app do |config|
+        config.traces_sample_rate = 1.0
+      end
+    end
+
+    it "records transaction" do
+      get "/posts"
+
+      expect(transport.events.count).to eq(2)
+
+      event = transport.events.first.to_hash
+      transaction = transport.events.last.to_hash
+
+      expect(event.dig(:contexts, :trace, :trace_id).length).to eq(32)
+      expect(event.dig(:contexts, :trace, :trace_id)).to eq(transaction.dig(:contexts, :trace, :trace_id))
+
+      expect(transaction[:type]).to eq("transaction")
+      expect(transaction[:spans].count).to eq(2)
+
+      first_span = transaction[:spans][0]
+      expect(first_span[:op]).to eq("rack.request")
+      expect(first_span[:status]).to eq("internal_error")
+      expect(first_span[:data]).to eq({ "status_code" => 500 })
+
+      second_span = transaction[:spans][1]
+      expect(second_span[:op]).to eq("sql.active_record")
+      expect(second_span[:description]).to eq("SELECT \"posts\".* FROM \"posts\"")
+      expect(second_span[:parent_span_id]).to eq(first_span[:span_id])
+    end
+  end
+
+  context "without traces_sample_rate set" do
+    before do
+      expect(described_class).not_to receive(:subscribe_tracing_events)
+
+      make_basic_app
+    end
+
+    it "doesn't record any transaction" do
+      get "/posts"
+
+      expect(transport.events.count).to eq(1)
+    end
+  end
+end

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Sentry::Rails, type: :request do
-  before(:all) do
+  before do
     make_basic_app
   end
 
@@ -21,8 +21,9 @@ RSpec.describe Sentry::Rails, type: :request do
     expect(described_class::VERSION).to be_a(String)
   end
 
-  it "inserts middleware" do
-    expect(Rails.application.middleware).to include(Sentry::Rails::CaptureException)
+  it "inserts middleware to a correct position" do
+    expect(Rails.application.middleware.find_index(Sentry::Rack::Tracing)).to eq(0)
+    expect(Rails.application.middleware.find_index(Sentry::Rails::CaptureException)).to eq(1)
   end
 
   it "doesn't do anything on a normal route" do

--- a/sentry-rails/spec/support/test_rails_app/app.rb
+++ b/sentry-rails/spec/support/test_rails_app/app.rb
@@ -1,5 +1,5 @@
 require 'rails'
-# require "active_record/railtie"
+require "active_record"
 require "action_view/railtie"
 require "action_controller/railtie"
 # require "action_mailer/railtie"
@@ -11,7 +11,34 @@ require 'sentry/rails'
 
 ActiveSupport::Deprecation.silenced = true
 
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+ActiveRecord::Base.logger = Logger.new(nil)
+
+ActiveRecord::Schema.define do
+  create_table :posts, force: true do |t|
+  end
+
+  create_table :comments, force: true do |t|
+    t.integer :post_id
+  end
+end
+
+class Post < ActiveRecord::Base
+  has_many :comments
+end
+
+class Comment < ActiveRecord::Base
+  belongs_to :post
+end
+
 class TestApp < Rails::Application
+end
+
+class PostsController < ActionController::Base
+  def index
+    Post.all.to_a
+    raise "foo"
+  end
 end
 
 class HelloController < ActionController::Base
@@ -48,6 +75,7 @@ def make_basic_app
     get "/exception", :to => "hello#exception"
     get "/view_exception", :to => "hello#view_exception"
     get "/not_found", :to => "hello#not_found"
+    resources :posts, only: [:index]
     root :to => "hello#world"
   end
 

--- a/sentry-ruby/examples/rails-6.0/config/application.rb
+++ b/sentry-ruby/examples/rails-6.0/config/application.rb
@@ -21,6 +21,7 @@ module Rails60
     config.exceptions_app = self.routes
 
     config.middleware.insert_after ActionDispatch::DebugExceptions, Sentry::Rack::CaptureException
+    config.middleware.insert 0, Sentry::Rack::Tracing
 
     Sentry.init do |config|
       config.breadcrumbs_logger = [:sentry_logger]

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -3,6 +3,9 @@ require "sentry/core_ext/object/deep_dup"
 require "sentry/configuration"
 require "sentry/logger"
 require "sentry/event"
+require "sentry/transaction_event"
+require "sentry/span"
+require "sentry/transaction"
 require "sentry/hub"
 require "sentry/rack"
 
@@ -60,6 +63,10 @@ module Sentry
       Thread.current[THREAD_LOCAL] || clone_hub_to_current_thread
     end
 
+    def get_transaction
+      get_current_hub.get_transaction
+    end
+
     def clone_hub_to_current_thread
       Thread.current[THREAD_LOCAL] = get_main_hub.clone
     end
@@ -90,6 +97,14 @@ module Sentry
 
     def capture_message(message, **options, &block)
       get_current_hub.capture_message(message, **options, &block)
+    end
+
+    def start_span(**options)
+      get_current_hub.start_span(**options)
+    end
+
+    def start_transaction(**options)
+      get_current_hub.start_transaction(**options)
     end
 
     def last_event_id

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -63,10 +63,6 @@ module Sentry
       Thread.current[THREAD_LOCAL] || clone_hub_to_current_thread
     end
 
-    def get_transaction
-      get_current_hub.get_transaction
-    end
-
     def clone_hub_to_current_thread
       Thread.current[THREAD_LOCAL] = get_main_hub.clone
     end
@@ -97,10 +93,6 @@ module Sentry
 
     def capture_message(message, **options, &block)
       get_current_hub.capture_message(message, **options, &block)
-    end
-
-    def start_span(**options)
-      get_current_hub.start_span(**options)
     end
 
     def start_transaction(**options)

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -95,6 +95,8 @@ module Sentry
 
     attr_reader :transport
 
+    attr_accessor :traces_sample_rate
+
     # Optional Proc, called before sending an event to the server/
     # E.g.: lambda { |event| event }
     # E.g.: lambda { |event| nil }

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -67,6 +67,23 @@ module Sentry
       @stack.pop
     end
 
+    def get_transaction
+      current_scope.span
+    end
+
+    def start_span(**options)
+      if span = current_scope.span
+        span.start_child(**options)
+      else
+        Span.new(**options)
+      end
+    end
+
+    def start_transaction(transaction: nil, **options)
+      transaction ||= Transaction.new(**options, sampled: true)
+      # TODO: Add sampling logic
+    end
+
     def capture_exception(exception, **options, &block)
       return unless current_client
 
@@ -99,7 +116,7 @@ module Sentry
 
       event = current_client.capture_event(event, scope)
 
-      @last_event_id = event.id
+      @last_event_id = event.event_id
       event
     end
 

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -67,18 +67,6 @@ module Sentry
       @stack.pop
     end
 
-    def get_transaction
-      current_scope.span
-    end
-
-    def start_span(**options)
-      if span = current_scope.span
-        span.start_child(**options)
-      else
-        Span.new(**options)
-      end
-    end
-
     def start_transaction(transaction: nil, **options)
       transaction ||= Transaction.new(**options, sampled: true)
       # TODO: Add sampling logic

--- a/sentry-ruby/lib/sentry/rack.rb
+++ b/sentry-ruby/lib/sentry/rack.rb
@@ -2,3 +2,4 @@ require 'time'
 require 'rack'
 
 require 'sentry/rack/capture_exception'
+require 'sentry/rack/tracing'

--- a/sentry-ruby/lib/sentry/rack/tracing.rb
+++ b/sentry-ruby/lib/sentry/rack/tracing.rb
@@ -1,0 +1,38 @@
+module Sentry
+  module Rack
+    class Tracing
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        Sentry.clone_hub_to_current_thread unless Sentry.get_current_hub
+
+        if Sentry.configuration.traces_sample_rate.to_f == 0.0
+          return @app.call(env)
+        end
+
+        Sentry.with_scope do |scope|
+          scope.set_transaction_name(env["PATH_INFO"]) if env["PATH_INFO"]
+          span = Sentry.start_transaction(name: scope.transaction_name, op: "rack.request")
+          scope.set_span(span)
+
+          begin
+            response = @app.call(env)
+          rescue
+            finish_span(span, 500)
+            raise
+          end
+
+          finish_span(span, response[0])
+          response
+        end
+      end
+
+      def finish_span(span, status_code)
+        span.set_http_status(status_code)
+        span.finish
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -98,10 +98,6 @@ module Sentry
       @span = span
     end
 
-    def get_span
-      @span
-    end
-
     def set_user(user_hash)
       check_argument_type!(user_hash, Hash)
       @user = user_hash
@@ -146,6 +142,15 @@ module Sentry
       @transaction_names.last
     end
 
+    def get_transaction
+      # transaction will always be the first in the span_recorder
+      span.span_recorder.spans.first if span
+    end
+
+    def get_span
+      span
+    end
+
     def set_fingerprint(fingerprint)
       check_argument_type!(fingerprint, Array)
 
@@ -180,6 +185,7 @@ module Sentry
       @transaction_names = []
       @event_processors = []
       @rack_env = {}
+      @span = nil
     end
 
     class << self

--- a/sentry-ruby/lib/sentry/span.rb
+++ b/sentry-ruby/lib/sentry/span.rb
@@ -3,13 +3,6 @@ require "securerandom"
 
 module Sentry
   class Span
-    TRACEPARENT_REGEXP = Regexp.new(
-      "^[ \t]*" +  # whitespace
-      "([0-9a-f]{32})?" +  # trace_id
-      "-?([0-9a-f]{16})?" +  # span_id
-      "-?([01])?" +  # sampled
-      "[ \t]*$"  # whitespace
-    )
     STATUS_MAP = {
       400 => "invalid_argument",
       401 => "unauthenticated",
@@ -51,7 +44,7 @@ module Sentry
       @timestamp = Time.now.utc.to_f
     end
 
-    def to_traceparent
+    def to_sentry_trace
       sampled_flag = ""
       sampled_flag = @sampled ? 1 : 0 unless @sampled.nil?
 

--- a/sentry-ruby/lib/sentry/span.rb
+++ b/sentry-ruby/lib/sentry/span.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+require "securerandom"
+
+module Sentry
+  class Span
+    TRACEPARENT_REGEXP = Regexp.new(
+      "^[ \t]*" +  # whitespace
+      "([0-9a-f]{32})?" +  # trace_id
+      "-?([0-9a-f]{16})?" +  # span_id
+      "-?([01])?" +  # sampled
+      "[ \t]*$"  # whitespace
+    )
+    STATUS_MAP = {
+      400 => "invalid_argument",
+      401 => "unauthenticated",
+      403 => "permission_denied",
+      404 => "not_found",
+      409 => "already_exists",
+      429 => "resource_exhausted",
+      499 => "cancelled",
+      500 => "internal_error",
+      501 => "unimplemented",
+      503 => "unavailable",
+      504 => "deadline_exceeded"
+    }
+
+
+    attr_reader :trace_id, :span_id, :parent_span_id, :sampled, :start_timestamp, :timestamp, :description, :op, :status, :tags, :data
+    attr_accessor :span_recorder
+
+    def initialize(description: nil, op: nil, status: nil, trace_id: nil, parent_span_id: nil, sampled: nil, start_timestamp: nil, timestamp: nil)
+      @trace_id = trace_id || SecureRandom.uuid.delete("-")
+      @span_id = SecureRandom.hex(8)
+      @parent_span_id = parent_span_id
+      @sampled = sampled
+      @start_timestamp = start_timestamp || Time.now.utc.to_f
+      @timestamp = timestamp
+      @description = description
+      @op = op
+      @status = status
+      @data = {}
+      @tags = {}
+      @span_recorder = SpanRecorder.new(1000)
+      @span_recorder.add(self)
+    end
+
+    def finish
+      # already finished
+      return if @timestamp
+
+      @timestamp = Time.now.utc.to_f
+    end
+
+    def to_traceparent
+      sampled_flag = ""
+      sampled_flag = @sampled ? 1 : 0 unless @sampled.nil?
+
+      "#{@trace_id}-#{@span_id}-#{sampled_flag}"
+    end
+
+    def to_hash
+      {
+        trace_id: @trace_id,
+        span_id: @span_id,
+        parent_span_id: @parent_span_id,
+        start_timestamp: @start_timestamp,
+        timestamp: @timestamp,
+        description: @description,
+        op: @op,
+        status: @status,
+        tags: @tags,
+        data: @data
+      }
+    end
+
+    def get_trace_context
+      {
+        trace_id: @trace_id,
+        span_id: @span_id,
+        description: @description,
+        op: @op,
+        status: @status
+      }
+    end
+
+    def start_child(**options)
+      options = options.dup.merge(trace_id: @trace_id, parent_span_id: @span_id, sampled: @sampled)
+      child_span = self.class.new(options)
+      child_span.span_recorder = @span_recorder
+      @span_recorder.add(child_span)
+      child_span
+    end
+
+    def set_status(status)
+      @status = status
+    end
+
+    def set_http_status(status_code)
+      status_code = status_code.to_i
+      set_data("status_code", status_code)
+
+      status =
+        if status_code >= 200 && status_code < 299
+          "ok"
+        else
+          STATUS_MAP[status_code]
+        end
+      set_status(status)
+    end
+
+    def set_data(key, value)
+      @data[key] = value
+    end
+
+    def set_tag(key, value)
+      @tags[key] = value
+    end
+
+    class SpanRecorder
+      attr_reader :max_length, :spans
+
+      def initialize(max_length)
+        @max_length = max_length
+        @spans = []
+      end
+
+      def add(span)
+        if @spans.count < @max_length
+          @spans << span
+        end
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -1,0 +1,34 @@
+module Sentry
+  class Transaction < Span
+    UNLABELD_NAME = "<unlabeled transaction>".freeze
+
+    attr_reader :name, :parent_sampled
+
+    def initialize(name: nil, parent_sampled: nil, **options)
+      super(**options)
+
+      @name = name
+      @parent_sampled = parent_sampled
+    end
+
+    def to_hash
+      hash = super
+      hash.merge!(name: @name, sampled: @sampled, parent_sampled: @parent_sampled)
+      hash
+    end
+
+    def finish(hub: nil)
+      super() # Span#finish doesn't take arguments
+
+      if @name.nil?
+        @name = UNLABELD_NAME
+      end
+
+      return unless @sampled
+
+      hub ||= Sentry.get_current_hub
+      event = hub.current_client.event_from_transaction(self)
+      hub.capture_event(event)
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/transaction_event.rb
+++ b/sentry-ruby/lib/sentry/transaction_event.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Sentry
+  class TransactionEvent < Event
+    ATTRIBUTES = %i(
+      event_id level timestamp start_timestamp
+      release environment server_name modules
+      user tags contexts extra
+      transaction platform sdk type
+    )
+
+    attr_accessor(*ATTRIBUTES)
+    attr_accessor :spans
+
+    def start_timestamp=(time)
+      @start_timestamp = time.is_a?(Time) ? time.strftime('%Y-%m-%dT%H:%M:%S') : time
+    end
+
+    def type
+      "transaction"
+    end
+
+    def to_hash
+      data = super
+      data[:spans] = @spans.map(&:to_hash) if @spans
+      data
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -49,10 +49,11 @@ module Sentry
 
     def encode(event_hash)
       event_id = event_hash[:event_id] || event_hash['event_id']
+      event_type = event_hash[:type] || event_hash['type']
 
       envelope = <<~ENVELOPE
         {"event_id":"#{event_id}","dsn":"#{configuration.dsn.to_s}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{DateTime.now.rfc3339}"}
-        {"type":"event","content_type":"application/json"}
+        {"type":"#{event_type}","content_type":"application/json"}
         #{JSON.generate(event_hash)}
       ENVELOPE
 

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -137,46 +137,6 @@ RSpec.describe Sentry::Hub do
     end
   end
 
-  describe "#start_span" do
-    it "initializes a new span object" do
-      span = subject.start_span(op: "foo")
-
-      expect(span).to be_a(Sentry::Span)
-      expect(span.op).to eq("foo")
-    end
-
-    context "already has a span in scope" do
-      let(:span) do
-        subject.start_span(op: "foo")
-      end
-
-      before do
-        subject.current_scope.set_span(span)
-      end
-
-      it "starts a child span of the current span" do
-        child_span = subject.start_span(op: "bar")
-
-        expect(child_span.op).to eq("bar")
-        expect(child_span.parent_span_id).to eq(span.span_id)
-      end
-    end
-  end
-
-  describe "#get_transaction" do
-    let(:span) do
-      subject.start_span(op: "foo")
-    end
-
-    before do
-      subject.current_scope.set_span(span)
-    end
-
-    it "gets the transaction/span stored in the current scope" do
-      expect(subject.get_transaction).to eq(span)
-    end
-  end
-
   describe "#with_scope" do
     it "builds a temporary scope" do
       inner_event = nil

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -137,6 +137,46 @@ RSpec.describe Sentry::Hub do
     end
   end
 
+  describe "#start_span" do
+    it "initializes a new span object" do
+      span = subject.start_span(op: "foo")
+
+      expect(span).to be_a(Sentry::Span)
+      expect(span.op).to eq("foo")
+    end
+
+    context "already has a span in scope" do
+      let(:span) do
+        subject.start_span(op: "foo")
+      end
+
+      before do
+        subject.current_scope.set_span(span)
+      end
+
+      it "starts a child span of the current span" do
+        child_span = subject.start_span(op: "bar")
+
+        expect(child_span.op).to eq("bar")
+        expect(child_span.parent_span_id).to eq(span.span_id)
+      end
+    end
+  end
+
+  describe "#get_transaction" do
+    let(:span) do
+      subject.start_span(op: "foo")
+    end
+
+    before do
+      subject.current_scope.set_span(span)
+    end
+
+    it "gets the transaction/span stored in the current scope" do
+      expect(subject.get_transaction).to eq(span)
+    end
+  end
+
   describe "#with_scope" do
     it "builds a temporary scope" do
       inner_event = nil
@@ -287,7 +327,7 @@ RSpec.describe Sentry::Hub do
 
       event = subject.capture_message("Test message")
 
-      expect(subject.last_event_id).to eq(event.id)
+      expect(subject.last_event_id).to eq(event.event_id)
     end
   end
 end

--- a/sentry-ruby/spec/sentry/rack/tracing_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/tracing_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+RSpec.describe Sentry::Rack::Tracing do
+  let(:exception) { ZeroDivisionError.new("divided by 0") }
+  let(:additional_headers) { {} }
+  let(:env) { Rack::MockRequest.env_for("/test", additional_headers) }
+
+  before do
+    Sentry.init do |config|
+      config.breadcrumbs_logger = [:sentry_logger]
+      config.dsn = DUMMY_DSN
+      config.transport.transport_class = Sentry::DummyTransport
+      config.traces_sample_rate = 1.0
+    end
+  end
+
+  let(:transport) do
+    Sentry.get_current_client.transport
+  end
+
+  it "starts a span and finishes it" do
+    app = ->(_) do
+      [200, {}, ["ok"]]
+    end
+
+    stack = described_class.new(app)
+
+    stack.call(env)
+
+    transaction = transport.events.last
+    expect(transaction.type).to eq("transaction")
+    expect(transaction.spans.count).to eq(1)
+    span = transaction.spans.last
+    expect(span[:status]).to eq("ok")
+    expect(span[:data]).to eq({ "status_code" => 200 })
+    expect(span[:timestamp]).not_to be_nil
+  end
+
+  context "when there's an exception" do
+    it "still finishes the transaction" do
+      app = ->(_) do
+        raise "foo"
+      end
+
+      app = Sentry::Rack::CaptureException.new(app)
+      stack = described_class.new(app)
+
+      expect do
+        stack.call(env)
+      end.to raise_error("foo")
+
+      expect(transport.events.count).to eq(2)
+      event = transport.events.first
+      transaction = transport.events.last
+      expect(event.contexts.dig(:trace, :trace_id).length).to eq(32)
+      expect(event.contexts.dig(:trace, :trace_id)).to eq(transaction.contexts.dig(:trace, :trace_id))
+
+      expect(transaction.type).to eq("transaction")
+      expect(transaction.spans.count).to eq(1)
+      span = transaction.spans.last
+      expect(span[:status]).to eq("internal_error")
+      expect(span[:data]).to eq({ "status_code" => 500 })
+      expect(span[:timestamp]).not_to be_nil
+    end
+  end
+
+  context "when traces_sample_rate is not set" do
+    before do
+      Sentry.configuration.traces_sample_rate = nil
+    end
+
+    it "doesn't record transaction" do
+      app = ->(_) do
+        [200, {}, ["ok"]]
+      end
+
+      stack = described_class.new(app)
+
+      stack.call(env)
+
+      expect(transport.events.count).to eq(0)
+    end
+  end
+end
+

--- a/sentry-ruby/spec/sentry/scope/setters_spec.rb
+++ b/sentry-ruby/spec/sentry/scope/setters_spec.rb
@@ -23,6 +23,22 @@ RSpec.describe Sentry::Scope do
     end
   end
 
+  describe "#set_span" do
+    let(:span) { Sentry::Span.new(op: "foo") }
+
+    it "sets the Span" do
+      subject.set_span(span)
+
+      expect(subject.span).to eq(span)
+    end
+
+    it "raises error when passed non-Span argument" do
+      expect do
+        subject.set_span(1)
+      end.to raise_error(ArgumentError)
+    end
+  end
+
   describe "#set_user" do
     it "raises error when passed non-hash argument" do
       expect do

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -171,5 +171,15 @@ RSpec.describe Sentry::Scope do
 
       expect(event.tags).to eq({ processed: true })
     end
+
+    it "sets trace context if there's a span" do
+      span = Sentry::Span.new(op: "foo")
+      subject.set_span(span)
+
+      subject.apply_to_event(event)
+
+      expect(event.contexts[:trace]).to eq(span.get_trace_context)
+      expect(event.contexts.dig(:trace, :op)).to eq("foo")
+    end
   end
 end

--- a/sentry-ruby/spec/sentry/span_spec.rb
+++ b/sentry-ruby/spec/sentry/span_spec.rb
@@ -1,0 +1,137 @@
+require "spec_helper"
+
+RSpec.describe Sentry::Span do
+  subject do
+    described_class.new(
+      op: "sql.query",
+      description: "SELECT * FROM users;",
+      status: "ok",
+      sampled: true
+    )
+  end
+
+  describe "#get_trace_context" do
+    it "returns correct context data" do
+      context = subject.get_trace_context
+
+      expect(context[:op]).to eq("sql.query")
+      expect(context[:description]).to eq("SELECT * FROM users;")
+      expect(context[:status]).to eq("ok")
+      expect(context[:trace_id].length).to eq(32)
+      expect(context[:span_id].length).to eq(16)
+    end
+  end
+
+  describe "#to_hash" do
+    before do
+      subject.set_data("controller", "WelcomeController")
+      subject.set_tag("foo", "bar")
+    end
+
+    it "returns correct data" do
+      hash = subject.to_hash
+
+      expect(hash[:op]).to eq("sql.query")
+      expect(hash[:description]).to eq("SELECT * FROM users;")
+      expect(hash[:status]).to eq("ok")
+      expect(hash[:data]).to eq({ "controller" => "WelcomeController" })
+      expect(hash[:tags]).to eq({ "foo" => "bar" })
+      expect(hash[:trace_id].length).to eq(32)
+      expect(hash[:span_id].length).to eq(16)
+    end
+  end
+
+  describe "#to_traceparent" do
+    it "returns correctly-formatted value" do
+      traceparent = subject.to_traceparent
+
+      expect(traceparent).to eq("#{subject.trace_id}-#{subject.span_id}-1")
+      expect(traceparent).to match(Sentry::Span::TRACEPARENT_REGEXP)
+    end
+
+    context "without sampled value" do
+      subject { described_class.new }
+
+      it "doesn't contain the sampled flag" do
+        traceparent = subject.to_traceparent
+
+        expect(traceparent).to eq("#{subject.trace_id}-#{subject.span_id}-")
+        expect(traceparent).to match(Sentry::Span::TRACEPARENT_REGEXP)
+      end
+    end
+  end
+
+  describe "#start_child" do
+    it "initializes a new child Span" do
+      # create subject span and wait for a sec for making time difference
+      subject
+      sleep 1
+
+      new_span = subject.start_child(op: "sql.query", description: "SELECT * FROM orders WHERE orders.user_id = 1", status: "ok")
+
+      expect(new_span.op).to eq("sql.query")
+      expect(new_span.description).to eq("SELECT * FROM orders WHERE orders.user_id = 1")
+      expect(new_span.status).to eq("ok")
+      expect(new_span.trace_id).to eq(subject.trace_id)
+      expect(new_span.span_id).not_to eq(subject.span_id)
+      expect(new_span.parent_span_id).to eq(subject.span_id)
+      expect(new_span.start_timestamp).not_to eq(subject.start_timestamp)
+      expect(new_span.sampled).to eq(true)
+    end
+
+    it "records the child span" do
+      new_span = subject.start_child(op: "sql.query", description: "SELECT * FROM orders WHERE orders.user_id = 1", status: "ok")
+
+      expect(subject.span_recorder.spans).to include(new_span)
+      expect(new_span.span_recorder).to eq(subject.span_recorder)
+    end
+  end
+
+  describe "#set_status" do
+    it "sets status" do
+      subject.set_status("ok")
+
+      expect(subject.status).to eq("ok")
+    end
+  end
+
+  describe "#set_http_status" do
+    {
+      200 => "ok",
+      400 => "invalid_argument",
+      401 => "unauthenticated",
+      403 => "permission_denied",
+      404 => "not_found",
+      409 => "already_exists",
+      429 => "resource_exhausted",
+      499 => "cancelled",
+      500 => "internal_error",
+      501 => "unimplemented",
+      503 => "unavailable",
+      504 => "deadline_exceeded"
+    }.each do |status_code, status|
+      it "adds status_code (#{status_code}) to data and sets correct status (#{status})" do
+        subject.set_http_status(status_code)
+
+        expect(subject.data["status_code"]).to eq(status_code)
+        expect(subject.status).to eq(status)
+      end
+    end
+  end
+
+  describe "#set_data" do
+    it "sets data" do
+      subject.set_data(:foo, "bar")
+
+      expect(subject.data).to eq({ foo: "bar" })
+    end
+  end
+
+  describe "#set_tag" do
+    it "sets tag" do
+      subject.set_tag(:foo, "bar")
+
+      expect(subject.tags).to eq({ foo: "bar" })
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/span_spec.rb
+++ b/sentry-ruby/spec/sentry/span_spec.rb
@@ -41,22 +41,22 @@ RSpec.describe Sentry::Span do
     end
   end
 
-  describe "#to_traceparent" do
+  describe "#to_sentry_trace" do
     it "returns correctly-formatted value" do
-      traceparent = subject.to_traceparent
+      sentry_trace = subject.to_sentry_trace
 
-      expect(traceparent).to eq("#{subject.trace_id}-#{subject.span_id}-1")
-      expect(traceparent).to match(Sentry::Span::TRACEPARENT_REGEXP)
+      expect(sentry_trace).to eq("#{subject.trace_id}-#{subject.span_id}-1")
+      expect(sentry_trace).to match(Sentry::Transaction::SENTRY_TRACE_REGEXP)
     end
 
     context "without sampled value" do
       subject { described_class.new }
 
       it "doesn't contain the sampled flag" do
-        traceparent = subject.to_traceparent
+        sentry_trace = subject.to_sentry_trace
 
-        expect(traceparent).to eq("#{subject.trace_id}-#{subject.span_id}-")
-        expect(traceparent).to match(Sentry::Span::TRACEPARENT_REGEXP)
+        expect(sentry_trace).to eq("#{subject.trace_id}-#{subject.span_id}-")
+        expect(sentry_trace).to match(Sentry::Transaction::SENTRY_TRACE_REGEXP)
       end
     end
   end

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -12,6 +12,19 @@ RSpec.describe Sentry::Transaction do
     )
   end
 
+  describe ".from_sentry_trace" do
+    let(:sentry_trace) { subject.to_sentry_trace }
+
+    it "returns correctly-formatted value" do
+      child_transaction = described_class.from_sentry_trace(sentry_trace, op: "child")
+
+      expect(child_transaction.trace_id).to eq(subject.trace_id)
+      expect(child_transaction.parent_span_id).to eq(subject.span_id)
+      expect(child_transaction.parent_sampled).to eq(true)
+      expect(child_transaction.op).to eq("child")
+    end
+  end
+
   describe "#to_hash" do
     it "returns correct data" do
       hash = subject.to_hash

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+
+RSpec.describe Sentry::Transaction do
+  subject do
+    described_class.new(
+      op: "sql.query",
+      description: "SELECT * FROM users;",
+      status: "ok",
+      sampled: true,
+      parent_sampled: true,
+      name: "foo"
+    )
+  end
+
+  describe "#to_hash" do
+    it "returns correct data" do
+      hash = subject.to_hash
+
+      expect(hash[:op]).to eq("sql.query")
+      expect(hash[:description]).to eq("SELECT * FROM users;")
+      expect(hash[:status]).to eq("ok")
+      expect(hash[:trace_id].length).to eq(32)
+      expect(hash[:span_id].length).to eq(16)
+      expect(hash[:sampled]).to eq(true)
+      expect(hash[:parent_sampled]).to eq(true)
+      expect(hash[:name]).to eq("foo")
+    end
+  end
+
+  describe "#finish" do
+    before do
+      Sentry.init do |config|
+        config.dsn = DUMMY_DSN
+        config.transport.transport_class = Sentry::DummyTransport
+      end
+    end
+
+    let(:events) do
+      Sentry.get_current_client.transport.events
+    end
+
+    it "finishes the transaction, converts it into an Event and send it" do
+      subject.finish
+
+      expect(events.count).to eq(1)
+      event = events.last.to_hash
+
+      expect(event[:spans][0]).to eq(subject.to_hash)
+      expect(event[:spans][0][:timestamp]).to be_a(Float)
+    end
+
+    context "if the transaction is not sampled" do
+      subject { described_class.new(sampled: false) }
+
+      it "doesn't send it" do
+        subject.finish
+
+        expect(events.count).to eq(0)
+      end
+    end
+
+    context "if the transaction doesn't have a name" do
+      subject { described_class.new(sampled: true) }
+
+      it "adds a default name" do
+        subject.finish
+
+        expect(events.count).to eq(1)
+        event = events.last.to_hash
+
+        expect(event[:spans][0][:name]).to eq("<unlabeled transaction>")
+      end
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -5,32 +5,6 @@ RSpec.describe Sentry::HTTPTransport do
   let(:event) { client.event_from_message("test") }
   subject { described_class.new(Sentry.configuration) }
 
-  describe "#encode" do
-    before do
-      Sentry.init do |config|
-        config.dsn = DUMMY_DSN
-      end
-    end
-
-    it "generates correct envelope content" do
-      _, result = subject.encode(event.to_hash)
-
-      envelope_header, item_header, item = result.split("\n")
-
-      expect(envelope_header).to eq(
-        <<~ENVELOPE_HEADER.chomp
-          {"event_id":"#{event.id}","dsn":"#{DUMMY_DSN}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{DateTime.now.rfc3339}"}
-        ENVELOPE_HEADER
-      )
-
-      expect(item_header).to eq(
-        '{"type":"event","content_type":"application/json"}'
-      )
-
-      expect(item).to eq(event.to_hash.to_json)
-    end
-  end
-
   describe "customizations" do
     before do
       Sentry.init do |c|

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -13,6 +13,64 @@ RSpec.describe Sentry::Transport do
 
   subject { described_class.new(configuration) }
 
+  describe "#encode" do
+    let(:client) { Sentry::Client.new(configuration) }
+
+    before do
+      Sentry.init do |config|
+        config.dsn = DUMMY_DSN
+      end
+    end
+
+    context "normal event" do
+      let(:event) { client.event_from_exception(ZeroDivisionError.new("divided by 0")) }
+      it "generates correct envelope content" do
+        _, result = subject.encode(event.to_hash)
+
+        envelope_header, item_header, item = result.split("\n")
+
+        expect(envelope_header).to eq(
+          <<~ENVELOPE_HEADER.chomp
+            {"event_id":"#{event.event_id}","dsn":"#{DUMMY_DSN}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{DateTime.now.rfc3339}"}
+          ENVELOPE_HEADER
+        )
+
+        expect(item_header).to eq(
+          '{"type":"event","content_type":"application/json"}'
+        )
+
+        expect(item).to eq(event.to_hash.to_json)
+      end
+    end
+
+    context "transaction event" do
+      let(:transaction) do
+        Sentry::Transaction.new(name: "test transaction", op: "rack.request")
+      end
+      let(:event) do
+        client.event_from_transaction(transaction)
+      end
+
+      it "generates correct envelope content" do
+        _, result = subject.encode(event.to_hash)
+
+        envelope_header, item_header, item = result.split("\n")
+
+        expect(envelope_header).to eq(
+          <<~ENVELOPE_HEADER.chomp
+            {"event_id":"#{event.event_id}","dsn":"#{DUMMY_DSN}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{DateTime.now.rfc3339}"}
+          ENVELOPE_HEADER
+        )
+
+        expect(item_header).to eq(
+          '{"type":"transaction","content_type":"application/json"}'
+        )
+
+        expect(item).to eq(event.to_hash.to_json)
+      end
+    end
+  end
+
   describe "#send_event" do
     let(:client) { Sentry::Client.new(configuration) }
     let(:event) { client.event_from_exception(ZeroDivisionError.new("divided by 0")) }
@@ -38,7 +96,7 @@ RSpec.describe Sentry::Transport do
         expect(subject.send_event(event)).to eq(event)
 
         expect(io.string).to match(
-          /INFO -- sentry: Sending event #{event.id} to Sentry/
+          /INFO -- sentry: Sending event #{event.event_id} to Sentry/
         )
       end
 

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -75,6 +75,26 @@ RSpec.describe Sentry do
     end
   end
 
+  describe ".start_transaction" do
+    it "starts a new transaction" do
+      expect(described_class.start_transaction).to be_a(Sentry::Transaction)
+    end
+  end
+
+  describe ".get_transaction" do
+    let(:transaction) { described_class.start_transaction }
+
+    before do
+      described_class.configure_scope do |scope|
+        scope.set_span(transaction)
+      end
+    end
+
+    it "gets the current transaction" do
+      expect(described_class.get_transaction).to eq(transaction)
+    end
+  end
+
   describe ".capture_message" do
     it "sends the message via current hub" do
       expect(described_class.get_current_hub).to receive(:capture_message).with("Test", tags: { foo: "baz" })

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -81,20 +81,6 @@ RSpec.describe Sentry do
     end
   end
 
-  describe ".get_transaction" do
-    let(:transaction) { described_class.start_transaction }
-
-    before do
-      described_class.configure_scope do |scope|
-        scope.set_span(transaction)
-      end
-    end
-
-    it "gets the current transaction" do
-      expect(described_class.get_transaction).to eq(transaction)
-    end
-  end
-
   describe ".capture_message" do
     it "sends the message via current hub" do
       expect(described_class.get_current_hub).to receive(:capture_message).with("Test", tags: { foo: "baz" })


### PR DESCRIPTION
This PR builds the groundwork for the performance monitoring feature. It can already send the new "transaction" type data to the server now.

This feature can be enabled by setting:

```ruby
Sentry.init do |config|
  # any float larger than 0.0 to activate the feature
  # but it doesn't do the sampling now and sends every transaction
  config.traces_sample_rate = 1.0
end
```

Every event happened inside a transaction will now have a new `Trace Details` section:

<img width="1163" alt="截圖 2020-11-20 下午3 48 15" src="https://user-images.githubusercontent.com/5079556/99773839-f8b1b400-2b47-11eb-964d-e076e3619fae.png">

---

By clicking `Search By Trace`, users can see all the events associated with that transaction, including the transaction event itself.

<img width="1515" alt="截圖 2020-11-20 下午3 48 48" src="https://user-images.githubusercontent.com/5079556/99773852-fe0efe80-2b47-11eb-9278-7bf4c55634d2.png">

---

And this is how a transaction event looks like:

<img width="1513" alt="截圖 2020-11-20 下午3 49 14" src="https://user-images.githubusercontent.com/5079556/99773859-ffd8c200-2b47-11eb-8b11-1fbce30497db.png">


### Upcoming Features

- Sampling mechanism
- Different tracing events (currently only supports rack request and active record's SQL query)
