### PR TITLE
ci(release): Enable releases through centralized repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       sdk_name:
-        description: SDK to release (raven, rails, ruby, sidekiq)
+        description: SDK to release (sentry-raven, sentry-rails, sentry-ruby, sentry-sidekiq)
         required: true
       version:
         description: Version to release
@@ -25,6 +25,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         with:
-          path: sentry-${{ inputs.sdk_name }}
+          path: ${{ inputs.sdk_name }}
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
-name: release
+name: Release
 on:
   workflow_dispatch:
     inputs:
       sdk_name:
         description: SDK to release (raven, rails, ruby, sidekiq)
-        required: ture
+        required: true
       version:
         description: Version to release
         required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: release
+on:
+  workflow_dispatch:
+    inputs:
+      sdk_name:
+        description: SDK to release (raven, rails, ruby, sidekiq)
+        required: ture
+      version:
+        description: Version to release
+        required: true
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: "Release a new version"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_RELEASE_PAT }}
+          fetch-depth: 0
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+        with:
+          path: sentry-${{ inputs.sdk_name }}
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}


### PR DESCRIPTION
Depends on getsentry/action-prepare-release#6