### PR TITLE
Use ::Rails::Railtie for checking Rails definition 

### DIFF
--- a/sentry-delayed_job/CHANGELOG.md
+++ b/sentry-delayed_job/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.2.1
 
+- Use ::Rails::Railtie for checking Rails definition [#1287](https://github.com/getsentry/sentry-ruby/pull/1284)
 - Convert job id to string to avoid weird syntax error [#1285](https://github.com/getsentry/sentry-ruby/pull/1285)
   - Fixes [#1282](https://github.com/getsentry/sentry-ruby/issues/1282)
 

--- a/sentry-delayed_job/lib/sentry-delayed_job.rb
+++ b/sentry-delayed_job/lib/sentry-delayed_job.rb
@@ -10,7 +10,7 @@ module Sentry
 
     register_integration name: "delayed_job", version: Sentry::DelayedJob::VERSION
 
-    if defined?(::Rails)
+    if defined?(::Rails::Railtie)
       class Railtie < ::Rails::Railtie
         config.after_initialize do
           next unless Sentry.initialized?


### PR DESCRIPTION
This is similar to #1284 but for `sentry-delayed_job`.