### PR TITLE
Sentry.send_event should also take a hint

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Supply event hint to async callback when possible [#1189](https://github.com/getsentry/sentry-ruby/pull/1189)
   - Fixes [#1188](https://github.com/getsentry/sentry-ruby/issues/1188)
 - Refactor stacktrace parsing and increase test coverage [#1190](https://github.com/getsentry/sentry-ruby/pull/1190)
+- Sentry.send_event should also take a hint [#1192](https://github.com/getsentry/sentry-ruby/pull/1192)
 
 ## 4.1.2
 

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -54,6 +54,7 @@ module Sentry
   class << self
     extend Forwardable
 
+    def_delegators :get_current_client, :configuration, :send_event
     def_delegators :get_current_scope, :set_tags, :set_extras, :set_user
 
     attr_accessor :background_worker
@@ -85,10 +86,6 @@ module Sentry
       get_current_scope.breadcrumbs.record(breadcrumb, &block)
     end
 
-    def configuration
-      get_current_client.configuration
-    end
-
     def get_current_client
       get_current_hub&.current_client
     end
@@ -116,10 +113,6 @@ module Sentry
 
     def configure_scope(&block)
       get_current_hub&.configure_scope(&block)
-    end
-
-    def send_event(event)
-      get_current_client.send_event(event)
     end
 
     def capture_event(event)

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -77,6 +77,31 @@ RSpec.describe Sentry do
     end
   end
 
+  describe ".send_event" do
+    let(:event) { Sentry.get_current_client.event_from_message("test message") }
+
+    before do
+      Sentry.configuration.before_send = lambda do |event, hint|
+        event.tags[:hint] = hint
+        event
+      end
+    end
+
+    it "sends the event" do
+      described_class.send_event(event)
+
+      expect(transport.events.count).to eq(1)
+    end
+
+    it "sends the event with hint" do
+      described_class.send_event(event, { foo: "bar" })
+
+      expect(transport.events.count).to eq(1)
+      event = transport.events.last
+      expect(event.tags[:hint][:foo]).to eq("bar")
+    end
+  end
+
   describe ".capture_event" do
     it_behaves_like "capture_helper" do
       let(:capture_helper) { :capture_event }


### PR DESCRIPTION
`Sentry.send_event`'s behavior & parameters should always match `Client#send_event`. So this commit uses delegation to replace manual method definition.