### PR TITLE
Use sentry-ruby-core as the main SDK dependency

### DIFF
--- a/sentry-sidekiq/CHANGELOG.md
+++ b/sentry-sidekiq/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.1.3
+
+- Use sentry-ruby-core as the main SDK dependency [#1245](https://github.com/getsentry/sentry-ruby/pull/1245)
+
 ## 4.1.2
 
 - Fix sidekiq middleware [#1175](https://github.com/getsentry/sentry-ruby/pull/1175)

--- a/sentry-sidekiq/sentry-sidekiq.gemspec
+++ b/sentry-sidekiq/sentry-sidekiq.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sentry-ruby", "~> 4.1.2"
+  spec.add_dependency "sentry-ruby-core", "~> 4.1.2"
 end

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -5,6 +5,8 @@ require "pry"
 require "sidekiq/cli"
 # require "support/test_sidekiq_app/app"
 
+require "sentry-ruby"
+
 require 'simplecov'
 
 SimpleCov.start do


### PR DESCRIPTION
This is part of #1201 