### PR TITLE
Add thread_id to Exception interface

### DIFF
--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -133,6 +133,7 @@ module Sentry
             int.type = e.class.to_s
             int.value = e.message.byteslice(0..MAX_MESSAGE_SIZE_IN_BYTES)
             int.module = e.class.to_s.split('::')[0...-1].join('::')
+            int.thread_id = Thread.current.object_id
 
             int.stacktrace =
               if e.backtrace && !backtraces.include?(e.backtrace.object_id)

--- a/sentry-ruby/lib/sentry/interfaces/single_exception.rb
+++ b/sentry-ruby/lib/sentry/interfaces/single_exception.rb
@@ -3,6 +3,7 @@ module Sentry
     attr_accessor :type
     attr_accessor :value
     attr_accessor :module
+    attr_accessor :thread_id
     attr_accessor :stacktrace
 
     def to_hash

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -324,9 +324,11 @@ RSpec.describe Sentry::Client do
       t.name = "Thread 1"
       t.join
 
-      thread = event.to_hash[:threads][:values][0]
+      event_hash = event.to_hash
+      thread = event_hash[:threads][:values][0]
 
       expect(thread[:id]).to eq(t.object_id)
+      expect(event_hash.dig(:exception, :values, 0, :thread_id)).to eq(t.object_id)
       expect(thread[:name]).to eq("Thread 1")
       expect(thread[:crashed]).to eq(true)
       expect(thread[:stacktrace]).to be_nil


### PR DESCRIPTION
The thread_id will help Sentry connect the exception's stacktrace with the threads interface we send. This can prevent some weird issues from happening.

Related issue: https://github.com/getsentry/sentry/issues/23870