### PR TITLE
Don't run RescuedExceptionInterceptor unless Sentry is initialized

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Don't run RescuedExceptionInterceptor unless Sentry is initialized [#1204](https://github.com/getsentry/sentry-ruby/pull/1204)
+
 ## 4.1.3
 
 - Remove DelayedJobAdapter from ignored list [#1179](https://github.com/getsentry/sentry-ruby/pull/1179)

--- a/sentry-rails/lib/sentry/rails/rescued_exception_interceptor.rb
+++ b/sentry-rails/lib/sentry/rails/rescued_exception_interceptor.rb
@@ -6,6 +6,8 @@ module Sentry
       end
 
       def call(env)
+        return @app.call(env) unless Sentry.initialized?
+
         begin
           @app.call(env)
         rescue => e


### PR DESCRIPTION
This should avoid errors like #1203 (although the SDK itself is not the root cause of this issue)