### PR TITLE
Support capturing "sentry-trace" header from the middleware

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support capturing "sentry-trace" header from the middleware [#1205](https://github.com/getsentry/sentry-ruby/pull/1205)
+
 ## 4.1.3
 
 - rm reference to old constant (from Rails v2.2) [#1184](https://github.com/getsentry/sentry-ruby/pull/1184)

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -16,7 +16,13 @@ module Sentry
           scope.set_transaction_name(env["PATH_INFO"]) if env["PATH_INFO"]
           scope.set_rack_env(env)
 
-          span = Sentry.start_transaction(name: scope.transaction_name, op: transaction_op)
+          span =
+            if sentry_trace = env["sentry-trace"]
+              Sentry::Transaction.from_sentry_trace(sentry_trace, name: scope.transaction_name, op: transaction_op)
+            else
+              Sentry.start_transaction(name: scope.transaction_name, op: transaction_op)
+            end
+
           scope.set_span(span)
 
           begin

--- a/sentry-ruby/lib/sentry/span.rb
+++ b/sentry-ruby/lib/sentry/span.rb
@@ -69,6 +69,7 @@ module Sentry
       {
         trace_id: @trace_id,
         span_id: @span_id,
+        parent_span_id: @parent_span_id,
         description: @description,
         op: @op,
         status: @status

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -123,7 +123,7 @@ module Sentry
         @name = UNLABELD_NAME
       end
 
-      return unless @sampled
+      return unless @sampled || @parent_sampled
 
       hub ||= Sentry.get_current_hub
       event = hub.current_client.event_from_transaction(self)


### PR DESCRIPTION
When `sentry-trace` is provided in the header, we should start the transaction with the information from the trace, including:

1. trace_id
2. parent_span_id
3. sampled

Closes #1200 