### PR TITLE
Refactor stacktrace parsing and increase test coverage

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Refactor RequestInterface [#1187](https://github.com/getsentry/sentry-ruby/pull/1187)
 - Supply event hint to async callback when possible [#1189](https://github.com/getsentry/sentry-ruby/pull/1189)
   - Fixes [#1188](https://github.com/getsentry/sentry-ruby/issues/1188)
+- Refactor stacktrace parsing and increase test coverage [#1190](https://github.com/getsentry/sentry-ruby/pull/1190)
 
 ## 4.1.2
 

--- a/sentry-ruby/lib/sentry/backtrace.rb
+++ b/sentry-ruby/lib/sentry/backtrace.rb
@@ -82,16 +82,14 @@ module Sentry
 
     # holder for an Array of Backtrace::Line instances
     attr_reader :lines
-    attr_reader :configuration
 
-    def self.parse(backtrace, configuration:)
+    def self.parse(backtrace, project_root, app_dirs_pattern, &backtrace_cleanup_callback)
       ruby_lines = backtrace.is_a?(Array) ? backtrace : backtrace.split(/\n\s*/)
 
-      ruby_lines = configuration.backtrace_cleanup_callback.call(ruby_lines) if configuration&.backtrace_cleanup_callback
+      ruby_lines = backtrace_cleanup_callback.call(ruby_lines) if backtrace_cleanup_callback
 
       in_app_pattern ||= begin
-        project_root = configuration.project_root&.to_s
-        Regexp.new("^(#{project_root}/)?#{configuration.app_dirs_pattern || APP_DIRS_PATTERN}")
+        Regexp.new("^(#{project_root}/)?#{app_dirs_pattern || APP_DIRS_PATTERN}")
       end
 
       lines = ruby_lines.to_a.map do |unparsed_line|

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -142,12 +142,7 @@ module Sentry
       project_root = configuration.project_root.to_s
 
       Backtrace.parse(backtrace, configuration: configuration).lines.reverse.each_with_object([]) do |line, memo|
-        frame = StacktraceInterface::Frame.new(project_root)
-        frame.abs_path = line.file if line.file
-        frame.function = line.method if line.method
-        frame.lineno = line.number
-        frame.in_app = line.in_app
-        frame.module = line.module_name if line.module_name
+        frame = StacktraceInterface::Frame.new(project_root, line)
 
         if configuration.context_lines && frame.abs_path
           frame.pre_context, frame.context_line, frame.post_context = \

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -141,7 +141,10 @@ module Sentry
     def collect_stacktrace_frames(backtrace)
       project_root = configuration.project_root.to_s
 
-      parsed_backtrace_lines = Backtrace.parse(backtrace, configuration: configuration).lines
+      parsed_backtrace_lines = Backtrace.parse(
+        backtrace, project_root, configuration.app_dirs_pattern, &configuration.backtrace_cleanup_callback
+      ).lines
+
       parsed_backtrace_lines.reverse.each_with_object([]) do |line, memo|
         frame = StacktraceInterface::Frame.new(project_root, line)
 

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -130,7 +130,7 @@ module Sentry
               if e.backtrace && !backtraces.include?(e.backtrace.object_id)
                 backtraces << e.backtrace.object_id
                 StacktraceInterface.new.tap do |stacktrace|
-                  stacktrace.frames = stacktrace_interface_from(e.backtrace)
+                  stacktrace.frames = collect_stacktrace_frames(e.backtrace)
                 end
               end
           end
@@ -138,7 +138,7 @@ module Sentry
       end
     end
 
-    def stacktrace_interface_from(backtrace)
+    def collect_stacktrace_frames(backtrace)
       project_root = configuration.project_root.to_s
 
       parsed_backtrace_lines = Backtrace.parse(backtrace, configuration: configuration).lines

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -141,15 +141,15 @@ module Sentry
     def stacktrace_interface_from(backtrace)
       project_root = configuration.project_root.to_s
 
-      Backtrace.parse(backtrace, configuration: configuration).lines.reverse.each_with_object([]) do |line, memo|
+      parsed_backtrace_lines = Backtrace.parse(backtrace, configuration: configuration).lines
+      parsed_backtrace_lines.reverse.each_with_object([]) do |line, memo|
         frame = StacktraceInterface::Frame.new(project_root, line)
 
-        if configuration.context_lines && frame.abs_path
-          frame.pre_context, frame.context_line, frame.post_context = \
-            configuration.linecache.get_file_context(frame.abs_path, frame.lineno, configuration.context_lines)
-        end
+        if frame.filename
+          frame.set_context(configuration.linecache, configuration.context_lines) if configuration.context_lines
 
-        memo << frame if frame.filename
+          memo << frame
+        end
       end
     end
 

--- a/sentry-ruby/lib/sentry/interfaces/stacktrace.rb
+++ b/sentry-ruby/lib/sentry/interfaces/stacktrace.rb
@@ -39,6 +39,13 @@ module Sentry
         @filename = prefix ? abs_path[prefix.to_s.chomp(File::SEPARATOR).length + 1..-1] : abs_path
       end
 
+      def set_context(linecache, context_lines)
+        return unless abs_path
+
+        self.pre_context, self.context_line, self.post_context = \
+            linecache.get_file_context(abs_path, lineno, context_lines)
+      end
+
       def to_hash(*args)
         data = super(*args)
         data[:filename] = filename

--- a/sentry-ruby/lib/sentry/interfaces/stacktrace.rb
+++ b/sentry-ruby/lib/sentry/interfaces/stacktrace.rb
@@ -13,8 +13,14 @@ module Sentry
       attr_accessor :abs_path, :context_line, :function, :in_app,
                     :lineno, :module, :pre_context, :post_context, :vars
 
-      def initialize(project_root)
+      def initialize(project_root, line)
         @project_root = project_root
+
+        @abs_path = line.file if line.file
+        @function = line.method if line.method
+        @lineno = line.number
+        @in_app = line.in_app
+        @module = line.module_name if line.module_name
       end
 
       def filename

--- a/sentry-ruby/spec/sentry/backtrace/lines_spec.rb
+++ b/sentry-ruby/spec/sentry/backtrace/lines_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+RSpec.describe Sentry::Backtrace::Line do
+  before do
+    perform_basic_setup
+  end
+  let(:unparsed_app_line) do
+    "app.rb:12:in `/'"
+  end
+  let(:unparsed_gem_line) do
+    "/PATH_TO_RUBY/gems/2.7.0/gems/sinatra-2.1.0/lib/sinatra/base.rb:1675:in `call'"
+  end
+
+  let(:in_app_pattern) do
+    project_root = Sentry.configuration.project_root&.to_s
+    Regexp.new("^(#{project_root}/)?#{Sentry::Backtrace::APP_DIRS_PATTERN}")
+  end
+
+  describe ".parse" do
+    it "parses app backtrace correctly" do
+      line = described_class.parse(unparsed_app_line, in_app_pattern)
+
+      expect(line.file).to eq("app.rb")
+      expect(line.number).to eq(12)
+      expect(line.method).to eq("/")
+      expect(line.in_app_pattern).to eq(in_app_pattern)
+      expect(line.module_name).to eq(nil)
+      expect(line.in_app).to eq(true)
+    end
+
+    it "parses gem backtrace correctly" do
+      line = described_class.parse(unparsed_gem_line, in_app_pattern)
+
+      expect(line.file).to eq(
+        "/PATH_TO_RUBY/gems/2.7.0/gems/sinatra-2.1.0/lib/sinatra/base.rb"
+      )
+      expect(line.number).to eq(1675)
+      expect(line.method).to eq("call")
+      expect(line.in_app_pattern).to eq(in_app_pattern)
+      expect(line.module_name).to eq(nil)
+      expect(line.in_app).to eq(false)
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/backtrace_spec.rb
+++ b/sentry-ruby/spec/sentry/backtrace_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Sentry::Backtrace do
   let(:configuration) { Sentry::Configuration.new }
   let(:backtrace) do
-    Sentry::Backtrace.parse(Thread.current.backtrace, configuration: configuration)
+    Sentry::Backtrace.parse(Thread.current.backtrace, configuration.project_root, configuration.app_dirs_pattern)
   end
 
   it "calls backtrace_cleanup_callback if it's present in the configuration" do
@@ -12,8 +12,7 @@ RSpec.describe Sentry::Backtrace do
       called = true
       backtrace
     end
-    configuration.backtrace_cleanup_callback = callback
-    Sentry::Backtrace.parse(Thread.current.backtrace, configuration: configuration)
+    Sentry::Backtrace.parse(Thread.current.backtrace, configuration.project_root, configuration.app_dirs_pattern, &callback)
 
     expect(called).to eq(true)
   end

--- a/sentry-ruby/spec/sentry/backtrace_spec.rb
+++ b/sentry-ruby/spec/sentry/backtrace_spec.rb
@@ -1,9 +1,43 @@
 require 'spec_helper'
 
 RSpec.describe Sentry::Backtrace do
-  let(:configuration) { Sentry::Configuration.new }
+  let(:fixture_root) { File.join(Dir.pwd, "spec", "support") }
+  let(:fixture_file) { File.join(fixture_root, "stacktrace_test_fixture.rb") }
+  let(:configuration) do
+    Sentry::Configuration.new.tap do |config|
+      config.project_root = fixture_root
+    end
+  end
+
   let(:backtrace) do
-    Sentry::Backtrace.parse(Thread.current.backtrace, configuration.project_root, configuration.app_dirs_pattern)
+    [
+      "#{fixture_file}:6:in `bar'",
+      "#{fixture_file}:2:in `foo'"
+    ]
+  end
+
+  let(:parsed_backtrace) do
+    described_class.parse(backtrace, fixture_root, configuration.app_dirs_pattern)
+  end
+
+  describe ".parse" do
+    it "returns an array of StacktraceInterface::Frames with correct information" do
+      lines = parsed_backtrace.lines.reverse
+
+      expect(lines.count).to eq(2)
+
+      first_line = lines.first
+
+      expect(first_line.file).to match(/stacktrace_test_fixture.rb/)
+      expect(first_line.method).to eq("foo")
+      expect(first_line.number).to eq(2)
+
+      second_line = lines.last
+
+      expect(second_line.file).to match(/stacktrace_test_fixture.rb/)
+      expect(second_line.method).to eq("bar")
+      expect(second_line.number).to eq(6)
+    end
   end
 
   it "calls backtrace_cleanup_callback if it's present in the configuration" do
@@ -18,19 +52,19 @@ RSpec.describe Sentry::Backtrace do
   end
 
   it "#lines" do
-    expect(backtrace.lines.first).to be_a(Sentry::Backtrace::Line)
+    expect(parsed_backtrace.lines.first).to be_a(Sentry::Backtrace::Line)
   end
 
   it "#inspect" do
-    expect(backtrace.inspect).to match(/Backtrace: .*>$/)
+    expect(parsed_backtrace.inspect).to match(/Backtrace: .*>$/)
   end
 
   it "#to_s" do
-    expect(backtrace.to_s).to match(/backtrace_spec.rb:\d/)
+    expect(parsed_backtrace.to_s).to match(/stacktrace_test_fixture.rb:\d/)
   end
 
   it "==" do
-    backtrace2 = Sentry::Backtrace.new(backtrace.lines)
-    expect(backtrace).to be == backtrace2
+    backtrace2 = Sentry::Backtrace.new(parsed_backtrace.lines)
+    expect(parsed_backtrace).to be == backtrace2
   end
 end

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -113,6 +113,49 @@ RSpec.describe Sentry::Event do
     end
   end
 
+  describe "#stacktrace_interface_from" do
+    let(:fixture_root) { File.join(Dir.pwd, "spec", "support") }
+    let(:fixture_file) { File.join(fixture_root, "stacktrace_test_fixture.rb") }
+    let(:configuration) do
+      Sentry::Configuration.new.tap do |config|
+        config.project_root = fixture_root
+      end
+    end
+
+    let(:backtrace) do
+      [
+        "#{fixture_file}:6:in `bar'",
+        "#{fixture_file}:2:in `foo'"
+      ]
+    end
+
+    subject do
+      described_class.new(configuration: configuration)
+    end
+
+    it "returns an array of StacktraceInterface::Frames with correct information" do
+      frames = subject.stacktrace_interface_from(backtrace)
+
+      first_frame = frames.first
+
+      expect(first_frame.filename).to match(/stacktrace_test_fixture.rb/)
+      expect(first_frame.function).to eq("foo")
+      expect(first_frame.lineno).to eq(2)
+      expect(first_frame.pre_context).to eq([nil, nil, "def foo\n"])
+      expect(first_frame.context_line).to eq("  bar\n")
+      expect(first_frame.post_context).to eq(["end\n", "\n", "def bar\n"])
+
+      second_frame = frames.last
+
+      expect(second_frame.filename).to match(/stacktrace_test_fixture.rb/)
+      expect(second_frame.function).to eq("bar")
+      expect(second_frame.lineno).to eq(6)
+      expect(second_frame.pre_context).to eq(["end\n", "\n", "def bar\n"])
+      expect(second_frame.context_line).to eq("  baz\n")
+      expect(second_frame.post_context).to eq(["end\n", nil, nil])
+    end
+  end
+
   describe '#to_json_compatible' do
     subject do
       Sentry::Event.new(configuration: configuration).tap do |event|

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Sentry::Event do
     end
   end
 
-  describe "#stacktrace_interface_from" do
+  describe "#collect_stacktrace_frames" do
     let(:fixture_root) { File.join(Dir.pwd, "spec", "support") }
     let(:fixture_file) { File.join(fixture_root, "stacktrace_test_fixture.rb") }
     let(:configuration) do
@@ -134,7 +134,7 @@ RSpec.describe Sentry::Event do
     end
 
     it "returns an array of StacktraceInterface::Frames with correct information" do
-      frames = subject.stacktrace_interface_from(backtrace)
+      frames = subject.collect_stacktrace_frames(backtrace)
 
       first_frame = frames.first
 

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Sentry::Event do
     end
   end
 
-  describe "#collect_stacktrace_frames" do
+  describe "#initialize_stacktrace_interface" do
     let(:fixture_root) { File.join(Dir.pwd, "spec", "support") }
     let(:fixture_file) { File.join(fixture_root, "stacktrace_test_fixture.rb") }
     let(:configuration) do
@@ -134,7 +134,10 @@ RSpec.describe Sentry::Event do
     end
 
     it "returns an array of StacktraceInterface::Frames with correct information" do
-      frames = subject.collect_stacktrace_frames(backtrace)
+      interface = subject.initialize_stacktrace_interface(backtrace)
+      expect(interface).to be_a(Sentry::StacktraceInterface)
+
+      frames = interface.frames
 
       first_frame = frames.first
 

--- a/sentry-ruby/spec/sentry/interfaces/stacktrace_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/stacktrace_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Sentry::StacktraceInterface::Frame do
       ]
     end
     let(:lines) do
-      Sentry::Backtrace.parse(raw_lines, configuration: configuration).lines
+      Sentry::Backtrace.parse(raw_lines, configuration.project_root, configuration.app_dirs_pattern).lines
     end
 
     it "initializes a Frame with the correct info from the given Backtrace::Line object" do

--- a/sentry-ruby/spec/sentry/interfaces/stacktrace_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/stacktrace_spec.rb
@@ -1,11 +1,32 @@
 require 'spec_helper'
 
 RSpec.describe Sentry::StacktraceInterface::Frame do
-  it "should convert pathnames to strings" do
-    frame = Sentry::StacktraceInterface::Frame.new(Sentry::Configuration.new.project_root)
-    $LOAD_PATH.unshift Pathname.pwd # Oh no, a Pathname in the $LOAD_PATH!
-    frame.abs_path = __FILE__
-    expect(frame.filename).to match(/stacktrace_spec.rb/)
-    $LOAD_PATH.shift
+  describe "#initialize" do
+    let(:configuration) { Sentry::Configuration.new }
+    let(:raw_lines) do
+      [
+        "#{__FILE__}:10:in `test_method'",
+        "#{configuration.project_root}/app/models/post.rb:5:in `save_user'"
+      ]
+    end
+    let(:lines) do
+      Sentry::Backtrace.parse(raw_lines, configuration: configuration).lines
+    end
+
+    it "initializes a Frame with the correct info from the given Backtrace::Line object" do
+      first_frame = Sentry::StacktraceInterface::Frame.new(configuration.project_root, lines.first)
+
+      expect(first_frame.filename).to match(/stacktrace_spec.rb/)
+      expect(first_frame.in_app).to eq(false)
+      expect(first_frame.function).to eq("test_method")
+      expect(first_frame.lineno).to eq(10)
+
+      second_frame = Sentry::StacktraceInterface::Frame.new(configuration.project_root, lines.last)
+
+      expect(second_frame.filename).to match(/post.rb/)
+      expect(second_frame.in_app).to eq(true)
+      expect(second_frame.function).to eq("save_user")
+      expect(second_frame.lineno).to eq(5)
+    end
   end
 end

--- a/sentry-ruby/spec/support/stacktrace_test_fixture.rb
+++ b/sentry-ruby/spec/support/stacktrace_test_fixture.rb
@@ -1,0 +1,7 @@
+def foo
+  bar
+end
+
+def bar
+  baz
+end


### PR DESCRIPTION
This PR moves all of the stacktrace parsing logic into the `StacktraceInterface`. It also adds more test cases around the stacktrace parsing results. 