### PR TITLE
Use env to carry original transaction name

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Use env to carry original transaction name [#1255](https://github.com/getsentry/sentry-ruby/pull/1255)
+
 ## 4.1.6
 
 - Prevent exceptions app from overriding event's transaction name [#1230](https://github.com/getsentry/sentry-ruby/pull/1230)

--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -12,6 +12,12 @@ module Sentry
       end
 
       def capture_exception(exception)
+        current_scope = Sentry.get_current_scope
+
+        if original_transaction = current_scope.rack_env["sentry.original_transaction"]
+          current_scope.set_transaction_name(original_transaction)
+        end
+
         Sentry::Rails.capture_exception(exception)
       end
     end

--- a/sentry-rails/lib/sentry/rails/rescued_exception_interceptor.rb
+++ b/sentry-rails/lib/sentry/rails/rescued_exception_interceptor.rb
@@ -17,14 +17,9 @@ module Sentry
           # so we need to hold a copy of env to report the accurate data (like request's url)
           if request.show_exceptions?
             scope = Sentry.get_current_scope
-            scope.set_rack_env(scope.rack_env.dup)
-            transaction = scope.transaction_name
-
-            # we also need to make sure the transaction name won't be overridden by the exceptions app
-            scope.add_event_processor do |event, hint|
-              event.transaction = transaction
-              event
-            end
+            copied_env = scope.rack_env.dup
+            copied_env["sentry.original_transaction"] = scope.transaction_name
+            scope.set_rack_env(copied_env)
           end
 
           env["sentry.rescued_exception"] = e if Sentry.configuration.rails.report_rescued_exceptions

--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -85,6 +85,23 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
       expect(second_span[:parent_span_id]).to eq(parent_span_id)
 
     end
+
+    it "doesn't get messed up by previous exception" do
+      get "/exception"
+
+      expect(transport.events.count).to eq(2)
+
+      get "/posts/1"
+
+      expect(transport.events.count).to eq(3)
+
+      transaction = transport.events.last.to_hash
+
+      expect(transaction[:type]).to eq("transaction")
+      expect(transaction[:transaction]).to eq("PostsController#show")
+      second_span = transaction[:spans][1]
+      expect(second_span[:description]).to eq("PostsController#show")
+    end
   end
 
   context "without traces_sample_rate set" do

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -43,7 +43,11 @@ RSpec.describe Sentry::Rails, type: :request do
     it "sets transaction to ControllerName#method" do
       get "/exception"
 
-      expect(event['transaction']).to eq("HelloController#exception")
+      expect(transport.events.last.transaction).to eq("HelloController#exception")
+
+      get "/posts"
+
+      expect(transport.events.last.transaction).to eq("PostsController#index")
     end
 
     it "sets correct request url" do
@@ -152,7 +156,11 @@ RSpec.describe Sentry::Rails, type: :request do
       it "sets transaction to ControllerName#method" do
         get "/exception"
 
-        expect(event['transaction']).to eq("HelloController#exception")
+        expect(transport.events.last.transaction).to eq("HelloController#exception")
+
+        get "/posts"
+
+        expect(transport.events.last.transaction).to eq("PostsController#index")
       end
 
       it "sets correct request url" do


### PR DESCRIPTION
Adding event processors in every request and bet it'll be cleaned up is
actually quite risky. If a processor is added to a parent scope for some
reason, all the child scopes will end up having the same transaction
name.