### PR TITLE
Add: Request ID to tags for Raven::Event

### DIFF
--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -25,6 +25,7 @@ require 'raven/transports'
 require 'raven/transports/http'
 require 'raven/utils/deep_merge'
 require 'raven/utils/real_ip'
+require 'raven/utils/request_id'
 require 'raven/utils/exception_cause_chain'
 require 'raven/instance'
 

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -226,6 +226,10 @@ module Raven
         int.from_rack(context.rack_env)
       end
       context.user[:ip_address] = calculate_real_ip_from_rack
+
+      if request_id = Utils::RequestId.read_from(context.rack_env)
+        context.tags[:request_id] = request_id
+      end
     end
 
     # When behind a proxy (or if the user is using a proxy), we can't use

--- a/lib/raven/utils/request_id.rb
+++ b/lib/raven/utils/request_id.rb
@@ -1,0 +1,16 @@
+module Raven
+  module Utils
+    module RequestId
+      REQUEST_ID_HEADERS = %w(action_dispatch.request_id HTTP_X_REQUEST_ID).freeze
+
+      # Request ID based on ActionDispatch::RequestId
+      def self.read_from(env_hash)
+        REQUEST_ID_HEADERS.each do |key|
+          request_id = env_hash[key]
+          return request_id if request_id
+        end
+        nil
+      end
+    end
+  end
+end

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe Raven::Event do
                          'SERVER_NAME' => 'localhost',
                          'SERVER_PORT' => '80',
                          'HTTP_X_FORWARDED_FOR' => '1.1.1.1, 2.2.2.2',
+                         'HTTP_X_REQUEST_ID' => '98765432',
                          'REMOTE_ADDR' => '192.168.1.1',
                          'PATH_INFO' => '/lol',
                          'rack.url_scheme' => 'http',
@@ -219,7 +220,7 @@ RSpec.describe Raven::Event do
     it "adds http data" do
       expect(hash[:request]).to eq(data: { 'foo' => 'bar' },
                                    env: { 'SERVER_NAME' => 'localhost', 'SERVER_PORT' => '80', "REMOTE_ADDR" => "192.168.1.1" },
-                                   headers: { 'Host' => 'localhost', "X-Forwarded-For" => "1.1.1.1, 2.2.2.2" },
+                                   headers: { 'Host' => 'localhost', "X-Forwarded-For" => "1.1.1.1, 2.2.2.2", 'X-Request-Id' => '98765432' },
                                    method: 'POST',
                                    query_string: 'biz=baz',
                                    url: 'http://localhost/lol',
@@ -228,6 +229,10 @@ RSpec.describe Raven::Event do
 
     it "sets user context ip address correctly" do
       expect(hash[:user][:ip_address]).to eq("1.1.1.1")
+    end
+
+    it "adds request_id to the tags" do
+      expect(hash[:tags][:request_id]).to eq("98765432")
     end
   end
 

--- a/spec/raven/utils/request_id_spec.rb
+++ b/spec/raven/utils/request_id_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe Raven::Utils::RequestId do
+  describe ".read_from" do
+    subject { Raven::Utils::RequestId.read_from(env_hash) }
+
+    context "when HTTP_X_REQUEST_ID is available" do
+      let(:env_hash) { { "HTTP_X_REQUEST_ID" => "request-id-sorta" } }
+
+      it { is_expected.to eq("request-id-sorta") }
+    end
+
+    context "when action_dispatch.request_id is available (from Rails middleware)" do
+      let(:env_hash) { { "action_dispatch.request_id" => "request-id-kinda" } }
+
+      it { is_expected.to eq("request-id-kinda") }
+    end
+
+    context "when no request-id is available" do
+      let(:env_hash) { { "foo" => "bar" } }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
Split from #1111 but this should only add to `Raven::Event`
- #1120 is the other half of this PR
- New Feature: Add `request_id` tags (when present) to Rack event