### PR TITLE
Add sidekiq adapter to sentry-rails' ignored adapters list

### DIFF
--- a/sentry-sidekiq/.rspec
+++ b/sentry-sidekiq/.rspec
@@ -1,3 +1,2 @@
 --format documentation
 --color
---require spec_helper

--- a/sentry-sidekiq/CHANGELOG.md
+++ b/sentry-sidekiq/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased (4.2.0)
+
+- Add sidekiq adapter to sentry-rails' ignored adapters list [#1257](https://github.com/getsentry/sentry-ruby/pull/1257)
+
 ## 4.1.3
 
 - Use sentry-ruby-core as the main SDK dependency [#1245](https://github.com/getsentry/sentry-ruby/pull/1245)

--- a/sentry-sidekiq/Gemfile
+++ b/sentry-sidekiq/Gemfile
@@ -8,8 +8,9 @@ gem "rspec", "~> 3.0"
 gem "codecov", "0.2.12"
 
 gem "sidekiq"
-gem "activejob"
+gem "rails"
 
 gem "sentry-ruby", path: "../sentry-ruby"
+gem "sentry-rails", path: "../sentry-rails"
 
 gem "pry"

--- a/sentry-sidekiq/lib/sentry-sidekiq.rb
+++ b/sentry-sidekiq/lib/sentry-sidekiq.rb
@@ -4,13 +4,22 @@ require "sentry/integrable"
 require "sentry/sidekiq/version"
 require "sentry/sidekiq/error_handler"
 require "sentry/sidekiq/sentry_context_middleware"
-# require "sentry/sidekiq/configuration"
 
 module Sentry
   module Sidekiq
     extend Sentry::Integrable
 
     register_integration name: "sidekiq", version: Sentry::Sidekiq::VERSION
+
+    if defined?(::Rails)
+      class Railtie < ::Rails::Railtie
+        config.after_initialize do
+          next unless Sentry.initialized?
+
+          Sentry.configuration.rails.ignored_active_job_adapters << "ActiveJob::QueueAdapters::SidekiqAdapter"
+        end
+      end
+    end
   end
 end
 

--- a/sentry-sidekiq/spec/sentry/rails_spec.rb
+++ b/sentry-sidekiq/spec/sentry/rails_spec.rb
@@ -1,0 +1,42 @@
+require "rails"
+require "sentry-rails"
+require "spec_helper"
+
+class TestApp < Rails::Application
+end
+
+def make_basic_app
+  app = Class.new(TestApp) do
+    def self.name
+      "RailsTestApp"
+    end
+  end
+
+  app.config.hosts = nil
+  app.config.secret_key_base = "test"
+  app.config.eager_load = true
+  app.initializer :configure_sentry do
+    Sentry.init do |config|
+      config.release = 'beta'
+      config.dsn = "dummy://12345:67890@sentry.localdomain:3000/sentry/42"
+      config.transport.transport_class = Sentry::DummyTransport
+      # for sending events synchronously
+      config.background_worker_threads = 0
+      yield(config, app) if block_given?
+    end
+  end
+
+  app.initialize!
+  Rails.application = app
+  app
+end
+
+RSpec.describe Sentry::Sidekiq do
+  before do
+    make_basic_app
+  end
+
+  it "adds sidekiq adapter to config.rails.ignored_active_job_adapters" do
+    expect(Sentry.configuration.rails.ignored_active_job_adapters).to include("ActiveJob::QueueAdapters::SidekiqAdapter")
+  end
+end


### PR DESCRIPTION
This makes sure sentry-rails & sentry-sidekiq don't report the same worker failure twice.