### PR TITLE
Serialize event hint before passing it to the async block

### DIFF
--- a/sentry-rails/examples/rails-6.0/config/application.rb
+++ b/sentry-rails/examples/rails-6.0/config/application.rb
@@ -19,5 +19,7 @@ module Rails60
 
     # https://github.com/getsentry/raven-ruby/issues/494
     config.exceptions_app = self.routes
+
+    config.webpacker.check_yarn_integrity = false
   end
 end

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -32,6 +32,7 @@ module Sentry
           event_hash = event.to_json_compatible
 
           if async_block.arity == 2
+            hint = JSON.parse(JSON.generate(hint))
             async_block.call(event_hash, hint)
           else
             async_block.call(event_hash)

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -80,14 +80,14 @@ RSpec.describe Sentry::Client do
           end
         end
 
-        it "supplies hint as the second argument" do
+        it "serializes hint and supplies it as the second argument" do
           expect(configuration.async).to receive(:call).and_call_original
 
           returned = subject.capture_event(event, scope, { foo: "bar" })
 
           expect(returned).to be_a(Sentry::Event)
           event = subject.transport.events.first
-          expect(event.dig("tags", "hint")).to eq({ foo: "bar" })
+          expect(event.dig("tags", "hint")).to eq({ "foo" => "bar" })
         end
       end
 


### PR DESCRIPTION
Event hint should also be serialized into a json-compatible hash to make sure ActiveJob can process it correctly.

Closes #1227 