### PR TITLE
Support config.before_breadcrumb

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add ThreadsInterface [#1178](https://github.com/getsentry/sentry-ruby/pull/1178)
 - Inspect exception cause by default & don't exclude ActiveJob::DeserializationError [#1180](https://github.com/getsentry/sentry-ruby/pull/1180)
   - Fixes [#1071](https://github.com/getsentry/sentry-ruby/issues/1071)
+- Support `config.before_breadcrumb` [#1253](https://github.com/getsentry/sentry-ruby/pull/1253)
 
 ## Unreleased
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -38,10 +38,19 @@ module Sentry
     #
     attr_accessor :backtrace_cleanup_callback
 
+    # Optional Proc, called before adding the breadcrumb to the current scope
+    # E.g.: lambda { |breadcrumb, hint| breadcrumb }
+    # E.g.: lambda { |breadcrumb, hint| nil }
+    # E.g.: lambda { |breadcrumb, hint|
+    #   breadcrumb.message = 'a'
+    #   breadcrumb
+    # }
+    attr_reader :before_breadcrumb
+
     # Optional Proc, called before sending an event to the server/
-    # E.g.: lambda { |event| event }
-    # E.g.: lambda { |event| nil }
-    # E.g.: lambda { |event|
+    # E.g.: lambda { |event, hint| event }
+    # E.g.: lambda { |event, hint| nil }
+    # E.g.: lambda { |event, hint|
     #   event[:message] = 'a'
     #   event
     # }
@@ -225,6 +234,14 @@ module Sentry
       end
 
       @before_send = value
+    end
+
+    def before_breadcrumb=(value)
+      unless value.nil? || value.respond_to?(:call)
+        raise ArgumentError, "before_breadcrumb must be callable (or nil to disable)"
+      end
+
+      @before_breadcrumb = value
     end
 
     def environment=(environment)

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -120,7 +120,13 @@ module Sentry
       event
     end
 
-    def add_breadcrumb(breadcrumb)
+    def add_breadcrumb(breadcrumb, hint: {})
+      if before_breadcrumb = current_client.configuration.before_breadcrumb
+        breadcrumb = before_breadcrumb.call(breadcrumb, hint)
+      end
+
+      return unless breadcrumb
+
       current_scope.add_breadcrumb(breadcrumb)
     end
 


### PR DESCRIPTION
Example:

```
config.before_breadcrumb = lambda do |breadcrumb, hint|
  breadcrumb.message = "foo"
  breadcrumb
end
```

Closes #1169 