### PR TITLE
Add rake integration

### DIFF
--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -11,6 +11,15 @@ require "sentry/transaction"
 require "sentry/hub"
 require "sentry/rack"
 
+def safely_require(lib)
+  begin
+    require lib
+  rescue LoadError
+  end
+end
+
+safely_require "sentry/rake"
+
 module Sentry
   class Error < StandardError
   end

--- a/sentry-ruby/lib/sentry/rake.rb
+++ b/sentry-ruby/lib/sentry/rake.rb
@@ -1,0 +1,17 @@
+require "rake"
+require "rake/task"
+
+module Rake
+  class Application
+    alias orig_display_error_messsage display_error_message
+    def display_error_message(ex)
+      Sentry.capture_exception(ex) do |scope|
+        task_name = top_level_tasks.join(' ')
+        scope.set_transaction_name(task_name)
+        scope.set_tag("rake_task", task_name)
+      end
+
+      orig_display_error_messsage(ex)
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/rake_spec.rb
+++ b/sentry-ruby/spec/sentry/rake_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe "rake auto-reporting" do
+  it "sends a report to Sentry" do
+    message = ""
+
+    # if we change the directory in the current process, it'll affect other tests that relies on system call too
+    # e.g. release detection tests
+    Thread.new do
+      message = `cd spec/support && bundle exec rake raise_exception 2>&1`
+    end.join
+
+    expect(message).to match(/Sending event [abcdef0-9]+ to Sentry/)
+  end
+end

--- a/sentry-ruby/spec/support/Rakefile.rb
+++ b/sentry-ruby/spec/support/Rakefile.rb
@@ -1,0 +1,10 @@
+require "rake"
+require "sentry-ruby"
+
+Sentry.init do |config|
+  config.dsn = 'http://12345:67890@sentry.localdomain/sentry/42'
+end
+
+task :raise_exception do
+  1/0
+end


### PR DESCRIPTION
This should add the identical functionality as `sentry-raven`'s [rake integration](https://github.com/getsentry/sentry-ruby/blob/master/sentry-raven/lib/raven/integrations/rake.rb).

closes #1134 