### PR TITLE
Add `ActionDispatch::Http::MimeNegotiation::InvalidType` to the list of default ignored Rails exceptions

### DIFF
--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -20,6 +20,7 @@ module Sentry
       'ActionController::RoutingError',
       'ActionController::UnknownAction',
       'ActionController::UnknownFormat',
+      'ActionDispatch::Http::MimeNegotiation::InvalidType',
       'ActionController::UnknownHttpMethod',
       'ActionDispatch::Http::Parameters::ParseError',
       'ActiveJob::DeserializationError', # Can cause infinite loops


### PR DESCRIPTION
`ActionDispatch::Http::MimeNegotiation::InvalidType` was introduced in rails/rails#40353 to allow services like Sentry to more specifically target this situation and ignore the exception.

It will be introduced in the next version of Rails 6.0.x, and is already released in 6.1.