### PR TITLE
fix: retry jobs that raise exceptions

### DIFF
--- a/sentry-sidekiq/lib/sentry-sidekiq.rb
+++ b/sentry-sidekiq/lib/sentry-sidekiq.rb
@@ -1,7 +1,7 @@
 require "sidekiq"
 require "sentry-ruby"
 require "sentry/sidekiq/version"
-require "sentry/sidekiq/error_handler"
+require "sentry/sidekiq/event_error_handler"
 require "sentry/sidekiq/cleanup_middleware"
 # require "sentry/sidekiq/configuration"
 
@@ -16,7 +16,7 @@ module Sentry
 end
 
 Sidekiq.configure_server do |config|
-  config.error_handlers << Sentry::Sidekiq::ErrorHandler.new
+  config.error_handlers << Sentry::Sidekiq::EventErrorHandler.new
   config.server_middleware do |chain|
     chain.add Sentry::Sidekiq::CleanupMiddleware
   end


### PR DESCRIPTION
Thanks for your Pull Request 🎉 

**Please keep these instructions in mind so we can review it more efficiently:**

- Add the references of all the related issues/PRs in the description
- Whether it's a new feature or a bug fix, make sure they're covered by new test cases
- If this PR contains any refactoring work, please give it its own commit(s)


**Other Notes**
- We squash all commits before merging
- We generally review new PRs within a week
- If you have any question, you can ask for feedback in our [discord community](https://discord.gg/Ww9hbqr) first

## Description
Describe your changes:

CleanupMiddleware was swallowing exceptions raised in jobs, preventing
Sidekiq from adding the job to the retry queue. Re-raising from the
CleanupMiddleware led to a second firing from the ErrorHandler
class. To get around this, this commit narrows the scope of
ErrorHandler to only handle Sidekiq lifecycle events, and renames the
ErrorHandler class to EventErrorHandler accordingly.

Also fixes (I think) a second issue, where active job context key
renaming was not being applied on the CleanupMiddleware class, which
was the class responsible for firing job error events. Ensures that
the context filter is called in the CleanupMiddleware as well.

Addresses https://github.com/getsentry/sentry-ruby/issues/1173
