### PR TITLE
Filter out redundant event/payload from breadcrumbs logger

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased (4.1.5)
+
+- Filter out redundant event/payload from breadcrumbs logger [#1222](https://github.com/getsentry/sentry-ruby/pull/1222)
+
 ## 4.1.4
 
 - Don't include headers & request info in tracing span or breadcrumb [#1199](https://github.com/getsentry/sentry-ruby/pull/1199)

--- a/sentry-rails/lib/sentry/rails/breadcrumb/active_support_logger.rb
+++ b/sentry-rails/lib/sentry/rails/breadcrumb/active_support_logger.rb
@@ -3,12 +3,13 @@ module Sentry
     module Breadcrumb
       module ActiveSupportLogger
         class << self
+          IGNORED_DATA_TYPES = [:request, :headers, :exception, :exception_object]
+
           def add(name, started, _finished, _unique_id, data)
-            if data.is_a?(Hash) && (data.key(:request) || data.key?(:headers))
+            if data.is_a?(Hash)
               # we should only mutate the copy of the data
               data = data.dup
-              data.delete(:request)
-              data.delete(:headers)
+              cleanup_data(data)
             end
 
             crumb = Sentry::Breadcrumb.new(
@@ -17,6 +18,12 @@ module Sentry
               timestamp: started.to_i
             )
             Sentry.add_breadcrumb(crumb)
+          end
+
+          def cleanup_data(data)
+            IGNORED_DATA_TYPES.each do |key|
+              data.delete(key) if data.key?(key)
+            end
           end
 
           def inject

--- a/sentry-rails/lib/sentry/rails/breadcrumb/active_support_logger.rb
+++ b/sentry-rails/lib/sentry/rails/breadcrumb/active_support_logger.rb
@@ -6,6 +6,9 @@ module Sentry
           IGNORED_DATA_TYPES = [:request, :headers, :exception, :exception_object]
 
           def add(name, started, _finished, _unique_id, data)
+            # skip Rails' internal events
+            return if name.start_with?("!")
+
             if data.is_a?(Hash)
               # we should only mutate the copy of the data
               data = data.dup


### PR DESCRIPTION
- Removes potentially large payload from breadcrumbs. They're likely to make the event exceed size limit and be rejected by Sentry.
- Ignores Rails' internal instrumentation events (names start with `!`)