### PR TITLE
Deep-copy spans

### DIFF
--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -57,7 +57,7 @@ module Sentry
       copy.user = user.deep_dup
       copy.transaction_names = transaction_names.deep_dup
       copy.fingerprint = fingerprint.deep_dup
-      copy.span = span
+      copy.span = span.deep_dup
       copy
     end
 

--- a/sentry-ruby/lib/sentry/span.rb
+++ b/sentry-ruby/lib/sentry/span.rb
@@ -100,6 +100,21 @@ module Sentry
       child_span.finish
     end
 
+    def deep_dup
+      copy = self.dup
+
+      if @span_recorder
+        copy.set_span_recorder
+        @span_recorder.spans.each do |span|
+          # span_recorder's first span is the current span, which should not be added to the copy's spans
+          next if span == self
+          copy.span_recorder.add(span.dup)
+        end
+      end
+
+      copy
+    end
+
     def set_op(op)
       @op = op
     end

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -40,6 +40,17 @@ RSpec.describe Sentry::Scope do
       expect(subject.user).to eq({})
       expect(subject.fingerprint).to eq([])
       expect(subject.transaction_names).to eq([])
+      expect(subject.span).to eq(nil)
+    end
+
+    it "deep-copies span as well" do
+      span = Sentry::Transaction.new(sampled: true)
+      subject.set_span(span)
+      copy = subject.dup
+
+      span.start_child
+
+      expect(copy.span.span_recorder.spans.count).to eq(1)
     end
   end
 

--- a/sentry-ruby/spec/sentry/span_spec.rb
+++ b/sentry-ruby/spec/sentry/span_spec.rb
@@ -22,6 +22,23 @@ RSpec.describe Sentry::Span do
     end
   end
 
+  describe "#deep_dup" do
+    it "copies all the values from the original span" do
+      copy = subject.deep_dup
+
+      subject.set_op("foo")
+      subject.set_description("bar")
+
+      expect(copy.op).to eq("sql.query")
+      expect(copy.description).to eq("SELECT * FROM users;")
+      expect(copy.status).to eq("ok")
+      expect(copy.trace_id).to eq(subject.trace_id)
+      expect(copy.trace_id.length).to eq(32)
+      expect(copy.span_id).to eq(subject.span_id)
+      expect(copy.span_id.length).to eq(16)
+    end
+  end
+
   describe "#to_hash" do
     before do
       subject.set_data("controller", "WelcomeController")


### PR DESCRIPTION
Scope's span should like other attributes be deep-copied instead of shared with reference, which can cause issues when used in a concurrent situation.