### PR TITLE
Remove DelayedJobAdapter from ignored list

### DIFF
--- a/sentry-rails/lib/sentry/rails/active_job.rb
+++ b/sentry-rails/lib/sentry/rails/active_job.rb
@@ -3,7 +3,6 @@ module Sentry
     module ActiveJobExtensions
       ALREADY_SUPPORTED_SENTRY_ADAPTERS = %w(
         ActiveJob::QueueAdapters::SidekiqAdapter
-        ActiveJob::QueueAdapters::DelayedJobAdapter
       ).freeze
 
       def self.included(base)


### PR DESCRIPTION
That adapter should be appended from the `sentry-delayed_job` integration, not in `sentry-rails`.