### PR TITLE
Add sentry-ruby-core as a more flexible option

### DIFF
--- a/sentry-ruby/.craft.yml
+++ b/sentry-ruby/.craft.yml
@@ -11,9 +11,23 @@ artifactProvider:
   name: github
 targets:
     - name: gem
+      onlyIfPresent: /^sentry-ruby$/
     - name: github
+      onlyIfPresent: /^sentry-ruby$/
       tagPrefix: sentry-ruby-v
     - name: registry
+      onlyIfPresent: /^sentry-ruby$/
       type: sdk
       config:
           canonical: 'gem:sentry-ruby'
+
+    - name: gem
+      onlyIfPresent: /^sentry-ruby-core$/
+    - name: github
+      onlyIfPresent: /^sentry-ruby-core$/
+      tagPrefix: sentry-ruby-v
+    - name: registry
+      onlyIfPresent: /^sentry-ruby-core$/
+      type: sdk
+      config:
+          canonical: 'gem:sentry-ruby-core'

--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## Unreleased (4.1.5)
+## 4.1.5
 
 - Event message and exception message should have a size limit [#1221](https://github.com/getsentry/sentry-ruby/pull/1221)
+- Add sentry-ruby-core as a more flexible option [#1226](https://github.com/getsentry/sentry-ruby/pull/1226)
 
 ## 4.1.4
 

--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in sentry-ruby.gemspec
-gemspec
+gem "sentry-ruby-core", path: "./"
+gem "sentry-ruby", path: "./"
 
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"

--- a/sentry-ruby/Rakefile
+++ b/sentry-ruby/Rakefile
@@ -1,4 +1,9 @@
-require "bundler/gem_tasks"
+require "rake/clean"
+CLOBBER.include "pkg"
+
+require "bundler/gem_helper"
+Bundler::GemHelper.install_tasks(name: "sentry-ruby")
+
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec).tap do |task|

--- a/sentry-ruby/sentry-ruby-core.gemspec
+++ b/sentry-ruby/sentry-ruby-core.gemspec
@@ -1,7 +1,7 @@
 require_relative "lib/sentry/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "sentry-ruby"
+  spec.name          = "sentry-ruby-core"
   spec.version       = Sentry::VERSION
   spec.authors = ["Sentry Team"]
   spec.description = spec.summary = "A gem that provides a client interface for the Sentry error logger"
@@ -12,12 +12,16 @@ Gem::Specification.new do |spec|
   spec.platform = Gem::Platform::RUBY
   spec.required_ruby_version = '>= 2.4'
   spec.extra_rdoc_files = ["README.md", "LICENSE.txt"]
+  spec.files = `git ls-files | grep -Ev '^(spec|benchmarks|examples)'`.split("\n")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"
 
-  spec.add_dependency "sentry-ruby-core", Sentry::VERSION
-  spec.add_dependency "faraday", ">= 1.0"
-  spec.add_dependency "concurrent-ruby", '~> 1.0', '>= 1.0.2'
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "faraday"
+  spec.add_dependency "concurrent-ruby"
 end


### PR DESCRIPTION
This won't affect any users of `sentry-ruby`, but some users can now use `sentry-ruby-core` without worrying about dependency issues.