### PR TITLE
ActiveSupportLogger should only record events that has a started time

### DIFF
--- a/sentry-rails/lib/sentry/rails/breadcrumb/active_support_logger.rb
+++ b/sentry-rails/lib/sentry/rails/breadcrumb/active_support_logger.rb
@@ -14,7 +14,10 @@ module Sentry
 
           def inject
             @subscriber = ::ActiveSupport::Notifications.subscribe(/.*/) do |name, started, finished, unique_id, data|
-              add(name, started, finished, unique_id, data)
+              # we only record events that has a started timestamp
+              if started.is_a?(Time)
+                add(name, started, finished, unique_id, data)
+              end
             end
           end
 


### PR DESCRIPTION
Because `ActiveSupport::Notifications.publish` can be used to publish anything, whether it's a standard Rails instrumentation payload, a string, or even a custom object, it's dangerous for the logger to accept anything that's being published.

So this PR filters out events that are not compatible with the default Rails instrumentation format to avoid issues.

closes #1131 