### PR TITLE
Separate individual breadcrumb's data serialization

### DIFF
--- a/sentry-ruby/lib/sentry/breadcrumb.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb.rb
@@ -1,5 +1,7 @@
 module Sentry
   class Breadcrumb
+    DATA_SERIALIZATION_ERROR_MESSAGE = "[data were removed due to serialization issues]"
+
     attr_accessor :category, :data, :message, :level, :timestamp, :type
 
     def initialize(category: nil, data: nil, message: nil, timestamp: nil, level: nil, type: nil)
@@ -13,13 +15,30 @@ module Sentry
 
     def to_hash
       {
-        :category => @category,
-        :data => @data,
-        :level => @level,
-        :message => @message,
-        :timestamp => @timestamp,
-        :type => @type
+        category: @category,
+        data: serialized_data,
+        level: @level,
+        message: @message,
+        timestamp: @timestamp,
+        type: @type
       }
+    end
+
+    private
+
+    def serialized_data
+      begin
+        ::JSON.parse(::JSON.generate(@data))
+      rescue Exception => e
+        Sentry.logger.debug(LOGGER_PROGNAME) do
+          <<~MSG
+can't serialize breadcrumb data because of error: #{e}
+data: #{@data}
+          MSG
+        end
+
+        DATA_SERIALIZATION_ERROR_MESSAGE
+      end
     end
   end
 end

--- a/sentry-ruby/lib/sentry/breadcrumb_buffer.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb_buffer.rb
@@ -34,7 +34,7 @@ module Sentry
 
     def to_hash
       {
-        :values => members.map(&:to_hash)
+        values: members.map(&:to_hash)
       }
     end
 

--- a/sentry-ruby/spec/sentry/breadcrumb_buffer_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb_buffer_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+RSpec.describe Sentry::BreadcrumbBuffer do
+  before do
+    perform_basic_setup
+  end
+
+  let(:crumb_1) do
+    Sentry::Breadcrumb.new(
+      category: "foo",
+      message: "crumb_1",
+      data: {
+        name: "John",
+        age: 25
+      }
+    )
+  end
+
+  let(:crumb_2) do
+    Sentry::Breadcrumb.new(
+      category: "bar",
+      message: "crumb_2",
+    )
+  end
+
+  let(:problematic_crumb) do
+    # circular reference
+    a = []
+    b = []
+    a.push(b)
+    b.push(a)
+
+    Sentry::Breadcrumb.new(
+      category: "baz",
+      message: "crumb_3",
+      data: a
+    )
+  end
+
+  describe "#to_hash" do
+    it "doesn't break because of 1 problematic crumb" do
+      subject.record(crumb_1)
+      subject.record(crumb_2)
+      subject.record(problematic_crumb)
+
+      result = subject.to_hash[:values]
+
+      expect(result[0][:category]).to eq("foo")
+      expect(result[0][:data]).to eq({ "name" => "John", "age" => 25 })
+      expect(result[1][:category]).to eq("bar")
+      expect(result[2][:category]).to eq("baz")
+      expect(result[2][:data]).to eq("[data were removed due to serialization issues]")
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/breadcrumb_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+
+RSpec.describe Sentry::Breadcrumb do
+  before do
+    perform_basic_setup
+  end
+
+  let(:crumb) do
+    Sentry::Breadcrumb.new(
+      category: "foo",
+      message: "crumb",
+      data: {
+        name: "John",
+        age: 25
+      }
+    )
+  end
+
+  let(:problematic_crumb) do
+    # circular reference
+    a = []
+    b = []
+    a.push(b)
+    b.push(a)
+
+    Sentry::Breadcrumb.new(
+      category: "baz",
+      message: "I cause issues",
+      data: a
+    )
+  end
+
+  describe "#to_hash" do
+    it "serializes data correctly" do
+      result = crumb.to_hash
+
+      expect(result[:category]).to eq("foo")
+      expect(result[:message]).to eq("crumb")
+      expect(result[:data]).to eq({ "name" => "John", "age" => 25 })
+    end
+
+    it "rescues data serialization issue and ditch the data" do
+      result = problematic_crumb.to_hash
+
+      expect(result[:category]).to eq("baz")
+      expect(result[:message]).to eq("I cause issues")
+      expect(result[:data]).to eq("[data were removed due to serialization issues]")
+    end
+  end
+end


### PR DESCRIPTION
Breadcrumb can literally contain any type of data, and some of them can
cause problems when being serialized, like a hash or array that contains
circular references. Currently, this is causing the entire event to be
ditched because of the serialization error or SystemStackError, which is
bothering the users.

However, to stop bad data from being recorded is almost impossible, or at
least it'll be extremely expensive to check. So this commit takes a
different approach:

1. we use `JSON.parse(JSON.generate(breadcrumb_data))` in
   `Breadcrumb#to_hash` to make sure the generated Hash is
   serializable.
2. if a breadcrumb's data is not serializable, the data will be
   thrown away but the breadcrumb will be preserved.
3. whenever the serialization error happens, Sentry will log related
   messages to help future debugging.

