### PR TITLE
Tidy up & performance improvements

### DIFF
--- a/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb
@@ -83,20 +83,6 @@ module Sentry
         Sentry.breadcrumbs
       end
     end
-    module OldBreadcrumbsSentryLogger
-      def self.included(base)
-        base.class_eval do
-          include Sentry::Breadcrumbs::SentryLogger
-          alias_method :add_without_sentry, :add
-          alias_method :add, :add_with_sentry
-        end
-      end
-
-      def add_with_sentry(*args)
-        add_breadcrumb(*args)
-        add_without_sentry(*args)
-      end
-    end
   end
 end
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -291,9 +291,13 @@ module Sentry
     end
 
     def excluded_exception?(incoming_exception)
-      excluded_exceptions.any? do |excluded_exception|
-        matches_exception?(get_exception_class(excluded_exception), incoming_exception)
+      excluded_exception_classes.any? do |excluded_exception|
+        matches_exception?(excluded_exception, incoming_exception)
       end
+    end
+
+    def excluded_exception_classes
+      @excluded_exception_classes ||= excluded_exceptions.map { |e| get_exception_class(e) }
     end
 
     def get_exception_class(x)

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -114,6 +114,8 @@ module Sentry
     # the dsn value, whether it's set via `config.dsn=` or `ENV["SENTRY_DSN"]`
     attr_reader :dsn
 
+    attr_reader :gem_specs
+
     # Most of these errors generate 4XX responses. In general, Sentry clients
     # only automatically report 5xx responses.
     IGNORE_DEFAULT = [
@@ -159,9 +161,11 @@ module Sentry
       self.server_name = server_name_from_env
       self.should_capture = false
 
-      @transport = Transport::Configuration.new
       self.before_send = false
       self.rack_env_whitelist = RACK_ENV_WHITELIST_DEFAULT
+
+      @transport = Transport::Configuration.new
+      @gem_specs = Hash[Gem::Specification.map { |spec| [spec.name, spec.version.to_s] }] if Gem::Specification.respond_to?(:map)
       post_initialization_callback
     end
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -293,7 +293,7 @@ module Sentry
     end
 
     def get_exception_class(x)
-      x.is_a?(Module) ? x : qualified_const_get(x)
+      x.is_a?(Module) ? x : safe_const_get(x)
     end
 
     def matches_exception?(excluded_exception_class, incoming_exception)
@@ -304,14 +304,9 @@ module Sentry
       end
     end
 
-    # In Ruby <2.0 const_get can't lookup "SomeModule::SomeClass" in one go
-    def qualified_const_get(x)
-      x = x.to_s
-      if !x.match(/::/)
-        Object.const_get(x)
-      else
-        x.split(MODULE_SEPARATOR).reject(&:empty?).inject(Object) { |a, e| a.const_get(e) }
-      end
+    def safe_const_get(x)
+      x = x.to_s unless x.is_a?(String)
+      Object.const_get(x)
     rescue NameError # There's no way to safely ask if a constant exist for an unknown string
       nil
     end

--- a/sentry-ruby/lib/sentry/dsn.rb
+++ b/sentry-ruby/lib/sentry/dsn.rb
@@ -2,7 +2,10 @@ require "uri"
 
 module Sentry
   class DSN
-    attr_reader :scheme, :project_id, :public_key, :secret_key, :host, :port, :path
+    PORT_MAP = { 'http' => 80, 'https' => 443 }.freeze
+    REQUIRED_ATTRIBUTES = %w(host path public_key project_id).freeze
+
+    attr_reader :scheme, :secret_key, :port, *REQUIRED_ATTRIBUTES
 
     def initialize(dsn_string)
       @raw_value = dsn_string
@@ -24,7 +27,7 @@ module Sentry
     end
 
     def valid?
-      %w(host path public_key project_id).all? { |k| public_send(k) }
+      REQUIRED_ATTRIBUTES.all? { |k| public_send(k) }
     end
 
     def to_s
@@ -33,7 +36,7 @@ module Sentry
 
     def server
       server = "#{scheme}://#{host}"
-      server += ":#{port}" unless port == { 'http' => 80, 'https' => 443 }[scheme]
+      server += ":#{port}" unless port == PORT_MAP[scheme]
       server += path
       server
     end

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -39,7 +39,7 @@ module Sentry
       @server_name = configuration.server_name
       @environment = configuration.current_environment
       @release = configuration.release
-      @modules = list_gem_specs if configuration.send_modules
+      @modules = configuration.gem_specs if configuration.send_modules
 
       @message = message || ""
 
@@ -168,11 +168,6 @@ module Sentry
         :real_ip => env["HTTP_X_REAL_IP"],
         :forwarded_for => env["HTTP_X_FORWARDED_FOR"]
       ).calculate_ip
-    end
-
-    def list_gem_specs
-      # Older versions of Rubygems don't support iterating over all specs
-      Hash[Gem::Specification.map { |spec| [spec.name, spec.version.to_s] }] if Gem::Specification.respond_to?(:map)
     end
   end
 end


### PR DESCRIPTION
This PR is mainly for refactoring some duplicated operations like:
- gem specs collection (don't need to be ran per-event)
- exception class generation (can be memoized)

So not only has the code become cleaner, but the memory allocation is also largely reduced.

## Result

### sentry-ruby

```
Calculating -------------------------------------
              branch    41.904k memsize (     7.599k retained)
                       254.000  objects (    56.000  retained)
                        50.000  strings (    30.000  retained)
Comparison:
              branch:      41904 allocated
              master:      48916 allocated - 1.17x more
```

### sentry-rails

```
Calculating -------------------------------------
              branch   694.174k memsize (    68.408k retained)
                         5.253k objects (   275.000  retained)
                        50.000  strings (    50.000  retained)
Comparison:
              branch:     694174 allocated
              master:     783219 allocated - 1.13x more
```