### PR TITLE
Require the English library

### DIFF
--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -1,3 +1,4 @@
+require "English"
 require "forwardable"
 require "time"
 


### PR DESCRIPTION
https://ruby-doc.org/stdlib-2.7.1/libdoc/English/rdoc/English.html

Should get rid of this warning:

```ruby
irb(main):001:0> Sentry.init {}
/Users/dentarg/.gem/ruby/2.7.1/gems/sentry-ruby-4.1.4/lib/sentry-ruby.rb:177: warning: global variable `$CHILD_STATUS' not initialized
```