### PR TITLE
Add additional checks to SendEventJob's definition

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Add additional checks to SendEventJob's definition [#1275](https://github.com/getsentry/sentry-ruby/pull/1275)
+  - Fixes [#1270](https://github.com/getsentry/sentry-ruby/issues/1270)
+  - Fixes [#1277](https://github.com/getsentry/sentry-ruby/issues/1277)
+
 ## 4.2.0
 
 ### Features

--- a/sentry-rails/app/jobs/sentry/send_event_job.rb
+++ b/sentry-rails/app/jobs/sentry/send_event_job.rb
@@ -2,10 +2,10 @@ return unless defined?(ActiveJob)
 
 module Sentry
   parent_job =
-    if defined?(ApplicationJob)
-      ApplicationJob
+    if defined?(::ApplicationJob)
+      ::ApplicationJob
     else
-      ActiveJob::Base
+      ::ActiveJob::Base
     end
 
   class SendEventJob < parent_job

--- a/sentry-rails/app/jobs/sentry/send_event_job.rb
+++ b/sentry-rails/app/jobs/sentry/send_event_job.rb
@@ -2,7 +2,7 @@ return unless defined?(ActiveJob)
 
 module Sentry
   parent_job =
-    if defined?(::ApplicationJob)
+    if defined?(::ApplicationJob) && ::ApplicationJob.ancestors.include?(::ActiveJob::Base)
       ::ApplicationJob
     else
       ::ActiveJob::Base

--- a/sentry-rails/app/jobs/sentry/send_event_job.rb
+++ b/sentry-rails/app/jobs/sentry/send_event_job.rb
@@ -9,8 +9,18 @@ module Sentry
     end
 
   class SendEventJob < parent_job
-    self.log_arguments = false if ::Rails.version.to_f >= 6.1
-    discard_on ActiveJob::DeserializationError # this will prevent infinite loop when there's an issue deserializing SentryJob
+    # the event argument is usually large and creates noise
+    self.log_arguments = false if respond_to?(:log_arguments=)
+
+    # this will prevent infinite loop when there's an issue deserializing SentryJob
+    if respond_to?(:discard_on)
+      discard_on ActiveJob::DeserializationError
+    else
+      # mimic what discard_on does for Rails 5.0
+      rescue_from ActiveJob::DeserializationError do
+        logger.error "Discarded #{self.class} due to a #{exception}. The original exception was #{error.cause.inspect}."
+      end
+    end
 
     def perform(event, hint = {})
       Sentry.send_event(event, hint)

--- a/sentry-rails/spec/sentry/send_event_job_spec.rb
+++ b/sentry-rails/spec/sentry/send_event_job_spec.rb
@@ -50,8 +50,28 @@ RSpec.describe "Sentry::SendEventJob" do
         make_basic_app
       end
 
+      after do
+        Object.send(:remove_const, "ApplicationJob")
+      end
+
       it "uses ApplicationJob as the parent class" do
         expect(Sentry::SendEventJob.superclass).to eq(ApplicationJob)
+      end
+    end
+
+    context "when ApplicationJob is defined but it's something else" do
+      before do
+        class ApplicationJob; end
+        load File.join(Dir.pwd, "app", "jobs", "sentry", "send_event_job.rb")
+        make_basic_app
+      end
+
+      after do
+        Object.send(:remove_const, "ApplicationJob")
+      end
+
+      it "uses ActiveJob::Base as the parent class" do
+        expect(Sentry::SendEventJob.superclass).to eq(ActiveJob::Base)
       end
     end
   end

--- a/sentry-rails/spec/sentry/send_event_job_spec.rb
+++ b/sentry-rails/spec/sentry/send_event_job_spec.rb
@@ -1,3 +1,4 @@
+require "active_job"
 require "spec_helper"
 
 RSpec.describe "Sentry::SendEventJob" do

--- a/sentry-rails/spec/spec_helper.rb
+++ b/sentry-rails/spec/spec_helper.rb
@@ -88,6 +88,12 @@ def build_exception_with_recursive_cause
   exception
 end
 
+def reload_send_event_job
+  Sentry.send(:remove_const, "SendEventJob") if defined?(Sentry::SendEventJob)
+  expect(defined?(Sentry::SendEventJob)).to eq(nil)
+  load File.join(Dir.pwd, "app", "jobs", "sentry", "send_event_job.rb")
+end
+
 def perform_basic_setup
   Sentry.init do |config|
     config.dsn = DUMMY_DSN


### PR DESCRIPTION
As reported in #1270, the `ApplicationJob` constant could mean something else to the user. So before inheriting it we should also check if it inherits `ActiveJob::Base` first.

closes #1270 

Also, Rails 5.0 doesn't support the `discard_on` method, so we need to fallback to `rescue_from`.

closes #1277 