### PR TITLE
Add notification for users who still use deprecated middlewares

### DIFF
--- a/sentry-ruby/examples/sinatra/app.rb
+++ b/sentry-ruby/examples/sinatra/app.rb
@@ -6,7 +6,6 @@ Sentry.init do |config|
   config.traces_sample_rate = 1.0
 end
 
-# this needs to be places before the CaptureException middleware
 use Sentry::Rack::CaptureExceptions
 
 get "/exception" do

--- a/sentry-ruby/lib/sentry/rack.rb
+++ b/sentry-ruby/lib/sentry/rack.rb
@@ -2,3 +2,4 @@ require 'rack'
 
 require 'sentry/rack/capture_exceptions'
 require 'sentry/rack/interface'
+require 'sentry/rack/deprecations'

--- a/sentry-ruby/lib/sentry/rack/deprecations.rb
+++ b/sentry-ruby/lib/sentry/rack/deprecations.rb
@@ -1,0 +1,19 @@
+module Sentry
+  module Rack
+    class DeprecatedMiddleware
+      def initialize(_)
+        raise Sentry::Error.new <<~MSG
+
+You're seeing this message because #{self.class} has been replaced by Sentry::Rack::CaptureExceptions.
+Removing this middleware from your app and upgrading sentry-rails to 4.1.0+ should solve the issue.
+        MSG
+      end
+    end
+
+    class Tracing < DeprecatedMiddleware
+    end
+
+    class CaptureException < DeprecatedMiddleware
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/rack/deprecations_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/deprecations_spec.rb
@@ -1,0 +1,19 @@
+return unless defined?(Rack)
+
+require "spec_helper"
+
+RSpec.describe Sentry::Rack::Tracing, rack: true do
+  it "returns friendly message when this class is initialized" do
+    expect do
+      described_class.new({})
+    end.to raise_error(Sentry::Error)
+  end
+end
+
+RSpec.describe Sentry::Rack::CaptureException do
+  it "returns friendly message when this class is initialized" do
+    expect do
+      described_class.new({})
+    end.to raise_error(Sentry::Error)
+  end
+end


### PR DESCRIPTION
This will provide more information than just causing load errors 😓 