### PR TITLE
Allow `Sentry.init` without block argument

### DIFF
--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -65,7 +65,7 @@ module Sentry
 
     def init(&block)
       config = Configuration.new
-      yield(config)
+      yield(config) if block_given?
       client = Client.new(config)
       scope = Scope.new
       hub = Hub.new(client, scope)

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -12,15 +12,30 @@ RSpec.describe Sentry do
   end
 
   describe ".init" do
-    it "initializes the current hub and main hub" do
-      described_class.init do |config|
-        config.dsn = DUMMY_DSN
-      end
+    context "with block argument" do
+      it "initializes the current hub and main hub" do
+        described_class.init do |config|
+          config.dsn = DUMMY_DSN
+        end
 
-      current_hub = described_class.get_current_hub
-      expect(current_hub).to be_a(Sentry::Hub)
-      expect(current_hub.current_scope).to be_a(Sentry::Scope)
-      expect(subject.get_main_hub).to eq(current_hub)
+        current_hub = described_class.get_current_hub
+        expect(current_hub).to be_a(Sentry::Hub)
+        expect(current_hub.current_scope).to be_a(Sentry::Scope)
+        expect(subject.get_main_hub).to eq(current_hub)
+      end
+    end
+
+    context "without block argument" do
+      it "initializes the current hub and main hub" do
+        ENV['SENTRY_DSN'] = DUMMY_DSN
+
+        described_class.init
+
+        current_hub = described_class.get_current_hub
+        expect(current_hub).to be_a(Sentry::Hub)
+        expect(current_hub.current_scope).to be_a(Sentry::Scope)
+        expect(subject.get_main_hub).to eq(current_hub)
+      end
     end
   end
 


### PR DESCRIPTION
## Description
When `SENTRY_DSN` has been passed from environment variable, `config.dsn` in `Sentry.init` is needless.

But simply call  `Sentry.init` will result in an error

e.g.

```ruby
# example.rb
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "sentry-ruby", "4.1.4"
end

require "sentry-ruby"

Sentry.init
```

```bash
$ SENTRY_DSN=xxxxxx ruby example.rb

/Users/sue445/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/sentry-ruby-4.1.4/lib/sentry-ruby.rb:67:in `init': no block given (yield) (LocalJumpError)
	from example.rb:10:in `<main>'
```

The workaround is below, but it's a bit dirty...

```ruby
Sentry.init do
  # nop
end

# or

Sentry.init {  }
```

So I made it possible to call `Sentry.init` without block