### PR TITLE
Separate rack integration

### DIFF
--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -24,6 +24,7 @@ jobs:
           - { os: ubuntu-latest, ruby_version: 2.7 }
           - { os: ubuntu-latest, ruby_version: jruby }
           - { os: ubuntu-latest, ruby_version: 2.7, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
+          - { os: ubuntu-latest, ruby_version: 2.7, options: { without_rack: 1 } }
     steps:
     - uses: actions/checkout@v1
 
@@ -36,6 +37,7 @@ jobs:
     - name: Run specs
       env:
         RUBYOPT: ${{ matrix.options.rubyopt }}
+        WITHOUT_RACK: ${{ matrix.options.without_rack }}
       run: |
         bundle install --jobs 4 --retry 3
         bundle exec rake

--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -8,7 +8,7 @@ gem "rspec", "~> 3.0"
 gem "codecov"
 
 gem "pry"
-gem "rack"
+gem "rack" unless ENV["WITHOUT_RACK"] == "1"
 
 gem "benchmark-ips"
 gem "benchmark_driver"

--- a/sentry-ruby/examples/without_integrations/Gemfile
+++ b/sentry-ruby/examples/without_integrations/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+ruby '> 2.6'
+
+gem 'sentry-ruby', path: "../../"

--- a/sentry-ruby/examples/without_integrations/app.rb
+++ b/sentry-ruby/examples/without_integrations/app.rb
@@ -1,0 +1,7 @@
+require "sentry-ruby"
+
+Sentry.init do |config|
+  config.dsn = 'https://2fb45f003d054a7ea47feb45898f7649@o447951.ingest.sentry.io/5434472'
+end
+
+Sentry.capture_message("test Sentry")

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -9,7 +9,6 @@ require "sentry/transaction_event"
 require "sentry/span"
 require "sentry/transaction"
 require "sentry/hub"
-require "sentry/rack"
 
 def safely_require(lib)
   begin
@@ -19,6 +18,7 @@ def safely_require(lib)
 end
 
 safely_require "sentry/rake"
+safely_require "sentry/rack"
 
 module Sentry
   class Error < StandardError

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -1,4 +1,5 @@
 require "forwardable"
+require "time"
 
 require "sentry/version"
 require "sentry/core_ext/object/deep_dup"

--- a/sentry-ruby/lib/sentry/interfaces/request.rb
+++ b/sentry-ruby/lib/sentry/interfaces/request.rb
@@ -1,5 +1,3 @@
-require 'rack'
-
 module Sentry
   class RequestInterface < Interface
     REQUEST_ID_HEADERS = %w(action_dispatch.request_id HTTP_X_REQUEST_ID).freeze
@@ -16,25 +14,6 @@ module Sentry
       self.headers = {}
       self.env = {}
       self.cookies = nil
-    end
-
-    def from_rack(env_hash)
-      req = ::Rack::Request.new(env_hash)
-
-      if Sentry.configuration.send_default_pii
-        self.data = read_data_from(req)
-        self.cookies = req.cookies
-      else
-        # need to completely wipe out ip addresses
-        IP_HEADERS.each { |h| env_hash.delete(h) }
-      end
-
-      self.url = req.scheme && req.url.split('?').first
-      self.method = req.request_method
-      self.query_string = req.query_string
-
-      self.headers = format_headers_for_sentry(env_hash)
-      self.env     = format_env_for_sentry(env_hash)
     end
 
     private

--- a/sentry-ruby/lib/sentry/rack.rb
+++ b/sentry-ruby/lib/sentry/rack.rb
@@ -1,4 +1,4 @@
-require 'time'
 require 'rack'
 
 require 'sentry/rack/capture_exceptions'
+require 'sentry/rack/interface'

--- a/sentry-ruby/lib/sentry/rack/interface.rb
+++ b/sentry-ruby/lib/sentry/rack/interface.rb
@@ -1,0 +1,22 @@
+module Sentry
+  class RequestInterface
+    def from_rack(env_hash)
+      req = ::Rack::Request.new(env_hash)
+
+      if Sentry.configuration.send_default_pii
+        self.data = read_data_from(req)
+        self.cookies = req.cookies
+      else
+        # need to completely wipe out ip addresses
+        IP_HEADERS.each { |h| env_hash.delete(h) }
+      end
+
+      self.url = req.scheme && req.url.split('?').first
+      self.method = req.request_method
+      self.query_string = req.query_string
+
+      self.headers = format_headers_for_sentry(env_hash)
+      self.env     = format_env_for_sentry(env_hash)
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -29,7 +29,7 @@ module Sentry
       event.level = level
       event.transaction = transaction_names.last
       event.breadcrumbs = breadcrumbs
-      event.rack_env = rack_env
+      event.rack_env = rack_env if rack_env
 
       unless @event_processors.empty?
         @event_processors.each do |processor_block|

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Sentry::Event do
     end
   end
 
-  context 'rack context specified' do
+  context 'rack context specified', rack: true do
     require 'stringio'
 
     before do

--- a/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
@@ -1,3 +1,5 @@
+return unless defined?(Rack)
+
 require 'spec_helper'
 
 RSpec.describe Sentry::RequestInterface do

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -1,6 +1,8 @@
+return unless defined?(Rack)
+
 require 'spec_helper'
 
-RSpec.describe Sentry::Rack::CaptureExceptions do
+RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
   let(:exception) { ZeroDivisionError.new("divided by 0") }
   let(:additional_headers) { {} }
   let(:env) { Rack::MockRequest.env_for("/test", additional_headers) }

--- a/sentry-ruby/spec/sentry/scope/setters_spec.rb
+++ b/sentry-ruby/spec/sentry/scope/setters_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Sentry::Scope do
     new_breadcrumb
   end
 
-  describe "#set_rack_env" do
+  describe "#set_rack_env", rack: true do
     let(:env) do
       Rack::MockRequest.env_for("/test", {})
     end

--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -37,6 +37,10 @@ RSpec.configure do |config|
     ENV.delete('RAILS_ENV')
     ENV.delete('RACK_ENV')
   end
+
+  config.before(:each, rack: true) do
+    skip("skip rack related tests") unless defined?(Rack)
+  end
 end
 
 def build_exception_with_cause(cause = "exception a")


### PR DESCRIPTION
Rack integration should be optional. This PR makes sure non-Rack applications can still use this SDK without any issue.

closes #1136 