### PR TITLE
Transaction created by .from_sentry_trace should inherit sampling decision

### DIFF
--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
         expect(transaction.timestamp).not_to be_nil
         expect(transaction.contexts.dig(:trace, :status)).to eq("ok")
         expect(transaction.contexts.dig(:trace, :op)).to eq("rails.request")
-        expect(transaction.spans.count).to eq(0)
+        expect(transaction.spans.count).to eq(3)
 
         # should inherit information from the external_transaction
         expect(transaction.contexts.dig(:trace, :trace_id)).to eq(external_transaction.trace_id)

--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Ignore invalid values for sentry-trace header that don't match the required format [#1265](https://github.com/getsentry/sentry-ruby/pull/1265)
+- Transaction created by `.from_sentry_trace` should inherit sampling decision [#1269](https://github.com/getsentry/sentry-ruby/pull/1269)
 
 ## 4.2.0
 

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -34,7 +34,7 @@ module Sentry
 
       sampled = sampled_flag != "0"
 
-      new(trace_id: trace_id, parent_span_id: parent_span_id, parent_sampled: sampled, **options)
+      new(trace_id: trace_id, parent_span_id: parent_span_id, parent_sampled: sampled, sampled: sampled, **options)
     end
 
     def to_hash

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Sentry::Transaction do
       expect(child_transaction.trace_id).to eq(subject.trace_id)
       expect(child_transaction.parent_span_id).to eq(subject.span_id)
       expect(child_transaction.parent_sampled).to eq(true)
+      expect(child_transaction.sampled).to eq(true)
       expect(child_transaction.op).to eq("child")
     end
 


### PR DESCRIPTION
Although having `parent_sampled: true` already makes the transaction qualify to be sent to Sentry, it also needs `sampled: true` to allow child spans to attach on it.

solves an issue spotted in https://github.com/getsentry/sentry-ruby/pull/1265