### PR TITLE
Sampling transaction

### DIFF
--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -52,7 +52,7 @@ module Sentry
         exceptions_class.send(:prepend, Sentry::Rails::Overrides::DebugExceptionsCatcher)
       end
 
-      if Sentry.configuration.traces_sample_rate.to_f > 0.0
+      if Sentry.configuration.tracing_enabled?
         Sentry::Rails::Tracing.subscribe_tracing_events
         Sentry::Rails::Tracing.patch_active_support_notifications
       end

--- a/sentry-rails/lib/sentry/rails/tracing/abstract_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/abstract_subscriber.rb
@@ -34,7 +34,7 @@ module Sentry
 
             scope = Sentry.get_current_scope
             transaction = scope.get_transaction
-            return unless transaction
+            return unless transaction && transaction.sampled
 
             span = transaction.start_child(**options)
             # duration in ActiveSupport is computed in millisecond

--- a/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
@@ -28,4 +28,16 @@ RSpec.describe Sentry::Rails::Tracing::ActionControllerSubscriber, :subscriber, 
     expect(span[:description]).to eq("HelloController#world")
     expect(span[:trace_id]).to eq(transaction.dig(:contexts, :trace, :trace_id))
   end
+
+  it "doesn't record spans for unsampled transaction" do
+    transaction = Sentry::Transaction.new(sampled: false)
+    Sentry.get_current_scope.set_span(transaction)
+
+    get "/world"
+
+    transaction.finish
+
+    expect(transport.events.count).to eq(0)
+    expect(transaction.span_recorder.spans).to eq([transaction])
+  end
 end

--- a/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Sentry::Rails::Tracing::ActionControllerSubscriber, :subscriber, 
   end
 
   it "records controller action processing event" do
-    transaction = Sentry.start_transaction
+    transaction = Sentry::Transaction.new(sampled: true)
     Sentry.get_current_scope.set_span(transaction)
 
     get "/world"

--- a/sentry-rails/spec/sentry/rails/tracing/action_view_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_view_subscriber_spec.rb
@@ -28,4 +28,16 @@ RSpec.describe Sentry::Rails::Tracing::ActionViewSubscriber, :subscriber, type: 
     expect(span[:description]).to match(/test_template\.html\.erb/)
     expect(span[:trace_id]).to eq(transaction.dig(:contexts, :trace, :trace_id))
   end
+
+  it "doesn't record spans for unsampled transaction" do
+    transaction = Sentry::Transaction.new(sampled: false)
+    Sentry.get_current_scope.set_span(transaction)
+
+    get "/view"
+
+    transaction.finish
+
+    expect(transport.events.count).to eq(0)
+    expect(transaction.span_recorder.spans).to eq([transaction])
+  end
 end

--- a/sentry-rails/spec/sentry/rails/tracing/action_view_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_view_subscriber_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Sentry::Rails::Tracing::ActionViewSubscriber, :subscriber, type: 
   end
 
   it "records view rendering event" do
-    transaction = Sentry.start_transaction
+    transaction = Sentry::Transaction.new(sampled: true)
     Sentry.get_current_scope.set_span(transaction)
 
     get "/view"

--- a/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
@@ -28,4 +28,16 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
     expect(span[:description]).to eq("SELECT \"posts\".* FROM \"posts\"")
     expect(span[:trace_id]).to eq(transaction.dig(:contexts, :trace, :trace_id))
   end
+
+  it "doesn't record spans for unsampled transaction" do
+    transaction = Sentry::Transaction.new(sampled: false)
+    Sentry.get_current_scope.set_span(transaction)
+
+    Post.all.to_a
+
+    transaction.finish
+
+    expect(transport.events.count).to eq(0)
+    expect(transaction.span_recorder.spans).to eq([transaction])
+  end
 end

--- a/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
   end
 
   it "records database query events" do
-    transaction = Sentry.start_transaction
+    transaction = Sentry::Transaction.new(sampled: true)
     Sentry.get_current_scope.set_span(transaction)
 
     Post.all.to_a

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -97,6 +97,8 @@ module Sentry
 
     attr_accessor :traces_sample_rate
 
+    attr_accessor :traces_sampler
+
     # Optional Proc, called before sending an event to the server/
     # E.g.: lambda { |event| event }
     # E.g.: lambda { |event| nil }

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -263,6 +263,10 @@ module Sentry
       environments.empty? || environments.include?(current_environment)
     end
 
+    def tracing_enabled?
+      !!((@traces_sample_rate && @traces_sample_rate > 0.0) || @traces_sampler)
+    end
+
     private
 
     def detect_project_root

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -68,8 +68,9 @@ module Sentry
     end
 
     def start_transaction(transaction: nil, **options)
-      transaction ||= Transaction.new(**options, sampled: true)
-      # TODO: Add sampling logic
+      transaction ||= Transaction.new(**options)
+      transaction.set_initial_sample_desicion
+      transaction
     end
 
     def capture_exception(exception, **options, &block)

--- a/sentry-ruby/lib/sentry/span.rb
+++ b/sentry-ruby/lib/sentry/span.rb
@@ -33,6 +33,9 @@ module Sentry
       @status = status
       @data = {}
       @tags = {}
+    end
+
+    def set_span_recorder
       @span_recorder = SpanRecorder.new(1000)
       @span_recorder.add(self)
     end
@@ -80,7 +83,11 @@ module Sentry
       options = options.dup.merge(trace_id: @trace_id, parent_span_id: @span_id, sampled: @sampled)
       child_span = Span.new(options)
       child_span.span_recorder = @span_recorder
-      @span_recorder.add(child_span)
+
+      if @span_recorder && @sampled
+        @span_recorder.add(child_span)
+      end
+
       child_span
     end
 

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -17,6 +17,7 @@ module Sentry
 
       @name = name
       @parent_sampled = parent_sampled
+      set_span_recorder
     end
 
     def self.from_sentry_trace(sentry_trace, **options)

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -8,6 +8,7 @@ module Sentry
       "[ \t]*$"  # whitespace
     )
     UNLABELD_NAME = "<unlabeled transaction>".freeze
+    MESSAGE_PREFIX = "[Tracing]"
 
     attr_reader :name, :parent_sampled
 
@@ -35,6 +36,56 @@ module Sentry
       hash
     end
 
+    def set_initial_sample_desicion(sampling_context = {})
+      unless Sentry.configuration.tracing_enabled?
+        @sampled = false
+        return
+      end
+
+      return unless @sampled.nil?
+
+      transaction_description = generate_transaction_description
+
+      logger = Sentry.configuration.logger
+      sample_rate = Sentry.configuration.traces_sample_rate
+      traces_sampler = Sentry.configuration.traces_sampler
+
+      if traces_sampler.is_a?(Proc)
+        sampling_context = sampling_context.merge(
+          parent_sampled: @parent_sampled,
+          transaction_context: self.to_hash
+        )
+
+        sample_rate = traces_sampler.call(sampling_context)
+      end
+
+      unless [true, false].include?(sample_rate) || (sample_rate.is_a?(Float) && sample_rate >= 0.0 && sample_rate <= 1.0)
+        @sampled = false
+        logger.warn("#{MESSAGE_PREFIX} Discarding #{transaction_description} because of invalid sample_rate: #{sample_rate}")
+        return
+      end
+
+      if sample_rate == 0.0 || sample_rate == false
+        @sampled = false
+        logger.debug("#{MESSAGE_PREFIX} Discarding #{transaction_description} because traces_sampler returned 0 or false")
+        return
+      end
+
+      if sample_rate == true
+        @sampled = true
+      else
+        @sampled = Random.rand < sample_rate
+      end
+
+      if @sampled
+        logger.debug("#{MESSAGE_PREFIX} Starting #{transaction_description}")
+      else
+        logger.debug(
+          "#{MESSAGE_PREFIX} Discarding #{transaction_description} because it's not included in the random sample (sampling rate = #{sample_rate})"
+        )
+      end
+    end
+
     def finish(hub: nil)
       super() # Span#finish doesn't take arguments
 
@@ -47,6 +98,15 @@ module Sentry
       hub ||= Sentry.get_current_hub
       event = hub.current_client.event_from_transaction(self)
       hub.capture_event(event)
+    end
+
+    private
+
+    def generate_transaction_description
+      result = op.nil? ? "" : "<#{@op}> "
+      result += "transaction"
+      result += " <#{@name}>" if @name
+      result
     end
   end
 end

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -10,6 +10,36 @@ RSpec.describe Sentry::Configuration do
     end
   end
 
+  describe "#tracing_enabled?" do
+    it "returns false by default" do
+      expect(subject.tracing_enabled?).to eq(false)
+    end
+
+    context "when traces_sample_rate == 0.0" do
+      it "returns false" do
+        subject.traces_sample_rate = 0.0
+
+        expect(subject.tracing_enabled?).to eq(false)
+      end
+    end
+
+    context "when traces_sample_rate > 0" do
+      it "returns true" do
+        subject.traces_sample_rate = 0.1
+
+        expect(subject.tracing_enabled?).to eq(true)
+      end
+    end
+
+    context "when traces_sampler is set" do
+      it "returns true" do
+        subject.traces_sampler = proc { true }
+
+        expect(subject.tracing_enabled?).to eq(true)
+      end
+    end
+  end
+
   describe "#transport" do
     it "returns an initialized Transport::Configuration object" do
       transport_config = subject.transport

--- a/sentry-ruby/spec/sentry/span_spec.rb
+++ b/sentry-ruby/spec/sentry/span_spec.rb
@@ -79,11 +79,19 @@ RSpec.describe Sentry::Span do
       expect(new_span.sampled).to eq(true)
     end
 
-    it "records the child span" do
-      new_span = subject.start_child(op: "sql.query", description: "SELECT * FROM orders WHERE orders.user_id = 1", status: "ok")
+    it "records the child span if span_recorder is present" do
+      subject.set_span_recorder
+      new_span = subject.start_child
 
       expect(subject.span_recorder.spans).to include(new_span)
       expect(new_span.span_recorder).to eq(subject.span_recorder)
+    end
+
+    it "doesn't record the child span if span_recorder is not present" do
+      new_span = subject.start_child
+
+      expect(subject.span_recorder).to eq(nil)
+      expect(new_span.span_recorder).to eq(nil)
     end
   end
 

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -25,6 +25,143 @@ RSpec.describe Sentry::Transaction do
     end
   end
 
+  describe "#set_initial_sample_desicion" do
+    before do
+      Sentry.init do |config|
+        config.dsn = DUMMY_DSN
+        config.transport.transport_class = Sentry::DummyTransport
+      end
+    end
+
+    context "when tracing is not enabled" do
+      before do
+        allow(Sentry.configuration).to receive(:tracing_enabled?).and_return(false)
+      end
+
+      it "sets @sampled to false and return" do
+        allow(Sentry.configuration).to receive(:tracing_enabled?).and_return(false)
+
+        transaction = described_class.new(sampled: true)
+        transaction.set_initial_sample_desicion
+        expect(transaction.sampled).to eq(false)
+      end
+    end
+
+    context "when tracing is enabled" do
+      let(:subject) { described_class.new(op: "rack.request", parent_sampled: true) }
+
+      before do
+        allow(Sentry.configuration).to receive(:tracing_enabled?).and_return(true)
+      end
+
+      context "when the transaction already has a decision" do
+        it "doesn't change it" do
+          transaction = described_class.new(sampled: true)
+          transaction.set_initial_sample_desicion
+          expect(transaction.sampled).to eq(true)
+
+          transaction = described_class.new(sampled: false)
+          transaction.set_initial_sample_desicion
+          expect(transaction.sampled).to eq(false)
+        end
+      end
+
+      context "when traces_sampler is not set" do
+        before do
+          Sentry.configuration.traces_sample_rate = 0.5
+        end
+
+        it "uses traces_sample_rate for sampling (positive result)" do
+          allow(Random).to receive(:rand).and_return(0.4)
+          expect(Sentry.configuration.logger).to receive(:debug).with(
+            "[Tracing] Starting <rack.request> transaction"
+          )
+
+          subject.set_initial_sample_desicion
+          expect(subject.sampled).to eq(true)
+        end
+
+        it "uses traces_sample_rate for sampling (negative result)" do
+          allow(Random).to receive(:rand).and_return(0.6)
+          expect(Sentry.configuration.logger).to receive(:debug).with(
+            "[Tracing] Discarding <rack.request> transaction because it's not included in the random sample (sampling rate = 0.5)"
+          )
+
+          subject.set_initial_sample_desicion
+          expect(subject.sampled).to eq(false)
+        end
+      end
+
+      context "when traces_sampler is provided" do
+        it "ignores the sampler if it's not callable" do
+          Sentry.configuration.traces_sampler = ""
+
+          expect do
+            subject.set_initial_sample_desicion
+          end.not_to raise_error
+        end
+
+        it "calls the sampler with sampling_context" do
+          sampling_context = {}
+
+          Sentry.configuration.traces_sampler = lambda do |context|
+            sampling_context = context
+          end
+
+          subject.set_initial_sample_desicion(foo: "bar")
+
+          # transaction_context's sampled attribute will be the old value
+          expect(sampling_context[:transaction_context].keys).to eq(subject.to_hash.keys)
+          expect(sampling_context[:parent_sampled]).to eq(true)
+          expect(sampling_context[:foo]).to eq("bar")
+        end
+
+        it "disgards the transaction if generated sample rate is not valid" do
+          expect(Sentry.configuration.logger).to receive(:warn).with(
+            "[Tracing] Discarding <rack.request> transaction because of invalid sample_rate: foo"
+          )
+
+          Sentry.configuration.traces_sampler = -> (_) { "foo" }
+          subject.set_initial_sample_desicion
+
+          expect(subject.sampled).to eq(false)
+        end
+
+        it "uses the genereted rate for sampling (positive)" do
+          expect(Sentry.configuration.logger).to receive(:debug).with(
+            "[Tracing] Starting transaction"
+          ).exactly(2)
+
+          subject = described_class.new
+          Sentry.configuration.traces_sampler = -> (_) { true }
+          subject.set_initial_sample_desicion
+          expect(subject.sampled).to eq(true)
+
+          subject = described_class.new
+          Sentry.configuration.traces_sampler = -> (_) { 1.0 }
+          subject.set_initial_sample_desicion
+          expect(subject.sampled).to eq(true)
+        end
+
+        it "uses the genereted rate for sampling (negative)" do
+          expect(Sentry.configuration.logger).to receive(:debug).with(
+            "[Tracing] Discarding transaction because traces_sampler returned 0 or false"
+          ).exactly(2)
+
+          subject = described_class.new
+          Sentry.configuration.traces_sampler = -> (_) { false }
+          subject.set_initial_sample_desicion
+          expect(subject.sampled).to eq(false)
+
+          subject = described_class.new
+          Sentry.configuration.traces_sampler = -> (_) { 0.0 }
+          subject.set_initial_sample_desicion
+          expect(subject.sampled).to eq(false)
+        end
+      end
+    end
+  end
+
   describe "#to_hash" do
     it "returns correct data" do
       hash = subject.to_hash

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -77,7 +77,19 @@ RSpec.describe Sentry do
 
   describe ".start_transaction" do
     it "starts a new transaction" do
-      expect(described_class.start_transaction).to be_a(Sentry::Transaction)
+      transaction = described_class.start_transaction(op: "foo")
+      expect(transaction).to be_a(Sentry::Transaction)
+      expect(transaction.op).to eq("foo")
+    end
+
+    context "when given an transaction object" do
+      it "adds sample decision to it" do
+        transaction = Sentry::Transaction.new
+
+        described_class.start_transaction(transaction: transaction)
+
+        expect(transaction.sampled).to eq(false)
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds the functionality for sampling transactions with:
- `config.traces_sampler`
- `config.traces_sample_rate`

It also adds some restrictions to not sampled transactions for saving resources.