### PR TITLE
Convert job id to string to avoid weird syntax error

### DIFF
--- a/sentry-delayed_job/CHANGELOG.md
+++ b/sentry-delayed_job/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.2.1
+
+- Convert job id to string to avoid weird syntax error [#1285](https://github.com/getsentry/sentry-ruby/pull/1285)
+  - Fixes [#1282](https://github.com/getsentry/sentry-ruby/issues/1282)
+
 ## 4.2.0
 
 - First release!

--- a/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
+++ b/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
@@ -8,7 +8,7 @@ module Sentry
         lifecycle.around(:invoke_job) do |job, *args, &block|
           Sentry.with_scope do |scope|
             scope.set_extras(**generate_extra(job))
-            scope.set_tags("delayed_job.queue" => job.queue, "delayed_job.id" => job.id)
+            scope.set_tags("delayed_job.queue" => job.queue, "delayed_job.id" => job.id.to_s)
 
             begin
               block.call(job, *args)
@@ -23,7 +23,7 @@ module Sentry
 
       def self.generate_extra(job)
         extra = {
-          "delayed_job.id": job.id,
+          "delayed_job.id": job.id.to_s,
           "delayed_job.priority": job.priority,
           "delayed_job.attempts": job.attempts,
           "delayed_job.run_at": job.run_at,

--- a/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
+++ b/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe Sentry::DelayedJob do
     expect(transport.events.count).to eq(1)
     event = transport.events.last.to_hash
     expect(event[:message]).to eq("report")
-    expect(event[:extra][:"delayed_job.id"]).to eq(enqueued_job.id)
-    expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id, "delayed_job.queue" => nil })
+    expect(event[:extra][:"delayed_job.id"]).to eq(enqueued_job.id.to_s)
+    expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id.to_s, "delayed_job.queue" => nil })
   end
 
   it "doesn't leak scope data outside of the job" do
@@ -59,7 +59,7 @@ RSpec.describe Sentry::DelayedJob do
     expect(transport.events.count).to eq(1)
     event = transport.events.last.to_hash
     expect(event[:message]).to eq("tagged report")
-    expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id, "delayed_job.queue" => nil, number: 1 })
+    expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id.to_s, "delayed_job.queue" => nil, number: 1 })
 
     Post.new.delay.report
     enqueued_job = Delayed::Backend::ActiveRecord::Job.last
@@ -67,7 +67,7 @@ RSpec.describe Sentry::DelayedJob do
 
     expect(transport.events.count).to eq(2)
     event = transport.events.last.to_hash
-    expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id, "delayed_job.queue" => nil })
+    expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id.to_s, "delayed_job.queue" => nil })
   end
 
   context "when a job failed" do
@@ -86,7 +86,7 @@ RSpec.describe Sentry::DelayedJob do
 
       expect(event[:sdk]).to eq({ name: "sentry.ruby.delayed_job", version: described_class::VERSION })
       expect(event.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
-      expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id, "delayed_job.queue" => nil })
+      expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id.to_s, "delayed_job.queue" => nil })
     end
 
     it "doesn't leak scope data" do
@@ -100,7 +100,7 @@ RSpec.describe Sentry::DelayedJob do
       expect(transport.events.count).to eq(1)
       event = transport.events.last.to_hash
 
-      expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id, "delayed_job.queue" => nil, number: 1 })
+      expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id.to_s, "delayed_job.queue" => nil, number: 1 })
       expect(Sentry.get_current_scope.extra).to eq({})
       expect(Sentry.get_current_scope.tags).to eq({})
 
@@ -113,7 +113,7 @@ RSpec.describe Sentry::DelayedJob do
 
       expect(transport.events.count).to eq(2)
       event = transport.events.last.to_hash
-      expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id, "delayed_job.queue" => nil })
+      expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id.to_s, "delayed_job.queue" => nil })
       expect(Sentry.get_current_scope.extra).to eq({})
       expect(Sentry.get_current_scope.tags).to eq({})
     end


### PR DESCRIPTION
fixes #1282 