### PR TITLE
Move span recorder related code from Span to Transaction

### DIFF
--- a/sentry-ruby/spec/sentry/span_spec.rb
+++ b/sentry-ruby/spec/sentry/span_spec.rb
@@ -95,21 +95,6 @@ RSpec.describe Sentry::Span do
       expect(new_span.start_timestamp).not_to eq(subject.start_timestamp)
       expect(new_span.sampled).to eq(true)
     end
-
-    it "records the child span if span_recorder is present" do
-      subject.set_span_recorder
-      new_span = subject.start_child
-
-      expect(subject.span_recorder.spans).to include(new_span)
-      expect(new_span.span_recorder).to eq(subject.span_recorder)
-    end
-
-    it "doesn't record the child span if span_recorder is not present" do
-      new_span = subject.start_child
-
-      expect(subject.span_recorder).to eq(nil)
-      expect(new_span.span_recorder).to eq(nil)
-    end
   end
 
   describe "#with_child_span" do

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -71,6 +71,30 @@ RSpec.describe Sentry::Transaction do
     end
   end
 
+  describe "#start_child" do
+    it "initializes a new child Span" do
+      # create subject span and wait for a sec for making time difference
+      subject
+
+      new_span = subject.start_child(op: "sql.query", description: "SELECT * FROM orders WHERE orders.user_id = 1", status: "ok")
+
+      expect(new_span.op).to eq("sql.query")
+      expect(new_span.description).to eq("SELECT * FROM orders WHERE orders.user_id = 1")
+      expect(new_span.status).to eq("ok")
+      expect(new_span.trace_id).to eq(subject.trace_id)
+      expect(new_span.span_id).not_to eq(subject.span_id)
+      expect(new_span.parent_span_id).to eq(subject.span_id)
+      expect(new_span.sampled).to eq(true)
+    end
+
+    it "records the child span if span_recorder" do
+      new_span = subject.start_child
+
+      expect(subject.span_recorder.spans).to include(new_span)
+      expect(new_span.span_recorder).to eq(subject.span_recorder)
+    end
+  end
+
   describe "#set_initial_sample_desicion" do
     before do
       Sentry.init do |config|


### PR DESCRIPTION
Since span recorder can only exist and be used in transactions, it doesn't need to be defined in the Span class.
