### PR TITLE
Inline global method

### DIFF
--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -13,15 +13,16 @@ require "sentry/transaction"
 require "sentry/hub"
 require "sentry/background_worker"
 
-def safely_require(lib)
+
+[
+  "sentry/rake",
+  "sentry/rack",
+].each do |lib|
   begin
     require lib
   rescue LoadError
   end
 end
-
-safely_require "sentry/rake"
-safely_require "sentry/rack"
 
 module Sentry
   class Error < StandardError


### PR DESCRIPTION
It is a good practice to avoid global method definition.
When method is defined in globally, this method can be called from outside of gem.
It may affect other gems that have the same named method.
