### PR TITLE
Don't include headers & request info in tracing span or breadcrumb

### DIFF
--- a/sentry-rails/lib/sentry/rails/breadcrumb/active_support_logger.rb
+++ b/sentry-rails/lib/sentry/rails/breadcrumb/active_support_logger.rb
@@ -4,6 +4,13 @@ module Sentry
       module ActiveSupportLogger
         class << self
           def add(name, started, _finished, _unique_id, data)
+            if data.is_a?(Hash) && (data.key(:request) || data.key?(:headers))
+              # we should only mutate the copy of the data
+              data = data.dup
+              data.delete(:request)
+              data.delete(:headers)
+            end
+
             crumb = Sentry::Breadcrumb.new(
               data: data,
               category: name,

--- a/sentry-rails/lib/sentry/rails/tracing/action_controller_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/action_controller_subscriber.rb
@@ -15,6 +15,9 @@ module Sentry
               description: "#{controller}##{action}",
               duration: duration
             ) do |span|
+              payload = payload.dup
+              payload.delete(:headers)
+              payload.delete(:request)
               span.set_data(:payload, payload)
               span.set_http_status(payload[:status])
             end

--- a/sentry-rails/spec/sentry/rails/active_support_breadcrumbs_spec.rb
+++ b/sentry-rails/spec/sentry/rails/active_support_breadcrumbs_spec.rb
@@ -32,36 +32,16 @@ RSpec.describe "Sentry::Breadcrumbs::ActiveSupportLogger", type: :request do
     event = transport.events.first.to_json_compatible
     breadcrumbs = event.dig("breadcrumbs", "values")
     expect(breadcrumbs.count).to eq(2)
-
-    if Rails.version.match(/6\.1/)
-      expect(breadcrumbs.first["data"]).to match(
-        {
-          "controller" => "HelloController",
-          "action" => "exception",
-          "params" => { "controller" => "hello", "action" => "exception" },
-          "headers" => anything,
-          "request" => anything,
-          "view_runtime" => nil,
-          "format" => "html",
-          "method" => "GET",
-          "path" => "/exception",
-          "exception" => ["RuntimeError", "An unhandled exception!"],
-          "exception_object" => "An unhandled exception!"
-        }
-      )
-    else
-      expect(breadcrumbs.first["data"]).to match(
-        {
-          "controller" => "HelloController",
-          "action" => "exception",
-          "params" => { "controller" => "hello", "action" => "exception" },
-          "headers" => anything,
-          "format" => "html",
-          "method" => "GET",
-          "path" => "/exception"
-        }
-      )
-    end
+    expect(breadcrumbs.first["data"]).to match(
+      {
+        "controller" => "HelloController",
+        "action" => "exception",
+        "params" => { "controller" => "hello", "action" => "exception" },
+        "format" => "html",
+        "method" => "GET",
+        "path" => "/exception",
+      }
+    )
   end
 
   it "ignores events that doesn't have a started timestamp" do

--- a/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Sentry::Rails::Tracing::ActionControllerSubscriber, :subscriber, 
       expect(span[:op]).to eq("process_action.action_controller")
       expect(span[:description]).to eq("HelloController#world")
       expect(span[:trace_id]).to eq(transaction.dig(:contexts, :trace, :trace_id))
+      expect(span[:data][:payload].keys).not_to include(:request)
+      expect(span[:data][:payload].keys).not_to include(:headers)
     end
   end
 


### PR DESCRIPTION
Data like `request` or `headers` can be huge in some applications. They're also likely to contain complex data structure that's hard/impossible to serialize (some might cause infinite loop).

Consider those information should have been collected in the `request` interface of the event, storing them in breadcrumbs could cause more harm than benefit.