### PR TITLE
Don't detect project root for Rails apps

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Don't detect project root for Rails apps [#1243](https://github.com/getsentry/sentry-ruby/pull/1243)
+
 ## 4.1.5
 
 - Serialize event hint before passing it to the async block [#1231](https://github.com/getsentry/sentry-ruby/pull/1231)

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -164,7 +164,7 @@ module Sentry
       self.inspect_exception_causes_for_exclusion = false
       self.linecache = ::Sentry::LineCache.new
       self.logger = ::Sentry::Logger.new(STDOUT)
-      self.project_root = detect_project_root
+      self.project_root = Dir.pwd
 
       self.release = detect_release
       self.sample_rate = 1.0
@@ -266,14 +266,6 @@ module Sentry
     end
 
     private
-
-    def detect_project_root
-      if defined? Rails.root # we are in a Rails application
-        Rails.root.to_s
-      else
-        Dir.pwd
-      end
-    end
 
     def detect_release
       detect_release_from_env ||


### PR DESCRIPTION
    1. That's `sentry-rails`'s job
    2. The current logic actually always fails when installed with
       `sentry-rails`. Because in the case the `Rails` in the code points to
       `Sentry::Rails` instead of the top-level `::Rails`.
