### PR TITLE
fix#1246: raise error when send_event failed

### DIFF
--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -33,7 +33,7 @@ module Sentry
       event
     rescue => e
       failed_for_exception(e, event)
-      nil
+      raise e
     end
 
     def generate_auth_header

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -125,12 +125,12 @@ RSpec.describe Sentry::Transport do
         allow(subject).to receive(:send_data).and_raise(StandardError)
       end
 
-      it "returns nil" do
-        expect(subject.send_event(event)).to eq(nil)
+      it "raises error" do
+        expect { subject.send_event(event) }.to raise_error
       end
 
       it "logs correct message" do
-        subject.send_event(event)
+        subject.send_event(event) rescue nil
 
         log = io.string
         expect(log).to match(


### PR DESCRIPTION
## Description
Sentry::Transport will swallow exceptions when send_event failed, so the app include sidekiq can't catch error and retry.
Related issue: [https://github.com/getsentry/sentry-ruby/issues/1246]()
