### PR TITLE
Fix headers serialization for sentry-ruby

### DIFF
--- a/sentry-ruby/lib/sentry/interfaces/request.rb
+++ b/sentry-ruby/lib/sentry/interfaces/request.rb
@@ -68,7 +68,6 @@ module Sentry
       env.each_with_object({}) do |(key, value), memo|
         begin
           key = key.to_s # rack env can contain symbols
-          value = value.to_s
           next memo['X-Request-Id'] ||= Utils::RequestId.read_from(env) if Utils::RequestId::REQUEST_ID_HEADERS.include?(key)
           next if is_server_protocol?(key, value, env["SERVER_PROTOCOL"])
           next if is_skippable_header?(key)
@@ -76,7 +75,7 @@ module Sentry
           # Rack stores headers as HTTP_WHAT_EVER, we need What-Ever
           key = key.sub(/^HTTP_/, "")
           key = key.split('_').map(&:capitalize).join('-')
-          memo[key] = value
+          memo[key] = value.to_s
         rescue StandardError => e
           # Rails adds objects to the Rack env that can sometimes raise exceptions
           # when `to_s` is called.

--- a/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
@@ -58,6 +58,17 @@ RSpec.describe Sentry::RequestInterface do
         expect(interface.headers).to eq("Content-Length" => "0", "X-Request-Id" => "12345678")
       end
     end
+
+    context 'with additional env variables' do
+      let(:mock) { double }
+      let(:env) { { "some.variable" => mock } }
+
+      it 'does not call #to_s for unnecessary env variables' do
+        expect(mock).not_to receive(:to_s)
+
+        interface = described_class.from_rack(env)
+      end
+    end
   end
 
   it "doesn't capture cookies info" do


### PR DESCRIPTION
## Description
There is performance issue with `sentry-raven` and `sentry-ruby` gems.

In some cases different middlewares assign to `env` hash some large objects.
I.e. [grape](https://github.com/ruby-grape/grape) expose his routing in `env['grape.routing_args']` https://github.com/ruby-grape/grape/blob/02d7113d09eb9fcb4264c841d1fdd305e3e8adb5/lib/grape/util/env.rb#L22

In large applications it may be havy hash object. So when `sentry` try to cast this with `#to_s` that causes to large CPU consumption. I.e. in our application it takes around 45 sec to perform and almost 100% CPU load).
And the result just throwed away because this is not headers that needs to be in the event.

There are some demo that emulates this issue https://gist.github.com/moofkit/e1bf1ca0d3186aa7f9b89d3c3ee7fc58
You can try it with
```
$ make start
$ make test
> time curl 'http://localhost:9292/exception'
{"error":"An error ocurred"}       10.11 real         0.00 user         0.00 sys
```

Why it takes 10 secs of 5 is covered in this issue https://github.com/getsentry/sentry-ruby/issues/777

So, this little patch postpone `Object#to_s` after all headers checks in both `sentry-raven` and `sentry-ruby` gems