### PR TITLE
Add per event backgrounding option

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ You can also disable this new non-blocking behaviour by giving a `0` value:
 config.background_worker_threads = 0 # all events will be sent synchronously
 ```
 
+If you want to send a particular event immediately, you can use event hints to do it:
+
+```ruby
+Sentry.capture_message("send me now!", hint: { background: false })
+```
+
 #### Contexts
 
 In sentry-ruby, every event will inherit their contextual data from the current scope. So you can enrich the event's data by configuring the current scope like:

--- a/sentry-ruby/README.md
+++ b/sentry-ruby/README.md
@@ -194,6 +194,12 @@ You can also disable this new non-blocking behaviour by giving a `0` value:
 config.background_worker_threads = 0 # all events will be sent synchronously
 ```
 
+If you want to send a particular event immediately, you can use event hints to do it:
+
+```ruby
+Sentry.capture_message("send me now!", hint: { background: false })
+```
+
 #### Contexts
 
 In sentry-ruby, every event will inherit their contextual data from the current scope. So you can enrich the event's data by configuring the current scope like:

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -20,7 +20,7 @@ module Sentry
       end
     end
 
-    def capture_event(event, scope, hint = nil)
+    def capture_event(event, scope, hint = {})
       return false unless configuration.sending_allowed?
 
       scope.apply_to_event(event, hint)

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -35,7 +35,11 @@ module Sentry
           send_event(event, hint)
         end
       else
-        Sentry.background_worker.perform do
+        if hint.fetch(:background, true)
+          Sentry.background_worker.perform do
+            send_event(event, hint)
+          end
+        else
           send_event(event, hint)
         end
       end

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -97,7 +97,7 @@ module Sentry
     def capture_event(event, **options, &block)
       return unless current_client
 
-      hint = options.delete(:hint)
+      hint = options.delete(:hint) || {}
       scope = current_scope.dup
 
       if block

--- a/sentry-ruby/lib/sentry/rake.rb
+++ b/sentry-ruby/lib/sentry/rake.rb
@@ -5,7 +5,7 @@ module Rake
   class Application
     alias orig_display_error_messsage display_error_message
     def display_error_message(ex)
-      Sentry.capture_exception(ex) do |scope|
+      Sentry.capture_exception(ex, hint: { background: false }) do |scope|
         task_name = top_level_tasks.join(' ')
         scope.set_transaction_name(task_name)
         scope.set_tag("rake_task", task_name)

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -98,6 +98,14 @@ RSpec.describe Sentry::Client do
 
         expect(transport.events.count).to eq(1)
       end
+
+      context "with hint: { background: false }" do
+        it "sends the event immediately" do
+          subject.capture_event(event, scope, { background: false })
+
+          expect(transport.events.count).to eq(1)
+        end
+      end
     end
   end
 

--- a/sentry-sidekiq/lib/sentry/sidekiq/cleanup_middleware.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/cleanup_middleware.rb
@@ -12,7 +12,7 @@ module Sentry
           begin
             yield
           rescue => ex
-            Sentry.capture_exception(ex)
+            Sentry.capture_exception(ex, hint: { background: false })
           end
         end
       end

--- a/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
@@ -13,7 +13,8 @@ module Sentry
           scope.set_transaction_name transaction_from_context(context)
           Sentry.capture_exception(
             ex,
-            extra: { sidekiq: context }
+            extra: { sidekiq: context },
+            hint: { background: false }
           )
         end
       end


### PR DESCRIPTION
Users should be able to use `hint: { background: false }` to bypass the background worker on a per-event basis. This is necessary for some of our integrations as well. For example, Rake tasks might leave the process earlier than the background worker sending the event, which will cause the users to lose their events intermittently.