### PR TITLE
Use the shared Sentry.utc_now helper for time generation

### DIFF
--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -23,6 +23,10 @@ module Sentry
     META
   end
 
+  def self.utc_now
+    Time.now.utc
+  end
+
   class << self
     def init(&block)
       config = Configuration.new

--- a/sentry-ruby/lib/sentry/breadcrumb.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb.rb
@@ -7,7 +7,7 @@ module Sentry
       @data = {}
       @level = nil
       @message = nil
-      @timestamp = Time.now.to_i
+      @timestamp = Sentry.utc_now.to_i
       @type = nil
     end
 

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -25,7 +25,7 @@ module Sentry
 
       # Set some simple default values
       @event_id      = SecureRandom.uuid.delete("-")
-      @timestamp     = Time.now.utc.iso8601
+      @timestamp     = Sentry.utc_now.iso8601
       @platform      = :ruby
       @sdk           = Sentry.sdk_meta
 
@@ -66,7 +66,7 @@ module Sentry
     end
 
     def timestamp=(time)
-      @timestamp = time.is_a?(Time) ? time.strftime('%Y-%m-%dT%H:%M:%S') : time
+      @timestamp = time.is_a?(Time) ? time.to_f : time
     end
 
     def level=(new_level) # needed to meet the Sentry spec

--- a/sentry-ruby/lib/sentry/span.rb
+++ b/sentry-ruby/lib/sentry/span.rb
@@ -26,7 +26,7 @@ module Sentry
       @span_id = SecureRandom.hex(8)
       @parent_span_id = parent_span_id
       @sampled = sampled
-      @start_timestamp = start_timestamp || Time.now.utc.to_f
+      @start_timestamp = start_timestamp || Sentry.utc_now.to_f
       @timestamp = timestamp
       @description = description
       @op = op
@@ -44,7 +44,7 @@ module Sentry
       # already finished
       return if @timestamp
 
-      @timestamp = Time.now.utc.to_f
+      @timestamp = Sentry.utc_now.to_f
     end
 
     def to_sentry_trace

--- a/sentry-ruby/lib/sentry/transaction_event.rb
+++ b/sentry-ruby/lib/sentry/transaction_event.rb
@@ -13,7 +13,7 @@ module Sentry
     attr_accessor :spans
 
     def start_timestamp=(time)
-      @start_timestamp = time.is_a?(Time) ? time.strftime('%Y-%m-%dT%H:%M:%S') : time
+      @start_timestamp = time.is_a?(Time) ? time.to_f : time
     end
 
     def type

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -36,7 +36,7 @@ module Sentry
     end
 
     def generate_auth_header
-      now = Time.now.to_i.to_s
+      now = Sentry.utc_now.to_i
       fields = {
         'sentry_version' => PROTOCOL_VERSION,
         'sentry_client' => USER_AGENT,
@@ -52,7 +52,7 @@ module Sentry
       event_type = event_hash[:type] || event_hash['type']
 
       envelope = <<~ENVELOPE
-        {"event_id":"#{event_id}","dsn":"#{configuration.dsn.to_s}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{DateTime.now.rfc3339}"}
+        {"event_id":"#{event_id}","dsn":"#{configuration.dsn.to_s}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{Sentry.utc_now.iso8601}"}
         {"type":"#{event_type}","content_type":"application/json"}
         #{JSON.generate(event_hash)}
       ENVELOPE

--- a/sentry-ruby/lib/sentry/transport/state.rb
+++ b/sentry-ruby/lib/sentry/transport/state.rb
@@ -9,7 +9,7 @@ module Sentry
         return true if @status == :online
 
         interval = @retry_after || [@retry_number, 6].min**2
-        return true if Time.now - @last_check >= interval
+        return true if Sentry.utc_now - @last_check >= interval
 
         false
       end
@@ -17,7 +17,7 @@ module Sentry
       def failure(retry_after = nil)
         @status = :error
         @retry_number += 1
-        @last_check = Time.now
+        @last_check = Sentry.utc_now
         @retry_after = retry_after
       end
 

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Sentry::Transport do
 
         expect(envelope_header).to eq(
           <<~ENVELOPE_HEADER.chomp
-            {"event_id":"#{event.event_id}","dsn":"#{DUMMY_DSN}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{DateTime.now.rfc3339}"}
+            {"event_id":"#{event.event_id}","dsn":"#{DUMMY_DSN}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{Time.now.utc.iso8601}"}
           ENVELOPE_HEADER
         )
 
@@ -58,7 +58,7 @@ RSpec.describe Sentry::Transport do
 
         expect(envelope_header).to eq(
           <<~ENVELOPE_HEADER.chomp
-            {"event_id":"#{event.event_id}","dsn":"#{DUMMY_DSN}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{DateTime.now.rfc3339}"}
+            {"event_id":"#{event.event_id}","dsn":"#{DUMMY_DSN}","sdk":#{Sentry.sdk_meta.to_json},"sent_at":"#{Time.now.utc.iso8601}"}
           ENVELOPE_HEADER
         )
 


### PR DESCRIPTION
The standard is to use `utc` timezone everywhere. So this PR adds a helper for that and unify time usages.