### PR TITLE
Use sentry-ruby-core as the main SDK dependency

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Prevent exceptions app from overriding event's transaction name [#1230](https://github.com/getsentry/sentry-ruby/pull/1230)
 - Fix project root detection [#1242](https://github.com/getsentry/sentry-ruby/pull/1242)
+- Use sentry-ruby-core as the main SDK dependency [#1244](https://github.com/getsentry/sentry-ruby/pull/1244)
 
 ## 4.1.5
 

--- a/sentry-rails/sentry-rails.gemspec
+++ b/sentry-rails/sentry-rails.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rails", ">= 5.0"
-  spec.add_dependency "sentry-ruby", "~> 4.1.2"
+  spec.add_dependency "sentry-ruby-core", "~> 4.1.2"
 end


### PR DESCRIPTION
This is part of #1201 