### PR TITLE
Don't subscribe render_partial and render_collection events

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Filter out redundant event/payload from breadcrumbs logger [#1222](https://github.com/getsentry/sentry-ruby/pull/1222)
 - Copy request env before Rails' ShowExceptions middleware [#1223](https://github.com/getsentry/sentry-ruby/pull/1223)
+- Don't subscribe render_partial and render_collection events [#1224](https://github.com/getsentry/sentry-ruby/pull/1224)
 
 ## 4.1.4
 

--- a/sentry-rails/lib/sentry/rails/tracing/action_view_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/action_view_subscriber.rb
@@ -2,19 +2,11 @@ module Sentry
   module Rails
     module Tracing
       class ActionViewSubscriber < AbstractSubscriber
-        EVENT_NAMES = ["render_template.action_view", "render_partial.action_view", "render_collection.action_view"]
+        EVENT_NAME = "render_template.action_view".freeze
 
         def self.subscribe!
-          EVENT_NAMES.each do |event_name|
-            subscribe_to_event(event_name) do |event_name, duration, payload|
-              record_on_current_span(op: event_name, start_timestamp: payload[:start_timestamp], description: payload[:identifier], duration: duration)
-            end
-          end
-        end
-
-        def self.unsubscribe!
-          EVENT_NAMES.each do |event_name|
-            ActiveSupport::Notifications.unsubscribe(event_name)
+          subscribe_to_event(EVENT_NAME) do |event_name, duration, payload|
+            record_on_current_span(op: event_name, start_timestamp: payload[:start_timestamp], description: payload[:identifier], duration: duration)
           end
         end
       end


### PR DESCRIPTION
As described in #1214, they're not very necessary and could create noise that'll push out other useful data of the view.