### PR TITLE
Fix duration of tracing event in Rails 5

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Use env to carry original transaction name [#1255](https://github.com/getsentry/sentry-ruby/pull/1255)
+- Fix duration of tracing event in Rails 5 [#1254](https://github.com/getsentry/sentry-ruby/pull/1254) (by @abcang)
 
 ## 4.1.6
 

--- a/sentry-rails/lib/sentry/rails/tracing/abstract_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/abstract_subscriber.rb
@@ -14,11 +14,11 @@ module Sentry
 
           def subscribe_to_event(event_name)
             if ::Rails.version.to_i == 5
-              ActiveSupport::Notifications.subscribe(event_name) do |_, start, finish, _, payload|
+              ActiveSupport::Notifications.subscribe(event_name) do |*args|
                 next unless Tracing.get_current_transaction
 
-                duration = finish.to_f - start.to_f
-                yield(event_name, duration, payload)
+                event = ActiveSupport::Notifications::Event.new(*args)
+                yield(event_name, event.duration, event.payload)
               end
             else
               ActiveSupport::Notifications.subscribe(event_name) do |event|

--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
       expect(first_span[:parent_span_id]).to eq(parent_span_id)
 
       # this is to make sure we calculate the timestamp in the correct scale (second instead of millisecond)
-      expect(first_span[:timestamp] - first_span[:start_timestamp]).to be <= 1
+      expect(first_span[:timestamp] - first_span[:start_timestamp]).to be_between(10.0 / 1_000_000, 10.0 / 1000)
 
       second_span = transaction[:spans][1]
       expect(second_span[:op]).to eq("process_action.action_controller")
@@ -77,7 +77,7 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
       expect(first_span[:parent_span_id]).to eq(parent_span_id)
 
       # this is to make sure we calculate the timestamp in the correct scale (second instead of millisecond)
-      expect(first_span[:timestamp] - first_span[:start_timestamp]).to be <= 1
+      expect(first_span[:timestamp] - first_span[:start_timestamp]).to be_between(10.0 / 1_000_000, 10.0 / 1000)
 
       second_span = transaction[:spans][1]
       expect(second_span[:op]).to eq("process_action.action_controller")


### PR DESCRIPTION
When I enabled Performance Monitoring with sentry-rails in Rails 5, I noticed that the duration was extremely short.
I fixed it to get the duration in the same way as in Rails 6 by using `ActiveSupport::Notifications: Event` in Rails 5.

![image](https://user-images.githubusercontent.com/4199439/106357536-fc349900-6349-11eb-96c9-30f9a45940a7.png)

