### PR TITLE
Support event hint

### DIFF
--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -80,12 +80,16 @@ module Sentry
 
       return unless event
 
+      options[:hint] ||= {}
+      options[:hint] = options[:hint].merge(exception: exception)
       capture_event(event, **options, &block)
     end
 
     def capture_message(message, **options, &block)
       return unless current_client
 
+      options[:hint] ||= {}
+      options[:hint] = options[:hint].merge(message: message)
       event = current_client.event_from_message(message)
       capture_event(event, **options, &block)
     end
@@ -93,6 +97,7 @@ module Sentry
     def capture_event(event, **options, &block)
       return unless current_client
 
+      hint = options.delete(:hint)
       scope = current_scope.dup
 
       if block
@@ -103,7 +108,7 @@ module Sentry
         scope.update_from_options(**options)
       end
 
-      event = current_client.capture_event(event, scope)
+      event = current_client.capture_event(event, scope, hint)
 
       @last_event_id = event.event_id
       event

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -15,7 +15,7 @@ module Sentry
       set_default_value
     end
 
-    def apply_to_event(event)
+    def apply_to_event(event, hint = nil)
       event.tags = tags.merge(event.tags)
       event.user = user.merge(event.user)
       event.extra = extra.merge(event.extra)
@@ -33,7 +33,7 @@ module Sentry
 
       unless @event_processors.empty?
         @event_processors.each do |processor_block|
-          event = processor_block.call(event)
+          event = processor_block.call(event, hint)
         end
       end
 

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Sentry::Client do
     end
 
     it "applies before_send callback before sending the event" do
-      configuration.before_send = lambda do |event|
+      configuration.before_send = lambda do |event, _hint|
         event.tags[:called] = true
         event
       end

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -76,6 +76,23 @@ RSpec.describe Sentry::Hub do
       end
     end
 
+    context "with a hint" do
+      it "passes the hint all the way down to Client#send_event" do
+        hint = nil
+        configuration.before_send = ->(event, h) { hint = h }
+
+        subject.send(capture_helper, capture_subject, hint: {foo: "bar"})
+
+        case capture_subject
+        when String
+          expect(hint).to eq({message: capture_subject, foo: "bar"})
+        when Exception
+          expect(hint).to eq({exception: capture_subject, foo: "bar"})
+        else
+          expect(hint).to eq({foo: "bar"})
+        end
+      end
+    end
   end
   describe '#capture_message' do
     let(:message) { "Test message" }

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -198,14 +198,16 @@ RSpec.describe Sentry::Scope do
     end
 
     it "applies event processors to the event" do
-      subject.add_event_processor do |event|
+      subject.add_event_processor do |event, hint|
         event.tags = { processed: true }
+        event.extra = hint
         event
       end
 
-      subject.apply_to_event(event)
+      subject.apply_to_event(event, { foo: "bar" })
 
       expect(event.tags).to eq({ processed: true })
+      expect(event.extra).to eq({ foo: "bar" })
     end
 
     it "sets trace context if there's a span" do


### PR DESCRIPTION
This PR adds support for event hints. It's useful to user's custom callbacks like `before_send` or event processors.