### PR TITLE
Improve top-level api safety

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix NoMethodError when sending is not allowed [#1161](https://github.com/getsentry/sentry-ruby/pull/1161)
 - Add notification for users who still use deprecated middlewares [#1160](https://github.com/getsentry/sentry-ruby/pull/1160)
+- Improve top-level api safety [#1161](https://github.com/getsentry/sentry-ruby/pull/1161)
 
 ## 4.1.0
 

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -79,7 +79,7 @@ module Sentry
     end
 
     def get_current_client
-      get_current_hub.current_client
+      get_current_hub&.current_client
     end
 
     def get_current_hub
@@ -96,15 +96,15 @@ module Sentry
     end
 
     def get_current_scope
-      get_current_hub.current_scope
+      get_current_hub&.current_scope
     end
 
     def with_scope(&block)
-      get_current_hub.with_scope(&block)
+      get_current_hub&.with_scope(&block)
     end
 
     def configure_scope(&block)
-      get_current_hub.configure_scope(&block)
+      get_current_hub&.configure_scope(&block)
     end
 
     def send_event(event)
@@ -112,23 +112,23 @@ module Sentry
     end
 
     def capture_event(event)
-      get_current_hub.capture_event(event)
+      get_current_hub&.capture_event(event)
     end
 
     def capture_exception(exception, **options, &block)
-      get_current_hub.capture_exception(exception, **options, &block)
+      get_current_hub&.capture_exception(exception, **options, &block)
     end
 
     def capture_message(message, **options, &block)
-      get_current_hub.capture_message(message, **options, &block)
+      get_current_hub&.capture_message(message, **options, &block)
     end
 
     def start_transaction(**options)
-      get_current_hub.start_transaction(**options)
+      get_current_hub&.start_transaction(**options)
     end
 
     def last_event_id
-      get_current_hub.last_event_id
+      get_current_hub&.last_event_id
     end
 
     def sys_command(command)

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -52,6 +52,17 @@ RSpec.describe Sentry do
   end
 
   shared_examples "capture_helper" do
+    context "without any Sentry setup" do
+      before do
+        allow(Sentry).to receive(:get_main_hub)
+        allow(Sentry).to receive(:get_current_hub)
+      end
+
+      it "doesn't cause any issue" do
+        described_class.send(capture_helper, capture_subject)
+      end
+    end
+
     context "with sending_allowed? condition" do
       before do
         expect(Sentry.configuration).to receive(:sending_allowed?).and_return(false)

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -1,12 +1,14 @@
 RSpec.describe Sentry do
   before do
-    Sentry.init do |config|
-      config.dsn = DUMMY_DSN
-    end
+    perform_basic_setup
   end
 
   let(:event) do
     Sentry::Event.new(configuration: Sentry::Configuration.new)
+  end
+
+  let(:transport) do
+    Sentry.get_current_client.transport
   end
 
   describe ".init" do
@@ -49,21 +51,46 @@ RSpec.describe Sentry do
     end
   end
 
-  describe ".capture_event" do
-    it "sends the event via current hub" do
-      expect(described_class.get_current_hub).to receive(:capture_event).with(event)
+  shared_examples "capture_helper" do
+    context "with sending_allowed? condition" do
+      before do
+        expect(Sentry.configuration).to receive(:sending_allowed?).and_return(false)
+      end
 
-      described_class.capture_event(event)
+      it "doesn't send the event nor assign last_event_id" do
+        described_class.send(capture_helper, capture_subject)
+
+        expect(transport.events).to be_empty
+        expect(subject.last_event_id).to eq(nil)
+      end
+    end
+  end
+
+  describe ".capture_event" do
+    it_behaves_like "capture_helper" do
+      let(:capture_helper) { :capture_event }
+      let(:capture_subject) { event }
+    end
+
+    it "sends the event via current hub" do
+      expect do
+        described_class.capture_event(event)
+      end.to change { transport.events.count }.by(1)
     end
   end
 
   describe ".capture_exception" do
     let(:exception) { ZeroDivisionError.new("divided by 0") }
 
-    it "sends the message via current hub" do
-      expect(described_class.get_current_hub).to receive(:capture_exception).with(exception, tags: { foo: "baz" })
+    it_behaves_like "capture_helper" do
+      let(:capture_helper) { :capture_exception }
+      let(:capture_subject) { exception }
+    end
 
-      described_class.capture_exception(exception, tags: { foo: "baz" })
+    it "sends the exception via current hub" do
+      expect do
+        described_class.capture_exception(exception, tags: { foo: "baz" })
+      end.to change { transport.events.count }.by(1)
     end
 
     it "doesn't do anything if the exception is excluded" do
@@ -72,6 +99,21 @@ RSpec.describe Sentry do
       result = described_class.capture_exception(exception)
 
       expect(result).to eq(nil)
+    end
+  end
+
+  describe ".capture_message" do
+    let(:message) { "Test" }
+
+    it_behaves_like "capture_helper" do
+      let(:capture_helper) { :capture_message }
+      let(:capture_subject) { message }
+    end
+
+    it "sends the message via current hub" do
+      expect do
+        described_class.capture_message("Test", tags: { foo: "baz" })
+      end.to change { transport.events.count }.by(1)
     end
   end
 
@@ -90,14 +132,6 @@ RSpec.describe Sentry do
 
         expect(transaction.sampled).to eq(false)
       end
-    end
-  end
-
-  describe ".capture_message" do
-    it "sends the message via current hub" do
-      expect(described_class.get_current_hub).to receive(:capture_message).with("Test", tags: { foo: "baz" })
-
-      described_class.capture_message("Test", tags: { foo: "baz" })
     end
   end
 


### PR DESCRIPTION
If the SDK is not initialized, the Sentry.get_current_hub will be nil, which will then cause NoMethodError when the user calls top-level APIs. This PR fixes this issue using the lonely operator.
