### PR TITLE
Add: Request ID to rack related events

### DIFF
--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -25,6 +25,7 @@ require 'raven/transports'
 require 'raven/transports/http'
 require 'raven/utils/deep_merge'
 require 'raven/utils/real_ip'
+require 'raven/utils/request_id'
 require 'raven/utils/exception_cause_chain'
 require 'raven/instance'
 

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -226,6 +226,10 @@ module Raven
         int.from_rack(context.rack_env)
       end
       context.user[:ip_address] = calculate_real_ip_from_rack
+
+      if request_id = Utils::RequestId.read_from(context.rack_env)
+        context.tags[:request_id] = request_id
+      end
     end
 
     # When behind a proxy (or if the user is using a proxy), we can't use

--- a/lib/raven/utils/request_id.rb
+++ b/lib/raven/utils/request_id.rb
@@ -1,0 +1,16 @@
+module Raven
+  module Utils
+    module RequestId
+      REQUEST_ID_HEADERS = %w(action_dispatch.request_id HTTP_X_REQUEST_ID).freeze
+
+      # Request ID based on ActionDispatch::RequestId
+      def self.read_from(env_hash)
+        REQUEST_ID_HEADERS.each do |key|
+          request_id = env_hash[key]
+          return request_id if request_id
+        end
+        nil
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -5,6 +5,7 @@ require 'securerandom'
 require 'sentry/interface'
 require 'sentry/backtrace'
 require 'sentry/utils/real_ip'
+require 'sentry/utils/request_id'
 
 module Sentry
   class Event
@@ -81,6 +82,9 @@ module Sentry
 
         if configuration.send_default_pii && ip = calculate_real_ip_from_rack(env.dup)
           user[:ip_address] = ip
+        end
+        if request_id = Utils::RequestId.read_from(env)
+          tags[:request_id] = request_id
         end
       end
     end

--- a/sentry-ruby/lib/sentry/interfaces/request.rb
+++ b/sentry-ruby/lib/sentry/interfaces/request.rb
@@ -39,15 +39,6 @@ module Sentry
 
     private
 
-    # Request ID based on ActionDispatch::RequestId
-    def read_request_id_from(env_hash)
-      REQUEST_ID_HEADERS.each do |key|
-        request_id = env_hash[key]
-        return request_id if request_id
-      end
-      nil
-    end
-
     # See Sentry server default limits at
     # https://github.com/getsentry/sentry/blob/master/src/sentry/conf/server.py
     def read_data_from(request)
@@ -67,7 +58,7 @@ module Sentry
         begin
           key = key.to_s # rack env can contain symbols
           value = value.to_s
-          next memo['X-Request-Id'] ||= read_request_id_from(env_hash) if REQUEST_ID_HEADERS.include?(key)
+          next memo['X-Request-Id'] ||= Utils::RequestId.read_from(env_hash) if Utils::RequestId::REQUEST_ID_HEADERS.include?(key)
           next unless key.upcase == key # Non-upper case stuff isn't either
 
           # Rack adds in an incorrect HTTP_VERSION key, which causes downstream

--- a/sentry-ruby/lib/sentry/utils/request_id.rb
+++ b/sentry-ruby/lib/sentry/utils/request_id.rb
@@ -1,0 +1,16 @@
+module Sentry
+  module Utils
+    module RequestId
+      REQUEST_ID_HEADERS = %w(action_dispatch.request_id HTTP_X_REQUEST_ID).freeze
+
+      # Request ID based on ActionDispatch::RequestId
+      def self.read_from(env_hash)
+        REQUEST_ID_HEADERS.each do |key|
+          request_id = env_hash[key]
+          return request_id if request_id
+        end
+        nil
+      end
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Sentry::Event do
         'SERVER_NAME' => 'localhost',
         'SERVER_PORT' => '80',
         'HTTP_X_FORWARDED_FOR' => '1.1.1.1, 2.2.2.2',
+        'HTTP_X_REQUEST_ID' => 'abcd-1234-abcd-1234',
         'REMOTE_ADDR' => '192.168.1.1',
         'PATH_INFO' => '/lol',
         'rack.url_scheme' => 'http',
@@ -65,12 +66,13 @@ RSpec.describe Sentry::Event do
 
         expect(event.to_hash[:request]).to eq(
           env: { 'SERVER_NAME' => 'localhost', 'SERVER_PORT' => '80' },
-          headers: { 'Host' => 'localhost' },
+          headers: { 'Host' => 'localhost', 'X-Request-Id' => 'abcd-1234-abcd-1234' },
           method: 'POST',
           query_string: 'biz=baz',
           url: 'http://localhost/lol',
           cookies: nil
         )
+        expect(event.to_hash[:tags][:request_id]).to eq("abcd-1234-abcd-1234")
         expect(event.to_hash[:user][:ip_address]).to eq(nil)
       end
     end
@@ -86,13 +88,14 @@ RSpec.describe Sentry::Event do
         expect(event.to_hash[:request]).to eq(
           data: { 'foo' => 'bar' },
           env: { 'SERVER_NAME' => 'localhost', 'SERVER_PORT' => '80', "REMOTE_ADDR" => "192.168.1.1" },
-          headers: { 'Host' => 'localhost', "X-Forwarded-For" => "1.1.1.1, 2.2.2.2" },
+          headers: { 'Host' => 'localhost', "X-Forwarded-For" => "1.1.1.1, 2.2.2.2", "X-Request-Id" => "abcd-1234-abcd-1234" },
           method: 'POST',
           query_string: 'biz=baz',
           url: 'http://localhost/lol',
           cookies: {}
         )
 
+        expect(event.to_hash[:tags][:request_id]).to eq("abcd-1234-abcd-1234")
         expect(event.to_hash[:user][:ip_address]).to eq("1.1.1.1")
       end
     end

--- a/sentry-ruby/spec/sentry/utils/request_id_spec.rb
+++ b/sentry-ruby/spec/sentry/utils/request_id_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe Sentry::Utils::RequestId do
+  describe ".read_from" do
+    subject { Sentry::Utils::RequestId.read_from(env_hash) }
+
+    context "when HTTP_X_REQUEST_ID is available" do
+      let(:env_hash) { { "HTTP_X_REQUEST_ID" => "request-id-sorta" } }
+
+      it { is_expected.to eq("request-id-sorta") }
+    end
+
+    context "when action_dispatch.request_id is available (from Rails middleware)" do
+      let(:env_hash) { { "action_dispatch.request_id" => "request-id-kinda" } }
+
+      it { is_expected.to eq("request-id-kinda") }
+    end
+
+    context "when no request-id is available" do
+      let(:env_hash) { { "foo" => "bar" } }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe Raven::Event do
                          'SERVER_NAME' => 'localhost',
                          'SERVER_PORT' => '80',
                          'HTTP_X_FORWARDED_FOR' => '1.1.1.1, 2.2.2.2',
+                         'HTTP_X_REQUEST_ID' => '98765432',
                          'REMOTE_ADDR' => '192.168.1.1',
                          'PATH_INFO' => '/lol',
                          'rack.url_scheme' => 'http',
@@ -219,7 +220,7 @@ RSpec.describe Raven::Event do
     it "adds http data" do
       expect(hash[:request]).to eq(data: { 'foo' => 'bar' },
                                    env: { 'SERVER_NAME' => 'localhost', 'SERVER_PORT' => '80', "REMOTE_ADDR" => "192.168.1.1" },
-                                   headers: { 'Host' => 'localhost', "X-Forwarded-For" => "1.1.1.1, 2.2.2.2" },
+                                   headers: { 'Host' => 'localhost', "X-Forwarded-For" => "1.1.1.1, 2.2.2.2", 'X-Request-Id' => '98765432' },
                                    method: 'POST',
                                    query_string: 'biz=baz',
                                    url: 'http://localhost/lol',
@@ -228,6 +229,10 @@ RSpec.describe Raven::Event do
 
     it "sets user context ip address correctly" do
       expect(hash[:user][:ip_address]).to eq("1.1.1.1")
+    end
+
+    it "adds request_id to the tags" do
+      expect(hash[:tags][:request_id]).to eq("98765432")
     end
   end
 

--- a/spec/raven/utils/request_id_spec.rb
+++ b/spec/raven/utils/request_id_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe Raven::Utils::RequestId do
+  describe ".read_from" do
+    subject { Raven::Utils::RequestId.read_from(env_hash) }
+
+    context "when HTTP_X_REQUEST_ID is available" do
+      let(:env_hash) { { "HTTP_X_REQUEST_ID" => "request-id-sorta" } }
+
+      it { is_expected.to eq("request-id-sorta") }
+    end
+
+    context "when action_dispatch.request_id is available (from Rails middleware)" do
+      let(:env_hash) { { "action_dispatch.request_id" => "request-id-kinda" } }
+
+      it { is_expected.to eq("request-id-kinda") }
+    end
+
+    context "when no request-id is available" do
+      let(:env_hash) { { "foo" => "bar" } }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
## Description
- Moved the initial logic from #1033 for `request_id` to shared utils 
- New Feature: Add `request_id` tags (when present) to Rack event
  - Added to both `Sentry::Event` & `Raven::Event` namespaces

## Why
- Inspired by https://blog.sentry.io/2019/01/31/using-nginx-sentry-trace-errors-logs & should address #891

## Testing

* Locally using the instructions from [Rails 6 Examples (top-level)](https://github.com/getsentry/sentry-ruby/tree/master/examples/rails-6.0) & [Rails 6 Examples (sentry-ruby)](https://github.com/getsentry/sentry-ruby/tree/master/sentry-ruby/examples/rails-6.0)
<img width="776" alt="request_id_tags_example" src="https://user-images.githubusercontent.com/2018474/100021147-09179800-2daf-11eb-9da0-dab60c665120.png">