### PR TITLE
Print deprecation message after sentry-raven is installed

### DIFF
--- a/sentry-raven/sentry-raven.gemspec
+++ b/sentry-raven/sentry-raven.gemspec
@@ -18,4 +18,11 @@ Gem::Specification.new do |gem|
   gem.executables = "raven"
 
   gem.add_dependency "faraday", ">= 1.0"
+
+  gem.post_install_message = <<~EOS
+    `sentry-raven` is deprecated! Please migrate to `sentry-ruby`
+
+    See https://docs.sentry.io/platforms/ruby/migration for the migration guide.
+
+  EOS
 end


### PR DESCRIPTION
# Context
`sentry-raven` has entered maintenance mode and I think `sentry-raven` users should migrate to `sentry-raven`.
However, `sentry-raven` users who just do `bundle update` are hard to notice this...

So I printed a message prompting the migration when gem is installed.

# Example
```bash
$ bundle exec rake build
sentry-raven 3.1.1 built to pkg/sentry-raven-3.1.1.gem.

$ gem install --no-doc ./pkg/sentry-raven-3.1.1.gem
`sentry-raven` is deprecated! Please migrate to `sentry-ruby`

See https://docs.sentry.io/platforms/ruby/migration for the migration guide.

Successfully installed sentry-raven-3.1.1
1 gem installed
```

