### PR TITLE
Transaction improvements

### DIFF
--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -4,6 +4,10 @@ module Sentry
       def collect_exception(env)
         super || env["action_dispatch.exception"]
       end
+
+      def transaction_op
+        "rails.request".freeze
+      end
     end
   end
 end

--- a/sentry-rails/lib/sentry/rails/controller_transaction.rb
+++ b/sentry-rails/lib/sentry/rails/controller_transaction.rb
@@ -2,10 +2,8 @@ module Sentry
   module Rails
     module ControllerTransaction
       def self.included(base)
-        base.prepend_around_action do |controller, block|
+        base.prepend_before_action do |controller|
           Sentry.get_current_scope.set_transaction_name("#{controller.class}##{controller.action_name}")
-          block.call
-          Sentry.get_current_scope.transaction_names.pop
         end
       end
     end

--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
       expect(event.dig(:contexts, :trace, :trace_id)).to eq(transaction.dig(:contexts, :trace, :trace_id))
 
       expect(transaction[:type]).to eq("transaction")
+      expect(transaction.dig(:contexts, :trace, :op)).to eq("rails.request")
       parent_span_id = transaction.dig(:contexts, :trace, :span_id)
       expect(transaction[:spans].count).to eq(2)
 
@@ -64,6 +65,7 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
       transaction = transport.events.last.to_hash
 
       expect(transaction[:type]).to eq("transaction")
+      expect(transaction.dig(:contexts, :trace, :op)).to eq("rails.request")
       parent_span_id = transaction.dig(:contexts, :trace, :span_id)
       expect(transaction[:spans].count).to eq(2)
 

--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
       described_class.remove_active_support_notifications_patch
     end
 
-    it "records transaction" do
+    it "records transaction with exception" do
       get "/posts"
 
       expect(transport.events.count).to eq(2)
@@ -54,9 +54,34 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
       expect(second_span[:op]).to eq("process_action.action_controller")
       expect(second_span[:description]).to eq("PostsController#index")
       expect(second_span[:parent_span_id]).to eq(parent_span_id)
+    end
 
-      # expect(second_span[:timestamp]).to be > first_span[:timestamp]
-      # expect(second_span[:start_timestamp]).to be < first_span[:start_timestamp]
+    it "records transaction alone" do
+      get "/posts/1"
+
+      expect(transport.events.count).to eq(1)
+
+      transaction = transport.events.last.to_hash
+
+      expect(transaction[:type]).to eq("transaction")
+      parent_span_id = transaction.dig(:contexts, :trace, :span_id)
+      expect(transaction[:spans].count).to eq(2)
+
+      first_span = transaction[:spans][0]
+      expect(first_span[:op]).to eq("sql.active_record")
+      expect(first_span[:description].squeeze("\s")).to eq(
+        'SELECT "posts".* FROM "posts" WHERE "posts"."id" = ? LIMIT ?'
+      )
+      expect(first_span[:parent_span_id]).to eq(parent_span_id)
+
+      # this is to make sure we calculate the timestamp in the correct scale (second instead of millisecond)
+      expect(first_span[:timestamp] - first_span[:start_timestamp]).to be <= 1
+
+      second_span = transaction[:spans][1]
+      expect(second_span[:op]).to eq("process_action.action_controller")
+      expect(second_span[:description]).to eq("PostsController#show")
+      expect(second_span[:parent_span_id]).to eq(parent_span_id)
+
     end
   end
 

--- a/sentry-rails/spec/support/test_rails_app/app.rb
+++ b/sentry-rails/spec/support/test_rails_app/app.rb
@@ -39,6 +39,10 @@ class PostsController < ActionController::Base
     Post.all.to_a
     raise "foo"
   end
+
+  def show
+    Post.find(params[:id])
+  end
 end
 
 class HelloController < ActionController::Base
@@ -83,7 +87,7 @@ def make_basic_app
     get "/view", :to => "hello#view"
     get "/not_found", :to => "hello#not_found"
     get "/world", to: "hello#world"
-    resources :posts, only: [:index]
+    resources :posts, only: [:index, :show]
     root :to => "hello#world"
   end
 

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -16,7 +16,7 @@ module Sentry
           scope.set_transaction_name(env["PATH_INFO"]) if env["PATH_INFO"]
           scope.set_rack_env(env)
 
-          span = Sentry.start_transaction(name: scope.transaction_name, op: "rack.request")
+          span = Sentry.start_transaction(name: scope.transaction_name, op: transaction_op)
           scope.set_span(span)
 
           begin
@@ -43,6 +43,10 @@ module Sentry
 
       def collect_exception(env)
         env['rack.exception'] || env['sinatra.error']
+      end
+
+      def transaction_op
+        "rack.request".freeze
       end
 
       def finish_span(span, status_code)

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -67,8 +67,9 @@ module Sentry
       # Convert to hash
       event_hash = event.to_hash
 
-      event_id = event_hash[:event_id] || event_hash['event_id']
-      configuration.logger.info(LOGGER_PROGNAME) { "Sending event #{event_id} to Sentry" }
+      event_id = event_hash[:event_id] || event_hash["event_id"]
+      event_type = event_hash[:type] || event_hash["type"]
+      configuration.logger.info(LOGGER_PROGNAME) { "Sending #{event_type} #{event_id} to Sentry" }
       encode(event_hash)
     end
 


### PR DESCRIPTION
This PR does several minor improvements:
1. Event sending message now distinguish event types, like: `Sending transaction 37c3e74081a246dcbf636d919448f4be to Sentry`.
2. Rails' transaction names should match the action name, like `PostsController#show`, instead of the request path.
3. Rails' transaction op should be `rails.request` instead of `rack.request`.