### PR TITLE
Capture exceptions in Action Cable connections and channels

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add Action Cable exception capturing [#1251](https://github.com/getsentry/sentry-ruby/pull/1251)
+
 ## 4.1.6
 
 - Prevent exceptions app from overriding event's transaction name [#1230](https://github.com/getsentry/sentry-ruby/pull/1230)

--- a/sentry-rails/lib/sentry/rails/action_cable.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable.rb
@@ -1,0 +1,72 @@
+module Sentry
+  module Rails
+    module ActionCable
+      class ErrorHandler
+        ACTION_CABLE_NAME = 'ActionCable'
+
+        def self.capture(env, transaction_name:, extra_context: nil, &block)
+          Sentry.with_scope do |scope|
+            scope.set_rack_env(env)
+            scope.set_extras(action_cable: extra_context) if extra_context
+            scope.set_transaction_name("#{ACTION_CABLE_NAME}/#{transaction_name}")
+
+            begin
+              block.call
+            rescue Exception => e # rubocop:disable Lint/RescueException
+              Sentry.capture_exception(e)
+
+              raise
+            end
+          end
+        end
+      end
+
+      module Connection
+        private
+
+        def handle_open
+          ErrorHandler.capture(env, transaction_name: "#{self.class.name}#connect") do
+            super
+          end
+        end
+
+        def handle_close
+          ErrorHandler.capture(env, transaction_name: "#{self.class.name}#disconnect") do
+            super
+          end
+        end
+      end
+
+      module Channel
+        module Subscriptions
+          def self.included(base)
+            base.class_eval do
+              set_callback :subscribe, :around, ->(_, block) { sentry_capture(:subscribed, &block) }, prepend: true
+              set_callback :unsubscribe, :around, ->(_, block) { sentry_capture(:unsubscribed, &block) }, prepend: true
+            end
+          end
+
+          private
+
+          def sentry_capture(hook, &block)
+            extra_context = { params: params }
+
+            ErrorHandler.capture(connection.env, transaction_name: "#{self.class.name}##{hook}", extra_context: extra_context, &block)
+          end
+        end
+
+        module Actions
+          private
+
+          def dispatch_action(action, data)
+            extra_context = { params: params, data: data }
+
+            ErrorHandler.capture(connection.env, transaction_name: "#{self.class.name}##{action}", extra_context: extra_context) do
+              super
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sentry-rails/lib/sentry/rails/action_cable/channel.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable/channel.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative 'exception_reporter'
+
+module Sentry
+  module Rails
+    module ActionCable
+      module Channel
+        module Subscriptions
+          extend ActiveSupport::Concern
+
+          included do
+            set_callback :subscribe, :around, ->(_, block) { sentry_capture(:subscribe, &block) }, prepend: true
+            set_callback :unsubscribe, :around, ->(_, block) { sentry_capture(:unsubscribe, &block) }, prepend: true
+          end
+
+          private
+
+          def sentry_capture(hook, &block)
+            extra_context = { params: params }
+
+            ExceptionReporter.capture(connection.env, transaction_name: "#{self.class.name}##{hook}", extra_context: extra_context, &block)
+          end
+        end
+
+        module Actions
+          private
+
+          def dispatch_action(action, data)
+            extra_context = { params: params, data: data }
+
+            ExceptionReporter.capture(connection.env, transaction_name: "#{self.class.name}##{action}", extra_context: extra_context) { super }
+          end
+        end
+      end
+    end
+  end
+end

--- a/sentry-rails/lib/sentry/rails/action_cable/connection.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable/connection.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'exception_reporter'
+
+module Sentry
+  module Rails
+    module ActionCable
+      module Connection
+        private
+
+        def handle_open
+          ExceptionReporter.capture(env, transaction_name: self.class.name) { super }
+        end
+      end
+    end
+  end
+end

--- a/sentry-rails/lib/sentry/rails/action_cable/exception_reporter.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable/exception_reporter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Sentry
+  module Rails
+    module ActionCable
+      class ExceptionReporter
+        TRANSACTION_PREFIX = 'ActionCable'
+
+        def self.capture(env, transaction_name:, extra_context: nil, &block)
+          Sentry.with_scope do |scope|
+            scope.set_rack_env(env)
+            scope.set_extras(action_cable: extra_context) if extra_context
+
+            scope.set_transaction_name [TRANSACTION_PREFIX, transaction_name].join('/')
+
+            begin
+              block.call
+            rescue Exception => e # rubocop:disable Lint/RescueException
+              Sentry.capture_exception(e)
+
+              raise
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sentry-rails/spec/sentry/rails/action_cable_spec.rb
+++ b/sentry-rails/spec/sentry/rails/action_cable_spec.rb
@@ -1,0 +1,83 @@
+require "spec_helper"
+require "action_cable/engine"
+require "action_cable/connection/test_case"
+require "action_cable/channel/test_case"
+
+# ensure we can access `connection.env` in tests like we can in production
+ActiveSupport.on_load :action_cable_channel_test_case do
+  class ::ActionCable::Channel::ConnectionStub
+    def env
+      @_env ||= ::ActionCable::Connection::TestRequest.create.env
+    end
+  end
+end
+
+class ChatChannel < ::ActionCable::Channel::Base
+  def subscribed
+    raise "foo"
+  end
+end
+
+class AppearanceChannel < ::ActionCable::Channel::Base
+  def appear
+    raise "foo"
+  end
+end
+
+RSpec.describe "Sentry::Rails::ActionCable" do
+  let(:transport) { Sentry.get_current_client.transport }
+
+  before(:all) do
+    make_basic_app
+    ::ActionCable.server.config.cable = { "adapter" => "test" }
+  end
+
+  describe ChatChannel do
+    include ActionCable::Channel::TestCase::Behavior
+
+    tests ChatChannel
+
+    it "captures errors during the subscribe" do
+      expect { subscribe room_id: 42 }.to raise_error('foo')
+
+      event = transport.events.last.to_json_compatible
+
+      expect(event).to include(
+        "transaction" => "ActionCable/ChatChannel#subscribed",
+        "extra" => {
+          "action_cable" => {
+            "params" => { "room_id" => 42 }
+          }
+        }
+      )
+
+      expect(Sentry.get_current_scope.extra).to eq({})
+    end
+  end
+
+  describe AppearanceChannel do
+    include ActionCable::Channel::TestCase::Behavior
+
+    tests AppearanceChannel
+
+    before { subscribe room_id: 42 }
+
+    it "captures errors during the action" do
+      expect { perform :appear, foo: 'bar' }.to raise_error('foo')
+
+      event = transport.events.last.to_json_compatible
+
+      expect(event).to include(
+        "transaction" => "ActionCable/AppearanceChannel#appear",
+        "extra" => {
+          "action_cable" => {
+            "params" => { "room_id" => 42 },
+            "data" => { "action" => "appear", "foo" => "bar" }
+          }
+        }
+      )
+
+      expect(Sentry.get_current_scope.extra).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
Hi @st0012! I mentioned this in https://github.com/getsentry/sentry-ruby/issues/470#issuecomment-708533493 (and https://github.com/getsentry/sentry-ruby/issues/470#issuecomment-709291341), and now that 4.x is reasonably stable, thought it worth getting this PR out there.

There are 5 types of hooks that Action Cable provides:

* `Connection#connect`
* `Connection#disconnect`
* `Channel#subscribed`
* `Channel#unsubscribed`
* `Channel` actions

Now, any exceptions raised within those hooks are captured by Sentry, and reported as `ActionCable/[...]` transactions. Additional context is included depending on the hook the exception was raised within.

A note/quirk: the Rack env that's included in the scope is from the `Connection`, and therefore has a URL of the cable `mount_path` (usually `/cable`) as well as the headers from that initial connection request.

Additionally, there is not currently a really clean way to hook in and set `user_context`. I don't know if that is a blocker for this integration, but wanted to make sure it was noted.

Closes #470.