### PR TITLE
Fix project root detection

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Prevent exceptions app from overriding event's transaction name [#1230](https://github.com/getsentry/sentry-ruby/pull/1230)
+- Fix project root detection [#1242](https://github.com/getsentry/sentry-ruby/pull/1242)
 
 ## 4.1.5
 

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -19,6 +19,7 @@ module Sentry
     config.after_initialize do
       next unless Sentry.initialized?
 
+      configure_project_root
       configure_sentry_logger
       extend_controller_methods
       extend_active_job if defined?(ActiveJob)
@@ -26,6 +27,10 @@ module Sentry
       setup_backtrace_cleanup_callback
       inject_breadcrumbs_logger
       activate_tracing
+    end
+
+    def configure_project_root
+      Sentry.configuration.project_root = ::Rails.root.to_s
     end
 
     def configure_sentry_logger

--- a/sentry-rails/spec/sentry/rails/event_spec.rb
+++ b/sentry-rails/spec/sentry/rails/event_spec.rb
@@ -2,11 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Sentry::Event do
   before do
-    Sentry.init do |config|
-      config.dsn = DUMMY_DSN
-      config.logger = ::Logger.new(nil)
-      config.transport.transport_class = Sentry::DummyTransport
-    end
+    make_basic_app
   end
 
   it "sets right SDK information" do
@@ -58,7 +54,7 @@ RSpec.describe Sentry::Event do
 
     context 'when a non-in_app path under project_root is on the load path' do
       it 'normalizes the filename using the load path' do
-        $LOAD_PATH.push "#{Rails.root}/vendor/bundle"
+        $LOAD_PATH.push "vendor/bundle"
         frames = hash[:exception][:values][0][:stacktrace][:frames]
         expect(frames[5][:filename]).to eq("cache/other_gem.rb")
         $LOAD_PATH.pop


### PR DESCRIPTION
We used to assume the project root would be detected by `Sentry::Configuration#detect_project_root`, but it's actually broken and fails to set project root for some Rails applications.

This commits fixes the issue.
