### PR TITLE
CI: Workaround YAML gotcha in Actions

### DIFF
--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -19,10 +19,10 @@ jobs:
     strategy:
       matrix:
         rails_version: [5.2, 6.0.0, 6.1.0]
-        ruby_version: [2.4, 2.5, 2.6, 2.7, 3.0, jruby]
+        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', jruby]
         os: [ubuntu-latest]
         include:
-          - ruby_version: 3.0
+          - ruby_version: '3.0'
             rails_version: 6.1.0
             env: RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
         exclude:
@@ -30,7 +30,7 @@ jobs:
             rails_version: 6.0.0
           - ruby_version: 2.4
             rails_version: 6.1.0
-          - ruby_version: 3.0
+          - ruby_version: '3.0'
             rails_version: 5.2
           - ruby_version: jruby
             rails_version: 6.1.0

--- a/.github/workflows/sentry_raven_test.yml
+++ b/.github/workflows/sentry_raven_test.yml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       matrix:
         rails_version: [0, 4.2, 5.2, 6.0.0]
-        ruby_version: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0, jruby]
+        ruby_version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', jruby]
         os: [ubuntu-latest]
         include:
-          - ruby_version: 3.0
+          - ruby_version: '3.0'
             rails_version: 0
           - ruby_version: 2.7
             rails_version: 6.0.0
@@ -33,11 +33,11 @@ jobs:
             rails_version: 6.0.0
           - ruby_version: 2.7
             rails_version: 4.2
-          - ruby_version: 3.0
+          - ruby_version: '3.0'
             rails_version: 4.2
-          - ruby_version: 3.0
+          - ruby_version: '3.0'
             rails_version: 5.2
-          - ruby_version: 3.0
+          - ruby_version: '3.0'
             rails_version: 6.0.0
 
     steps:

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -22,10 +22,10 @@ jobs:
           - { os: ubuntu-latest, ruby_version: 2.5 }
           - { os: ubuntu-latest, ruby_version: 2.6 }
           - { os: ubuntu-latest, ruby_version: 2.7 }
-          - { os: ubuntu-latest, ruby_version: 3.0 }
+          - { os: ubuntu-latest, ruby_version: '3.0' }
           - { os: ubuntu-latest, ruby_version: jruby }
-          - { os: ubuntu-latest, ruby_version: 3.0, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
-          - { os: ubuntu-latest, ruby_version: 3.0, options: { without_rack: 1 } }
+          - { os: ubuntu-latest, ruby_version: '3.0', options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
+          - { os: ubuntu-latest, ruby_version: '3.0', options: { without_rack: 1 } }
     steps:
     - uses: actions/checkout@v1
 

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.4, 2.5, 2.6, 2.7, 3.0, jruby]
+        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', jruby]
         os: [ubuntu-latest]
         include:
-          - ruby_version: 3.0
+          - ruby_version: '3.0'
             env: RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
To avoid unexpectedly stop testing Ruby 3.0 when Ruby 3.1 is released.

See actions/runner#849

You can see that it says just `3`, not `3.0` at https://github.com/getsentry/sentry-ruby/runs/1775107213?check_suite_focus=true#step:4:4