### PR TITLE
fix format headers for sentry-raven

### DIFF
--- a/sentry-raven/lib/raven/integrations/rack.rb
+++ b/sentry-raven/lib/raven/integrations/rack.rb
@@ -100,7 +100,6 @@ module Raven
       env_hash.each_with_object({}) do |(key, value), memo|
         begin
           key = key.to_s # rack env can contain symbols
-          value = value.to_s
           next memo['X-Request-Id'] ||= Utils::RequestId.read_from(env_hash) if Utils::RequestId::REQUEST_ID_HEADERS.include?(key)
           next unless key.upcase == key # Non-upper case stuff isn't either
 
@@ -116,7 +115,7 @@ module Raven
           # Rack stores headers as HTTP_WHAT_EVER, we need What-Ever
           key = key.sub(/^HTTP_/, "")
           key = key.split('_').map(&:capitalize).join('-')
-          memo[key] = value
+          memo[key] = value.to_s
         rescue StandardError => e
           # Rails adds objects to the Rack env that can sometimes raise exceptions
           # when `to_s` is called.

--- a/sentry-raven/spec/raven/integrations/rack_spec.rb
+++ b/sentry-raven/spec/raven/integrations/rack_spec.rb
@@ -126,6 +126,18 @@ RSpec.describe Raven::Rack do
         expect(interface.headers).to eq("Content-Length" => "0", "X-Request-Id" => "12345678")
       end
     end
+
+    context 'with additional env variables' do
+      let(:mock) { double }
+      let(:env) { { "some.variable" => mock } }
+
+      it 'does not call #to_s for unnecessary env variables' do
+        expect(mock).not_to receive(:to_s)
+
+        interface = Raven::HttpInterface.new
+        interface.from_rack(env)
+      end
+    end
   end
 
   it 'puts cookies into the cookies attribute' do


### PR DESCRIPTION
## Description
Postpone headers serialization in `sentry-raven`
More details in PR: https://github.com/getsentry/sentry-ruby/pull/1197


