### PR TITLE
Prevent exceptions app from overriding event's transaction name

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Prevent exceptions app from overriding event's transaction name [#1230](https://github.com/getsentry/sentry-ruby/pull/1230)
+
 ## 4.1.5
 
 - Add `ActionDispatch::Http::MimeNegotiation::InvalidType` to the list of default ignored Rails exceptions [#1215](https://github.com/getsentry/sentry-ruby/pull/1215) (by @agrobbin)

--- a/sentry-rails/lib/sentry/rails/rescued_exception_interceptor.rb
+++ b/sentry-rails/lib/sentry/rails/rescued_exception_interceptor.rb
@@ -18,6 +18,13 @@ module Sentry
           if request.show_exceptions?
             scope = Sentry.get_current_scope
             scope.set_rack_env(scope.rack_env.dup)
+            transaction = scope.transaction_name
+
+            # we also need to make sure the transaction name won't be overridden by the exceptions app
+            scope.add_event_processor do |event, hint|
+              event.transaction = transaction
+              event
+            end
           end
 
           env["sentry.rescued_exception"] = e if Sentry.configuration.rails.report_rescued_exceptions

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -1,10 +1,6 @@
 require "spec_helper"
 
 RSpec.describe Sentry::Rails, type: :request do
-  before do
-    make_basic_app
-  end
-
   let(:transport) do
     Sentry.get_current_client.transport
   end
@@ -17,14 +13,44 @@ RSpec.describe Sentry::Rails, type: :request do
     transport.events = []
   end
 
-  it "has version set" do
-    expect(described_class::VERSION).to be_a(String)
-  end
+  context "with simplist config" do
+    before do
+      make_basic_app
+    end
 
-  it "inserts middleware to a correct position" do
-    app = Rails.application
-    expect(app.middleware.find_index(Sentry::Rails::CaptureExceptions)).to eq(0)
-    expect(app.middleware.find_index(Sentry::Rails::RescuedExceptionInterceptor)).to eq(app.middleware.count - 1)
+    it "has version set" do
+      expect(described_class::VERSION).to be_a(String)
+    end
+
+    it "inserts middleware to a correct position" do
+      app = Rails.application
+      expect(app.middleware.find_index(Sentry::Rails::CaptureExceptions)).to eq(0)
+      expect(app.middleware.find_index(Sentry::Rails::RescuedExceptionInterceptor)).to eq(app.middleware.count - 1)
+    end
+
+    it "sets Sentry.configuration.logger correctly" do
+      expect(Sentry.configuration.logger).to eq(Rails.logger)
+    end
+
+    it "sets Sentry.configuration.project_root correctly" do
+      expect(Sentry.configuration.project_root).to eq(Rails.root.to_s)
+    end
+
+    it "doesn't clobber a manually configured release" do
+      expect(Sentry.configuration.release).to eq('beta')
+    end
+
+    it "sets transaction to ControllerName#method" do
+      get "/exception"
+
+      expect(event['transaction']).to eq("HelloController#exception")
+    end
+
+    it "sets correct request url" do
+      get "/exception"
+
+      expect(event.dig("request", "url")).to eq("http://www.example.com/exception")
+    end
   end
 
   context "with development config" do
@@ -116,28 +142,24 @@ RSpec.describe Sentry::Rails, type: :request do
       end
     end
 
-    it "sets transaction to ControllerName#method" do
-      get "/exception"
+    context "with config.exceptions_app = self.routes" do
+      before do
+        make_basic_app do |config, app|
+          app.config.exceptions_app = app.routes
+        end
+      end
 
-      expect(event['transaction']).to eq("HelloController#exception")
+      it "sets transaction to ControllerName#method" do
+        get "/exception"
+
+        expect(event['transaction']).to eq("HelloController#exception")
+      end
+
+      it "sets correct request url" do
+        get "/exception"
+
+        expect(event.dig("request", "url")).to eq("http://www.example.com/exception")
+      end
     end
-
-    it "sets correct request url" do
-      get "/exception"
-
-      expect(event.dig("request", "url")).to eq("http://www.example.com/exception")
-    end
-  end
-
-  it "sets Sentry.configuration.logger correctly" do
-    expect(Sentry.configuration.logger).to eq(Rails.logger)
-  end
-
-  it "sets Sentry.configuration.project_root correctly" do
-    expect(Sentry.configuration.project_root).to eq(Rails.root.to_s)
-  end
-
-  it "doesn't clobber a manually configured release" do
-    expect(Sentry.configuration.release).to eq('beta')
   end
 end

--- a/sentry-rails/spec/support/test_rails_app/app.rb
+++ b/sentry-rails/spec/support/test_rails_app/app.rb
@@ -51,6 +51,10 @@ class HelloController < ActionController::Base
     raise "An unhandled exception!"
   end
 
+  def reporting
+    head :ok
+  end
+
   def view_exception
     render inline: "<%= foo %>"
   end
@@ -87,6 +91,7 @@ def make_basic_app
     get "/not_found", :to => "hello#not_found"
     get "/world", to: "hello#world"
     resources :posts, only: [:index, :show]
+    get "500", to: "hello#reporting"
     root :to => "hello#world"
   end
 


### PR DESCRIPTION

> Because exceptions app also works like a normal controller action, when
it renders the exception, it'll push a new transaction name to the scope
as well. But that's not the transaction name we want to display in
Sentry.
> But unlike how we deal with the rack env overriding issue, this time we
need to use event processors to replace the transaction name.

This should address the issue mentioned in https://github.com/getsentry/sentry-ruby/issues/1219#issuecomment-765570507