### PR TITLE
Continue ActiveJob execution if Sentry is not initialized

### DIFF
--- a/sentry-rails/lib/sentry/rails/active_job.rb
+++ b/sentry-rails/lib/sentry/rails/active_job.rb
@@ -8,12 +8,16 @@ module Sentry
       def self.included(base)
         base.class_eval do
           around_perform do |job, block|
-            if already_supported_by_specific_integration?(job)
-              block.call
-            else
-              Sentry.with_scope do
-                capture_and_reraise_with_sentry(job, block)
+            if Sentry.initialized?
+              if already_supported_by_specific_integration?(job)
+                block.call
+              else
+                Sentry.with_scope do
+                  capture_and_reraise_with_sentry(job, block)
+                end
               end
+            else
+              block.call
             end
           end
         end

--- a/sentry-rails/spec/sentry/rails/activejob_spec.rb
+++ b/sentry-rails/spec/sentry/rails/activejob_spec.rb
@@ -1,14 +1,20 @@
 require "spec_helper"
 
-class MyActiveJob < ActiveJob::Base
+class FailedJob < ActiveJob::Base
   self.logger = nil
 
   class TestError < RuntimeError
   end
 
   def perform
-    Sentry.get_current_scope.set_extras(foo: :bar)
     raise TestError, "Boom!"
+  end
+end
+
+class MyActiveJob < FailedJob
+  def perform
+    Sentry.get_current_scope.set_extras(foo: :bar)
+    super
   end
 end
 
@@ -16,6 +22,18 @@ class RescuedActiveJob < MyActiveJob
   rescue_from TestError, :with => :rescue_callback
 
   def rescue_callback(error); end
+end
+
+RSpec.describe "without Sentry initialized" do
+  before(:each) do
+    FailedJob.queue_adapter = :inline
+  end
+
+  it "runs job" do
+    job = FailedJob.new
+
+    expect { job.perform_now }.to raise_error(FailedJob::TestError)
+  end
 end
 
 RSpec.describe "ActiveJob integration" do


### PR DESCRIPTION
Sentry.with_scope will swallow the block when the SDK is not initialized. So when users initialize the SDK conditionally, sometimes the job won't be executed at all.

This fixes #1216 and #1211