### PR TITLE
rm reference to old constant (from Rails v2.2)

### DIFF
--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -134,7 +134,6 @@ module Sentry
     # Most of these errors generate 4XX responses. In general, Sentry clients
     # only automatically report 5xx responses.
     IGNORE_DEFAULT = [
-      'CGI::Session::CookieStore::TamperedWithCookie',
       'Mongoid::Errors::DocumentNotFound',
       'Rack::QueryParser::InvalidParameterError',
       'Rack::QueryParser::ParameterTypeError',


### PR DESCRIPTION
## Description

[CGI::Session::CookieStore::TamperedWithCookie was defined](https://github.com/rails/rails/blob/2-2-stable/actionpack/lib/action_controller/session/cookie_store.rb#L49) as part of [an extension of Ruby's CGI](https://github.com/rails/rails/tree/2-2-stable/actionpack/lib/action_controller/cgi_ext) in Rails v2.2. So technically, it probably belongs in `sentry-rails` as opposed to `sentry-ruby`. However, this constant is no longer present in [Rails >= 5.0 (the requirement for `sentry-rails`)](https://github.com/getsentry/sentry-ruby/blob/master/sentry-rails/sentry-rails.gemspec#L25).

The `TamperedWithCookie` constant was [originally referenced by Raven in a refactor of its backtrace cleaner in 2012](https://github.com/getsentry/sentry-ruby/pull/58/files#diff-2337b0e4ecfcd526e8dbf0aa6f3a5570a2228c2cc71afdf6ba0edd4d361a40c2R45). The `CookieStore` was [removed from Rails in 2008 when ActionPack switched to using Rack-based sessions](https://github.com/rails/rails/commit/ed708307137c811d14e5fd2cb4ea550add381a82#diff-018dc029403b3cf53f21aef6fc77debda6e09c0739f6d7ff6a1331e40e5135eaL48).

_Note: this constant is also referred to by `sentry-raven` but I didn't bother removing it there since it's in maintenance mode._ 