### PR TITLE
Support rails 6.1

### DIFF
--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -18,16 +18,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rails_version: [5.2, 6.0]
+        rails_version: [5.2, 6.0.0, 6.1.0]
         ruby_version: [2.4, 2.5, 2.6, 2.7, jruby]
         os: [ubuntu-latest]
         include:
           - ruby_version: 2.7
-            rails_version: 6.0
+            rails_version: 6.1.0
             env: RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
         exclude:
           - ruby_version: 2.4
-            rails_version: 6.0
+            rails_version: 6.0.0
+          - ruby_version: 2.4
+            rails_version: 6.1.0
+          - ruby_version: jruby
+            rails_version: 6.1.0
 
     steps:
     - uses: actions/checkout@v1
@@ -60,7 +64,7 @@ jobs:
       RAILS_VERSION: ${{ matrix.rails_version }}
     strategy:
       matrix:
-        rails_version: [5.2, 6.0]
+        rails_version: [5.2, 6.1.0]
         ruby_version: [2.6, 2.7]
         os: [ubuntu-latest]
     steps:

--- a/.github/workflows/sentry_raven_test.yml
+++ b/.github/workflows/sentry_raven_test.yml
@@ -15,20 +15,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rails_version: [0, 4.2, 5.2, 6.0]
+        rails_version: [0, 4.2, 5.2, 6.0.0]
         ruby_version: [2.3, 2.4, 2.5, 2.6, 2.7, jruby, head]
         os: [ubuntu-latest]
         include:
           - ruby_version: head
             rails_version: 0
           - ruby_version: 2.7
-            rails_version: 6.0
+            rails_version: 6.0.0
             env: RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
         exclude:
           - ruby_version: 2.3
-            rails_version: 6.0
+            rails_version: 6.0.0
           - ruby_version: 2.4
-            rails_version: 6.0
+            rails_version: 6.0.0
           - ruby_version: 2.7
             rails_version: 4.2
           - ruby_version: head
@@ -36,7 +36,7 @@ jobs:
           - ruby_version: head
             rails_version: 5.2
           - ruby_version: head
-            rails_version: 6.0
+            rails_version: 6.0.0
 
     steps:
     - uses: actions/checkout@v1
@@ -67,7 +67,7 @@ jobs:
       RAILS_VERSION: ${{ matrix.rails_version }}
     strategy:
       matrix:
-        rails_version: [5.2, 6.0]
+        rails_version: [5.2, 6.0.0]
         ruby_version: [2.6, 2.7]
         os: [ubuntu-latest]
     steps:

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 gemspec
 
 rails_version = ENV["RAILS_VERSION"]
-rails_version = "6.0" if rails_version.nil?
+rails_version = "6.1.0" if rails_version.nil?
 
 gem 'activerecord-jdbcmysql-adapter', platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby

--- a/sentry-rails/spec/sentry/rails/active_support_breadcrumbs_spec.rb
+++ b/sentry-rails/spec/sentry/rails/active_support_breadcrumbs_spec.rb
@@ -25,16 +25,34 @@ RSpec.describe "Sentry::Breadcrumbs::ActiveSupportLogger", type: :request do
     breadcrumbs = event.dig("breadcrumbs", "values")
     expect(breadcrumbs.count).to eq(2)
 
-    expect(breadcrumbs.first["data"]).to match(
-      {
-        "controller" => "HelloController",
-        "action" => "exception",
-        "params" => { "controller" => "hello", "action" => "exception" },
-        "headers" => anything,
-        "format" => "html",
-        "method" => "GET",
-        "path" => "/exception"
-      }
-    )
+    if Rails.version.match(/6\.1/)
+      expect(breadcrumbs.first["data"]).to match(
+        {
+          "controller" => "HelloController",
+          "action" => "exception",
+          "params" => { "controller" => "hello", "action" => "exception" },
+          "headers" => anything,
+          "request" => anything,
+          "view_runtime" => nil,
+          "format" => "html",
+          "method" => "GET",
+          "path" => "/exception",
+          "exception" => ["RuntimeError", "An unhandled exception!"],
+          "exception_object" => "An unhandled exception!"
+        }
+      )
+    else
+      expect(breadcrumbs.first["data"]).to match(
+        {
+          "controller" => "HelloController",
+          "action" => "exception",
+          "params" => { "controller" => "hello", "action" => "exception" },
+          "headers" => anything,
+          "format" => "html",
+          "method" => "GET",
+          "path" => "/exception"
+        }
+      )
+    end
   end
 end


### PR DESCRIPTION
No major changes are required, just need to update `sentry-rails`'s tests.