### PR TITLE
Implement non-blocking event sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ The official Ruby-language client and integration layer for the [Sentry](https:/
 
 We test on Ruby 2.4, 2.5, 2.6 and 2.7 at the latest patchlevel/teeny version. We also support JRuby 9.0.
 
+## Migrate From sentry-raven
+
+If you're using `sentry-raven`, we recommend you to migrate to this new SDK. You can find the benefits of migrating and how to do it in our [migration guide](https://docs.sentry.io/platforms/ruby/migration/).
+
 ## Getting Started
 
 ### Install
@@ -136,9 +140,9 @@ We also provide integrations with popular frameworks/libraries with the related 
 
 You're all set - but there's a few more settings you may want to know about too!
 
-#### async
+#### Blocking v.s. Non-blocking
 
-When an error or message occurs, the notification is immediately sent to Sentry. Sentry can be configured to send asynchronously:
+**Before version 4.1.0**, `sentry-ruby` sends every event immediately. But it can be configured to send asynchronously:
 
 ```ruby
 config.async = lambda { |event|
@@ -160,6 +164,35 @@ class SentryJob < ActiveJob::Base
     Sentry.send_event(event)
   end
 end
+```
+
+
+**After version 4.1.0**, `sentry-ruby` sends events asynchronously by default. The functionality works like this: 
+
+1. When the SDK is initialized, a `Sentry::BackgroundWorker` will be initialized too.
+2. When an event is passed to `Client#capture_event`, instead of sending it directly with `Client#send_event`, we'll let the worker do it.
+3. The worker will have a number of threads. And the one of the idle threads will pick the job and call `Client#send_event`.
+  - If all the threads are busy, new jobs will be put into a queue, which has a limit of 30.
+  - If the queue size is exceeded, new events will be dropped.
+
+However, if you still prefer to use your own async approach, that's totally fine. If you have `config.async` set, the worker won't initialize a thread pool and won't be used either.
+
+##### About `Sentry::BackgroundWorker`
+
+- The worker is built on top of the [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby) gem's [ThreadPoolExecutor](http://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/ThreadPoolExecutor.html), which is also used by Rails ActiveJob's async adapter. This should minimize the risk of messing up client applications with our own thread pool implementaion.
+
+This functionality also introduces a new `background_worker_threads` config option. It allows you to decide how many threads should the worker hold. By default, the value will be the number of the processors your machine has. For example, if your machine has 4 processors, the value would be 4.
+
+Of course, you can always override the value to fit your use cases, like
+
+```ruby
+config.background_worker_threads = 5 # the worker will have 5 threads for sending events
+```
+
+You can also disable this new non-blocking behaviour by giving a `0` value:
+
+```ruby
+config.background_worker_threads = 0 # all events will be sent synchronously
 ```
 
 #### Contexts
@@ -187,7 +220,6 @@ Or use top-level setters
 Sentry.set_user(id: 1, email: "test@example.com")
 Sentry.set_tags(tag_1: "foo", tag_2: "bar")
 Sentry.set_extras(order_number: 1234, tickets_count: 4)
-
 ```
 
 Or build up a temporary scope for local information:

--- a/sentry-rails/spec/sentry/rails/controller_methods_spec.rb
+++ b/sentry-rails/spec/sentry/rails/controller_methods_spec.rb
@@ -8,11 +8,7 @@ RSpec.describe Sentry::Rails::ControllerMethods do
   end
 
   before do
-    Sentry.init do |config|
-      config.logger = ::Logger.new(nil)
-      config.dsn = DUMMY_DSN
-      config.transport.transport_class = Sentry::DummyTransport
-    end
+    perform_basic_setup
   end
 
   let(:options) do

--- a/sentry-rails/spec/sentry/rails/overrides/debug_exceptions_catcher_spec.rb
+++ b/sentry-rails/spec/sentry/rails/overrides/debug_exceptions_catcher_spec.rb
@@ -21,11 +21,7 @@ RSpec.shared_examples "exception catching middleware" do
   end
 
   before do
-    Sentry.init do |config|
-      config.logger = ::Logger.new(nil)
-      config.dsn = DUMMY_DSN
-      config.transport.transport_class = Sentry::DummyTransport
-    end
+    perform_basic_setup
   end
 
   after do

--- a/sentry-rails/spec/spec_helper.rb
+++ b/sentry-rails/spec/spec_helper.rb
@@ -93,5 +93,7 @@ def perform_basic_setup
     config.dsn = DUMMY_DSN
     config.logger = ::Logger.new(nil)
     config.transport.transport_class = Sentry::DummyTransport
+    # for sending events synchronously
+    config.background_worker_threads = 0
   end
 end

--- a/sentry-rails/spec/support/test_rails_app/app.rb
+++ b/sentry-rails/spec/support/test_rails_app/app.rb
@@ -96,6 +96,8 @@ def make_basic_app
       # for speeding up request specs
       config.rails.report_rescued_exceptions = false
       config.transport.transport_class = Sentry::DummyTransport
+      # for sending events synchronously
+      config.background_worker_threads = 0
       yield(config) if block_given?
     end
   end

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -10,6 +10,7 @@ require "sentry/transaction_event"
 require "sentry/span"
 require "sentry/transaction"
 require "sentry/hub"
+require "sentry/background_worker"
 
 def safely_require(lib)
   begin
@@ -44,6 +45,8 @@ module Sentry
 
     def_delegators :get_current_scope, :set_tags, :set_extras, :set_user
 
+    attr_accessor :background_worker
+
     def init(&block)
       config = Configuration.new
       yield(config)
@@ -52,6 +55,7 @@ module Sentry
       hub = Hub.new(client, scope)
       Thread.current[THREAD_LOCAL] = hub
       @main_hub = hub
+      @background_worker = Sentry::BackgroundWorker.new(config)
     end
 
     def initialized?

--- a/sentry-ruby/lib/sentry/background_worker.rb
+++ b/sentry-ruby/lib/sentry/background_worker.rb
@@ -1,0 +1,32 @@
+require "concurrent/executor/thread_pool_executor"
+
+module Sentry
+  class BackgroundWorker
+    attr_reader :max_queue, :number_of_threads
+
+    def initialize(configuration)
+      @max_queue = 30
+      @number_of_threads = configuration.background_worker_threads
+
+      @executor =
+        if @number_of_threads == 0
+          configuration.logger.debug(LOGGER_PROGNAME) { "config.background_worker_threads is set to 0, all events will be sent synchronously" }
+          Concurrent::ImmediateExecutor.new
+        else
+          configuration.logger.debug(LOGGER_PROGNAME) { "initialized a background worker with #{@number_of_threads} threads" }
+
+          Concurrent::ThreadPoolExecutor.new(
+            min_threads: 0,
+            max_threads: @number_of_threads,
+            max_queue: @max_queue
+          )
+        end
+    end
+
+    def perform(&block)
+      @executor.post do
+        block.call
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/background_worker.rb
+++ b/sentry-ruby/lib/sentry/background_worker.rb
@@ -22,7 +22,8 @@ module Sentry
           Concurrent::ThreadPoolExecutor.new(
             min_threads: 0,
             max_threads: @number_of_threads,
-            max_queue: @max_queue
+            max_queue: @max_queue,
+            fallback_policy: :discard
           )
         end
     end

--- a/sentry-ruby/lib/sentry/background_worker.rb
+++ b/sentry-ruby/lib/sentry/background_worker.rb
@@ -1,4 +1,5 @@
 require "concurrent/executor/thread_pool_executor"
+require "concurrent/executor/immediate_executor"
 
 module Sentry
   class BackgroundWorker
@@ -9,7 +10,10 @@ module Sentry
       @number_of_threads = configuration.background_worker_threads
 
       @executor =
-        if @number_of_threads == 0
+        if configuration.async?
+          configuration.logger.debug(LOGGER_PROGNAME) { "config.async is set, BackgroundWorker is disabled" }
+          Concurrent::ImmediateExecutor.new
+        elsif @number_of_threads == 0
           configuration.logger.debug(LOGGER_PROGNAME) { "config.background_worker_threads is set to 0, all events will be sent synchronously" }
           Concurrent::ImmediateExecutor.new
         else

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -35,7 +35,9 @@ module Sentry
           send_event(event, hint)
         end
       else
-        send_event(event, hint)
+        Sentry.background_worker.perform do
+          send_event(event, hint)
+        end
       end
 
       event

--- a/sentry-ruby/sentry-ruby.gemspec
+++ b/sentry-ruby/sentry-ruby.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", ">= 1.0"
+  spec.add_dependency "concurrent-ruby"
 end

--- a/sentry-ruby/spec/sentry/background_worker_spec.rb
+++ b/sentry-ruby/spec/sentry/background_worker_spec.rb
@@ -1,0 +1,62 @@
+require "spec_helper"
+
+RSpec.describe Sentry::BackgroundWorker do
+  let(:string_io) { StringIO.new }
+
+  describe "#initialize" do
+    let(:configuration) do
+      Sentry::Configuration.new.tap do |config|
+        config.logger = Logger.new(string_io)
+      end
+    end
+
+    context "when config.background_worker_threads is set" do
+      it "initializes a background worker with correct number of threads and queue size" do
+        worker = described_class.new(configuration)
+
+        expect(worker.max_queue).to eq(30)
+        expect(worker.number_of_threads).to eq(Concurrent.processor_count)
+      end
+    end
+
+    context "when config.background_worker_threads is 0" do
+      before do
+        configuration.background_worker_threads = 0
+      end
+
+      it "initializes a background worker that process jobs synchronously" do
+        worker = described_class.new(configuration)
+
+        expect(string_io.string).to match(
+          /config.background_worker_threads is set to 0, all events will be sent synchronously/
+        )
+
+        # verify the behavior of executor instead of checking its class
+        counter = 0
+
+        worker.perform do
+          sleep 0.1
+          counter += 1
+        end
+
+        expect(counter).to eq(1)
+      end
+    end
+
+    context "when config.background_worker_threads is set" do
+      before do
+        configuration.background_worker_threads = 5
+      end
+
+      it "sets the worker's number_of_threads accordingly" do
+        worker = described_class.new(configuration)
+
+        expect(worker.number_of_threads).to eq(5)
+
+        expect(string_io.string).to match(
+          /initialized a background worker with 5 threads/
+        )
+      end
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -5,11 +5,16 @@ RSpec.describe Sentry::Hub do
     config = Sentry::Configuration.new
     config.dsn = DUMMY_DSN
     config.transport.transport_class = Sentry::DummyTransport
+    config.background_worker_threads = 0
     config
   end
   let(:client) { Sentry::Client.new(configuration) }
   let(:transport) { client.transport }
   let(:scope) { Sentry::Scope.new }
+
+  before do
+    Sentry.background_worker = Sentry::BackgroundWorker.new(configuration)
+  end
 
   subject { described_class.new(client, scope) }
 

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -13,11 +13,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
 
   describe "exceptions capturing" do
     before do
-      Sentry.init do |config|
-        config.breadcrumbs_logger = [:sentry_logger]
-        config.dsn = DUMMY_DSN
-        config.transport.transport_class = Sentry::DummyTransport
-      end
+      perform_basic_setup
     end
 
     it 'captures the exception from direct raise' do
@@ -155,10 +151,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
 
   describe "performance monitoring" do
     before do
-      Sentry.init do |config|
-        config.breadcrumbs_logger = [:sentry_logger]
-        config.dsn = DUMMY_DSN
-        config.transport.transport_class = Sentry::DummyTransport
+      perform_basic_setup do |config|
         config.traces_sample_rate = 0.5
       end
     end

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -97,10 +97,7 @@ RSpec.describe Sentry::Transaction do
 
   describe "#set_initial_sample_desicion" do
     before do
-      Sentry.init do |config|
-        config.dsn = DUMMY_DSN
-        config.transport.transport_class = Sentry::DummyTransport
-      end
+      perform_basic_setup
     end
 
     context "when tracing is not enabled" do
@@ -249,10 +246,7 @@ RSpec.describe Sentry::Transaction do
 
   describe "#finish" do
     before do
-      Sentry.init do |config|
-        config.dsn = DUMMY_DSN
-        config.transport.transport_class = Sentry::DummyTransport
-      end
+      perform_basic_setup
     end
 
     let(:events) do

--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -76,3 +76,14 @@ def build_exception_with_recursive_cause
   allow(exception).to receive(:backtrace).and_return(backtrace)
   exception
 end
+
+def perform_basic_setup
+  Sentry.init do |config|
+    config.breadcrumbs_logger = [:sentry_logger]
+    config.dsn = DUMMY_DSN
+    config.transport.transport_class = Sentry::DummyTransport
+    # so the events will be sent synchronously for testing
+    config.background_worker_threads = 0
+    yield(config) if block_given?
+  end
+end

--- a/sentry-ruby/spec/support/Rakefile.rb
+++ b/sentry-ruby/spec/support/Rakefile.rb
@@ -3,6 +3,7 @@ require "sentry-ruby"
 
 Sentry.init do |config|
   config.dsn = 'http://12345:67890@sentry.localdomain/sentry/42'
+  config.background_worker_threads = 0
 end
 
 task :raise_exception do

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -88,6 +88,7 @@ def perform_basic_setup
   Sentry.init do |config|
     config.dsn = DUMMY_DSN
     config.logger = ::Logger.new(nil)
+    config.background_worker_threads = 0
     config.transport.transport_class = Sentry::DummyTransport
   end
 end


### PR DESCRIPTION
For users who don't use `config.async`, sending events is currently a blocking operation. This means a request won't complete before some SDK operations like serializing or making requests to Sentry are also finished. So this PR introduces non-blocking event sending functionality to the SDK.

The functionality works like this: 
1. When the SDK is initialized, a `Sentry::BackgroundWorker` will be initialized too.
2. When an event is passed to `Client#capture_event`, instead of sending it directly with `Client#send_event`, we'll let the worker do it.
3. The worker will have a number of threads. And one of the idle threads will pick the job and call `Client#send_event`.
  - If all the threads are busy, new jobs will be put into a queue, which has a limit of 30.
  - If the queue size is exceeded, new events will be dropped.

### About Sentry::BackgroundWorker

- The worker is built on top of the [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby) gem's [ThreadPoolExecutor](http://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/ThreadPoolExecutor.html), which is also used by Rails ActiveJob's async adapter. This should minimize the risk of messing up client applications with our own thread pool implementation.
- It respects users' async implementation. So if the users have `config.async` set, the worker won't initialize a thread pool and won't be used either.
- The worker will be initialized at the end of the `Sentry.init` call.

#### New Configuration Option - `background_worker_threads`

This change also introduces a new `background_worker_threads` config option. It allows users to decide how many threads should the worker hold. By default, the value will be the number of the processors the user's machine has. For example, if the user's machine has 4 processors, the value would be 4.

Of course, users can always override the value to fit their use cases, like

```ruby
config.background_worker_threads = 5 # the worker will have 5 threads for sending events
```

Users can also disable this new non-blocking behaviour by giving a `0` value:

```ruby
config.background_worker_threads = 0 # all events will be sent synchronously
```

closes #1130
