### PR TITLE
Gracefully handle "sentry-trace" headers that don't match the regexp

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- Ignore invalid values for sentry-trace header that don't match the required format [#1265](https://github.com/getsentry/sentry-ruby/pull/1265)
+
 ## 4.2.0
 
 ### Features

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -16,12 +16,9 @@ module Sentry
           scope.set_transaction_name(env["PATH_INFO"]) if env["PATH_INFO"]
           scope.set_rack_env(env)
 
-          span =
-            if sentry_trace = env["HTTP_SENTRY_TRACE"]
-              Sentry::Transaction.from_sentry_trace(sentry_trace, name: scope.transaction_name, op: transaction_op)
-            else
-              Sentry.start_transaction(name: scope.transaction_name, op: transaction_op)
-            end
+          sentry_trace = env["HTTP_SENTRY_TRACE"]
+          span = Sentry::Transaction.from_sentry_trace(sentry_trace, name: scope.transaction_name, op: transaction_op) if sentry_trace
+          span ||= Sentry.start_transaction(name: scope.transaction_name, op: transaction_op)
 
           scope.set_span(span)
 

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -29,6 +29,7 @@ module Sentry
       return unless sentry_trace
 
       match = SENTRY_TRACE_REGEXP.match(sentry_trace)
+      return if match.nil?
       trace_id, parent_span_id, sampled_flag = match[1..3]
 
       sampled = sampled_flag != "0"

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe Sentry::Transaction do
       expect(child_transaction.parent_sampled).to eq(true)
       expect(child_transaction.op).to eq("child")
     end
+
+    it "handles invalid values without crashing" do
+      child_transaction = described_class.from_sentry_trace("dummy", op: "child")
+
+      expect(child_transaction).to be_nil
+    end
   end
 
   describe "#deep_dup" do


### PR DESCRIPTION
Fixes the handling of invalid "sentry-trace" header values, such as "null", that otherwise lead to an application crash.

Example error backtrace:

```
Rack app error handling request { POST /action }
#<NoMethodError: undefined method `[]' for nil:NilClass>
.../sentry-ruby-core-4.1.6/lib/sentry/transaction.rb:32:in `from_sentry_trace'
.../sentry-ruby-core-4.1.6/lib/sentry/rack/capture_exceptions.rb:21:in `block in call'
.../sentry-ruby-core-4.1.6/lib/sentry/hub.rb:52:in `with_scope'
.../sentry-ruby-core-4.1.6/lib/sentry-ruby.rb:149:in `with_scope'
.../sentry-ruby-core-4.1.6/lib/sentry/rack/capture_exceptions.rb:14:in `call'
```