### PR TITLE
Fix NoMethodError when sending is not allowed

### DIFF
--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -21,7 +21,7 @@ module Sentry
     end
 
     def capture_event(event, scope, hint = {})
-      return false unless configuration.sending_allowed?
+      return unless configuration.sending_allowed?
 
       scope.apply_to_event(event, hint)
 

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -110,7 +110,7 @@ module Sentry
 
       event = current_client.capture_event(event, scope, hint)
 
-      @last_event_id = event.event_id
+      @last_event_id = event&.event_id
       event
     end
 

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Sentry::Client do
 
         returned = subject.capture_event(event, scope)
 
-        expect(returned).to eq(false)
+        expect(returned).to eq(nil)
       end
 
       context "when async raises an exception" do


### PR DESCRIPTION
Here's a full description of the issue https://github.com/getsentry/sentry-ruby/pull/1147#issuecomment-748155180

Stacktraces copied from the comment:

```
     NoMethodError:
       undefined method `event_id' for false:FalseClass
     Shared Example Group: "an unauthorized response" called from ./spec/requests/webhooks/slack_spec.rb:390
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sentry-ruby-4.1.0/lib/sentry/hub.rb:113:in `capture_event'
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sentry-ruby-4.1.0/lib/sentry/hub.rb:85:in `capture_exception'
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sentry-ruby-4.1.0/lib/sentry-ruby.rb:119:in `capture_exception'
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sentry-ruby-4.1.0/lib/sentry/rack/capture_exceptions.rb:28:in `rescue in block in call'
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sentry-ruby-4.1.0/lib/sentry/rack/capture_exceptions.rb:22:in `block in call'
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sentry-ruby-4.1.0/lib/sentry/hub.rb:50:in `with_scope'
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sentry-ruby-4.1.0/lib/sentry-ruby.rb:103:in `with_scope'
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sentry-ruby-4.1.0/lib/sentry/rack/capture_exceptions.rb:14:in `call'
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-cors-1.1.1/lib/rack/cors.rb:100:in `call'
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-6.0.3.4/lib/rails/engine.rb:527:in `call'
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-test-1.1.0/lib/rack/mock_session.rb:29:in `request'
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-test-1.1.0/lib/rack/test.rb:266:in `process_request'
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-test-1.1.0/lib/rack/test.rb:119:in `request'
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/actionpack-6.0.3.4/lib/action_dispatch/testing/integration.rb:270:in `process'
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/actionpack-6.0.3.4/lib/action_dispatch/testing/integration.rb:24:in `post'
     # /usr/local/var/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/actionpack-6.0.3.4/lib/action_dispatch/testing/integration.rb:359:in `block (2 levels) in <module:Runner>'
```