### PR TITLE
Add Request ID to tags for Sentry::Event

### DIFF
--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -5,6 +5,7 @@ require 'securerandom'
 require 'sentry/interface'
 require 'sentry/backtrace'
 require 'sentry/utils/real_ip'
+require 'sentry/utils/request_id'
 
 module Sentry
   class Event
@@ -81,6 +82,9 @@ module Sentry
 
         if configuration.send_default_pii && ip = calculate_real_ip_from_rack(env.dup)
           user[:ip_address] = ip
+        end
+        if request_id = Utils::RequestId.read_from(env)
+          tags[:request_id] = request_id
         end
       end
     end

--- a/sentry-ruby/lib/sentry/interfaces/request.rb
+++ b/sentry-ruby/lib/sentry/interfaces/request.rb
@@ -39,15 +39,6 @@ module Sentry
 
     private
 
-    # Request ID based on ActionDispatch::RequestId
-    def read_request_id_from(env_hash)
-      REQUEST_ID_HEADERS.each do |key|
-        request_id = env_hash[key]
-        return request_id if request_id
-      end
-      nil
-    end
-
     # See Sentry server default limits at
     # https://github.com/getsentry/sentry/blob/master/src/sentry/conf/server.py
     def read_data_from(request)
@@ -67,7 +58,7 @@ module Sentry
         begin
           key = key.to_s # rack env can contain symbols
           value = value.to_s
-          next memo['X-Request-Id'] ||= read_request_id_from(env_hash) if REQUEST_ID_HEADERS.include?(key)
+          next memo['X-Request-Id'] ||= Utils::RequestId.read_from(env_hash) if Utils::RequestId::REQUEST_ID_HEADERS.include?(key)
           next unless key.upcase == key # Non-upper case stuff isn't either
 
           # Rack adds in an incorrect HTTP_VERSION key, which causes downstream

--- a/sentry-ruby/lib/sentry/utils/request_id.rb
+++ b/sentry-ruby/lib/sentry/utils/request_id.rb
@@ -1,0 +1,16 @@
+module Sentry
+  module Utils
+    module RequestId
+      REQUEST_ID_HEADERS = %w(action_dispatch.request_id HTTP_X_REQUEST_ID).freeze
+
+      # Request ID based on ActionDispatch::RequestId
+      def self.read_from(env_hash)
+        REQUEST_ID_HEADERS.each do |key|
+          request_id = env_hash[key]
+          return request_id if request_id
+        end
+        nil
+      end
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Sentry::Event do
         'SERVER_NAME' => 'localhost',
         'SERVER_PORT' => '80',
         'HTTP_X_FORWARDED_FOR' => '1.1.1.1, 2.2.2.2',
+        'HTTP_X_REQUEST_ID' => 'abcd-1234-abcd-1234',
         'REMOTE_ADDR' => '192.168.1.1',
         'PATH_INFO' => '/lol',
         'rack.url_scheme' => 'http',
@@ -65,12 +66,13 @@ RSpec.describe Sentry::Event do
 
         expect(event.to_hash[:request]).to eq(
           env: { 'SERVER_NAME' => 'localhost', 'SERVER_PORT' => '80' },
-          headers: { 'Host' => 'localhost' },
+          headers: { 'Host' => 'localhost', 'X-Request-Id' => 'abcd-1234-abcd-1234' },
           method: 'POST',
           query_string: 'biz=baz',
           url: 'http://localhost/lol',
           cookies: nil
         )
+        expect(event.to_hash[:tags][:request_id]).to eq("abcd-1234-abcd-1234")
         expect(event.to_hash[:user][:ip_address]).to eq(nil)
       end
     end
@@ -86,13 +88,14 @@ RSpec.describe Sentry::Event do
         expect(event.to_hash[:request]).to eq(
           data: { 'foo' => 'bar' },
           env: { 'SERVER_NAME' => 'localhost', 'SERVER_PORT' => '80', "REMOTE_ADDR" => "192.168.1.1" },
-          headers: { 'Host' => 'localhost', "X-Forwarded-For" => "1.1.1.1, 2.2.2.2" },
+          headers: { 'Host' => 'localhost', "X-Forwarded-For" => "1.1.1.1, 2.2.2.2", "X-Request-Id" => "abcd-1234-abcd-1234" },
           method: 'POST',
           query_string: 'biz=baz',
           url: 'http://localhost/lol',
           cookies: {}
         )
 
+        expect(event.to_hash[:tags][:request_id]).to eq("abcd-1234-abcd-1234")
         expect(event.to_hash[:user][:ip_address]).to eq("1.1.1.1")
       end
     end

--- a/sentry-ruby/spec/sentry/utils/request_id_spec.rb
+++ b/sentry-ruby/spec/sentry/utils/request_id_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe Sentry::Utils::RequestId do
+  describe ".read_from" do
+    subject { Sentry::Utils::RequestId.read_from(env_hash) }
+
+    context "when HTTP_X_REQUEST_ID is available" do
+      let(:env_hash) { { "HTTP_X_REQUEST_ID" => "request-id-sorta" } }
+
+      it { is_expected.to eq("request-id-sorta") }
+    end
+
+    context "when action_dispatch.request_id is available (from Rails middleware)" do
+      let(:env_hash) { { "action_dispatch.request_id" => "request-id-kinda" } }
+
+      it { is_expected.to eq("request-id-kinda") }
+    end
+
+    context "when no request-id is available" do
+      let(:env_hash) { { "foo" => "bar" } }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
Split from #1111 but this should only add to `Sentry::Event`
- #1119 is the other half of this PR
- New Feature: Add `request_id` tags (when present) to Rack event

