### PR TITLE
Use copied env in events

### DIFF
--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -78,13 +78,21 @@ module Sentry
       unless request || env.empty?
         env = env.dup
 
+        if configuration.send_default_pii
+          if ip = calculate_real_ip_from_rack(env)
+            user[:ip_address] = ip
+          end
+        else
+          # need to completely wipe out ip addresses
+          RequestInterface::IP_HEADERS.each do |header|
+            env.delete(header)
+          end
+        end
+
         @request = Sentry::RequestInterface.new.tap do |int|
           int.from_rack(env)
         end
 
-        if configuration.send_default_pii && ip = calculate_real_ip_from_rack(env)
-          user[:ip_address] = ip
-        end
         if request_id = Utils::RequestId.read_from(env)
           tags[:request_id] = request_id
         end

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -76,11 +76,13 @@ module Sentry
 
     def rack_env=(env)
       unless request || env.empty?
+        env = env.dup
+
         @request = Sentry::RequestInterface.new.tap do |int|
           int.from_rack(env)
         end
 
-        if configuration.send_default_pii && ip = calculate_real_ip_from_rack(env.dup)
+        if configuration.send_default_pii && ip = calculate_real_ip_from_rack(env)
           user[:ip_address] = ip
         end
         if request_id = Utils::RequestId.read_from(env)

--- a/sentry-ruby/lib/sentry/rack/interface.rb
+++ b/sentry-ruby/lib/sentry/rack/interface.rb
@@ -6,9 +6,6 @@ module Sentry
       if Sentry.configuration.send_default_pii
         self.data = read_data_from(req)
         self.cookies = req.cookies
-      else
-        # need to completely wipe out ip addresses
-        IP_HEADERS.each { |h| env_hash.delete(h) }
       end
 
       self.url = req.scheme && req.url.split('?').first

--- a/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
@@ -14,24 +14,6 @@ RSpec.describe Sentry::RequestInterface do
     end
   end
 
-  it "removes ip address headers" do
-    ip = "1.1.1.1"
-
-    env.merge!(
-      "REMOTE_ADDR" => ip,
-      "HTTP_CLIENT_IP" => ip,
-      "HTTP_X_REAL_IP" => ip,
-      "HTTP_X_FORWARDED_FOR" => ip
-    )
-
-    interface.from_rack(env)
-
-    expect(interface.env).to_not include("REMOTE_ADDR")
-    expect(interface.headers.keys).not_to include("Client-Ip")
-    expect(interface.headers.keys).not_to include("X-Real-Ip")
-    expect(interface.headers.keys).not_to include("X-Forwarded-For")
-  end
-
   it 'excludes non whitelisted params from rack env' do
     additional_env = { "random_param" => "text", "query_string" => "test" }
     new_env = env.merge(additional_env)


### PR DESCRIPTION
Because Sentry now prepares/sends events in the background, sharing the same env object with the main thread means that the background worker & the main thread could process it at the same time. And since env is essentially a Hash object, this will trigger the:

```
RuntimeError: can't add a new key into hash during iteration
```

Hopefully, this can fix https://github.com/getsentry/sentry-ruby/issues/1183.

(It's possible that such issues could also be caused by sharing the underlying hash values, like params. But deep-copying the entire env hash could be costly so I want to see if this fix works first.)
