### PR TITLE
always convert trusted proxies to string

### DIFF
--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -41,7 +41,7 @@ module Sentry
     end
 
     def configure_trusted_proxies
-      Sentry.configuration.trusted_proxies += Array(::Rails.application.config.action_dispatch.trusted_proxies)
+      Sentry.configuration.trusted_proxies += Array(::Rails.application.config.action_dispatch.trusted_proxies).map(&:to_s)
     end
 
     def extend_active_job

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -41,7 +41,7 @@ module Sentry
     end
 
     def configure_trusted_proxies
-      Sentry.configuration.trusted_proxies += Array(::Rails.application.config.action_dispatch.trusted_proxies).map(&:to_s)
+      Sentry.configuration.trusted_proxies += Array(::Rails.application.config.action_dispatch.trusted_proxies)
     end
 
     def extend_active_job

--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- always convert trusted proxies to string [#1288](https://github.com/getsentry/sentry-ruby/pull/1288)
+  - fixes [#1274](https://github.com/getsentry/sentry-ruby/issues/1274)
+
 ## 4.2.1
 
 ### Bug Fixes

--- a/sentry-ruby/lib/sentry/utils/real_ip.rb
+++ b/sentry-ruby/lib/sentry/utils/real_ip.rb
@@ -29,7 +29,7 @@ module Sentry
         @client_ip = client_ip
         @real_ip = real_ip
         @forwarded_for = forwarded_for
-        @trusted_proxies = (LOCAL_ADDRESSES + Array(trusted_proxies)).map { |proxy| IPAddr.new(proxy) }.uniq
+        @trusted_proxies = (LOCAL_ADDRESSES + Array(trusted_proxies)).map { |proxy| IPAddr.new(proxy.to_s) }.uniq
       end
 
       def calculate_ip

--- a/sentry-ruby/spec/sentry/utils/real_ip_spec.rb
+++ b/sentry-ruby/spec/sentry/utils/real_ip_spec.rb
@@ -63,6 +63,19 @@ RSpec.describe Sentry::Utils::RealIp do
     end
   end
 
+  context "when custom proxies are provided as IPAddr" do
+    subject do
+      Sentry::Utils::RealIp.new(
+        :forwarded_for => "2.2.2.2, 3.3.3.3, 4.4.4.4",
+        :trusted_proxies => [IPAddr.new("4.4.4.4")]
+      )
+    end
+
+    it "should return the first IP not in the trusted proxy list" do
+      expect(subject.calculate_ip).to eq("3.3.3.3")
+    end
+  end
+
   context "when an invalid IP is provided" do
     subject do
       Sentry::Utils::RealIp.new(


### PR DESCRIPTION
fix https://github.com/getsentry/sentry-ruby/issues/1274

## Description
`IPAddr.new` only accept the address as a string but not as an `IPAddr` as suggested in the [Rails documentation](https://api.rubyonrails.org/classes/ActionDispatch/RemoteIp.html).
