### PR TITLE
Disabled SDK shouldn't even call the async block

### DIFF
--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -21,6 +21,8 @@ module Sentry
     end
 
     def capture_event(event, scope, hint = nil)
+      return false unless configuration.sending_allowed?
+
       scope.apply_to_event(event, hint)
 
       if configuration.async?
@@ -64,8 +66,6 @@ module Sentry
     end
 
     def send_event(event, hint = nil)
-      return false unless configuration.sending_allowed?
-
       event = configuration.before_send.call(event, hint) if configuration.before_send
       if event.nil?
         configuration.logger.info(LOGGER_PROGNAME) { "Discarded event because before_send returned nil" }

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -47,6 +47,16 @@ RSpec.describe Sentry::Client do
         expect(returned).to be_a(Sentry::Event)
       end
 
+      it "doesn't call the async block if not allow sending events" do
+        allow(configuration).to receive(:sending_allowed?).and_return(false)
+
+        expect(configuration.async).not_to receive(:call)
+
+        returned = subject.capture_event(event, scope)
+
+        expect(returned).to eq(false)
+      end
+
       context "when async raises an exception" do
         around do |example|
           prior_async = configuration.async


### PR DESCRIPTION
If the SDK is disabled or in a invalid state (like no DSN provided), the event should be discarded before the `config.async` is called. Otherwise, users will have jobs enqueued for sending nothing as described in #1152.

closes #1152