### PR TITLE
Capture sentry-trace with the correct http header key

### DIFF
--- a/sentry-rails/spec/support/test_rails_app/app.rb
+++ b/sentry-rails/spec/support/test_rails_app/app.rb
@@ -40,7 +40,9 @@ class PostsController < ActionController::Base
   end
 
   def show
-    Post.find(params[:id])
+    p = Post.find(params[:id])
+
+    render plain: p.id
   end
 end
 

--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Don't detect project root for Rails apps [#1243](https://github.com/getsentry/sentry-ruby/pull/1243)
 - Separate individual breadcrumb's data serialization [#1250](https://github.com/getsentry/sentry-ruby/pull/1250)
+- Capture sentry-trace with the correct http header key [#1260](https://github.com/getsentry/sentry-ruby/pull/1260)
 
 ## 4.1.5
 

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -17,7 +17,7 @@ module Sentry
           scope.set_rack_env(env)
 
           span =
-            if sentry_trace = env["sentry-trace"]
+            if sentry_trace = env["HTTP_SENTRY_TRACE"]
               Sentry::Transaction.from_sentry_trace(sentry_trace, name: scope.transaction_name, op: transaction_op)
             else
               Sentry.start_transaction(name: scope.transaction_name, op: transaction_op)

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
       end
 
       it "inherits trace info from the transaction" do
-        env["sentry-trace"] = external_transaction.to_sentry_trace
+        env["HTTP_SENTRY_TRACE"] = external_transaction.to_sentry_trace
 
         stack.call(env)
 


### PR DESCRIPTION
    When receiving a request with `sentry-trace` header, the server will alter
    the header's key to `HTTP_SENTRY_TRACE`. So we should use
    `HTTP_SENTRY_TRACE` to capture the trace data in the middleware.