### PR TITLE
Inspect exception cause by default & don't exclude ActiveJob::DeserializationError 

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased (4.2.0)
+
+- Inspect exception cause by default & don't exclude ActiveJob::DeserializationError [#1180](https://github.com/getsentry/sentry-ruby/pull/1180)
+  - Fixes [#1071](https://github.com/getsentry/sentry-ruby/issues/1071)
+
 ## 4.1.4
 
 - Don't include headers & request info in tracing span or breadcrumb [#1199](https://github.com/getsentry/sentry-ruby/pull/1199)

--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -22,7 +22,6 @@ module Sentry
       'ActionController::UnknownFormat',
       'ActionController::UnknownHttpMethod',
       'ActionDispatch::Http::Parameters::ParseError',
-      'ActiveJob::DeserializationError', # Can cause infinite loops
       'ActiveRecord::RecordNotFound'
     ].freeze
     class Configuration

--- a/sentry-rails/spec/sentry/rails/activejob_spec.rb
+++ b/sentry-rails/spec/sentry/rails/activejob_spec.rb
@@ -51,6 +51,42 @@ RSpec.describe "ActiveJob integration" do
     expect(Sentry.get_current_scope.extra).to eq({})
   end
 
+  context "when DeserializationError happens in user's jobs" do
+    before do
+      make_basic_app
+    end
+
+    class DeserializationErrorJob < ActiveJob::Base
+      def perform
+        1/0
+      rescue
+        raise ActiveJob::DeserializationError
+      end
+    end
+
+    context "and in SentryJob too" do
+      before do
+        Sentry.configuration.async = lambda do |event|
+          SentryJob.perform_now(event)
+        end
+      end
+
+      class SentryJob < ActiveJob::Base
+        def perform(event)
+          Post.find(0)
+        rescue
+          raise ActiveJob::DeserializationError
+        end
+      end
+
+      it "doesn't cause infinite loop" do
+        expect do
+          DeserializationErrorJob.perform_now
+        end.to raise_error(ActiveJob::DeserializationError, /divided by 0/)
+      end
+    end
+  end
+
   context 'using rescue_from' do
     it 'does not trigger Sentry' do
       job = RescuedActiveJob.new

--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased (4.2.0)
 
 - Add ThreadsInterface [#1178](https://github.com/getsentry/sentry-ruby/pull/1178)
+- Inspect exception cause by default & don't exclude ActiveJob::DeserializationError [#1180](https://github.com/getsentry/sentry-ruby/pull/1180)
+  - Fixes [#1071](https://github.com/getsentry/sentry-ruby/issues/1071)
 
 ## 4.1.4
 

--- a/sentry-ruby/README.md
+++ b/sentry-ruby/README.md
@@ -158,6 +158,7 @@ config.async = lambda { |event, hint| SentryJob.perform_later(event, hint) }
 
 class SentryJob < ActiveJob::Base
   queue_as :default
+  discard_on ActiveJob::DeserializationError # this will prevent infinite loop when there's an issue deserializing SentryJob
 
   def perform(event, hint)
     Sentry.send_event(event, hint)

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -161,7 +161,7 @@ module Sentry
       self.enabled_environments = []
       self.exclude_loggers = []
       self.excluded_exceptions = IGNORE_DEFAULT.dup
-      self.inspect_exception_causes_for_exclusion = false
+      self.inspect_exception_causes_for_exclusion = true
       self.linecache = ::Sentry::LineCache.new
       self.logger = ::Sentry::Logger.new(STDOUT)
       self.project_root = detect_project_root

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -327,6 +327,10 @@ RSpec.describe Sentry::Configuration do
       context 'when the raised exception has a cause that is in excluded_exceptions' do
         let(:incoming_exception) { build_exception_with_cause(MyTestException.new) }
         context 'when inspect_exception_causes_for_exclusion is false' do
+          before do
+            subject.inspect_exception_causes_for_exclusion = false
+          end
+
           it 'returns true' do
             expect(subject.exception_class_allowed?(incoming_exception)).to eq true
           end


### PR DESCRIPTION
By turning on `inspect_exception_causes_for_exclusion` by default, the SDK will compare exceptions with their causes as well. This can prevent issues like #642. 

And because `ActiveJob::DeserializationError` was added to the `excluded_exceptions` list as a solution of #642, we can remove it now, which should solve #1071.

(changing the default value of `inspect_exception_causes_for_exclusion` is considered as a feature so this will be shipped in `4.2.0`)

closes #1071 