### PR TITLE
Capture exceptions in Action Cable connections and channels

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add Action Cable exception capturing (Rails 6+) [#1295](https://github.com/getsentry/sentry-ruby/pull/1295)
+
 ## 4.2.2
 
 - Always define Sentry::SendEventJob to avoid eager load issues [#1286](https://github.com/getsentry/sentry-ruby/pull/1286)

--- a/sentry-rails/examples/rails-6.0/app/channels/appearance_channel.rb
+++ b/sentry-rails/examples/rails-6.0/app/channels/appearance_channel.rb
@@ -1,0 +1,14 @@
+class AppearanceChannel < ApplicationCable::Channel
+  def subscribed
+  end
+
+  def unsubscribed
+  end
+
+  def hello
+  end
+
+  def goodbye(data)
+    1 / 0
+  end
+end

--- a/sentry-rails/examples/rails-6.0/app/channels/application_cable/connection.rb
+++ b/sentry-rails/examples/rails-6.0/app/channels/application_cable/connection.rb
@@ -1,4 +1,6 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    def connect
+    end
   end
 end

--- a/sentry-rails/examples/rails-6.0/app/controllers/welcome_controller.rb
+++ b/sentry-rails/examples/rails-6.0/app/controllers/welcome_controller.rb
@@ -5,6 +5,9 @@ class WelcomeController < ApplicationController
     1 / 0
   end
 
+  def appearance
+  end
+
   def view_error
   end
 

--- a/sentry-rails/examples/rails-6.0/app/javascript/channels/appearance_channel.js
+++ b/sentry-rails/examples/rails-6.0/app/javascript/channels/appearance_channel.js
@@ -1,0 +1,26 @@
+import consumer from './consumer';
+
+consumer.subscriptions.create('AppearanceChannel', {
+  initialized() {
+    this.hello = this.hello.bind(this);
+    this.goodbye = this.goodbye.bind(this);
+  },
+
+  connected() {
+    document.querySelector('button#hello').addEventListener('click', this.hello);
+    document.querySelector('button#goodbye').addEventListener('click', this.goodbye);
+  },
+
+  disconnect() {
+    document.querySelector('button#hello').removeEventListener('click', this.hello);
+    document.querySelector('button#goodbye').removeEventListener('click', this.goodbye);
+  },
+
+  hello() {
+    this.perform('hello');
+  },
+
+  goodbye() {
+    this.perform('goodbye', { forever: true });
+  }
+});

--- a/sentry-rails/examples/rails-6.0/app/views/welcome/appearance.html.erb
+++ b/sentry-rails/examples/rails-6.0/app/views/welcome/appearance.html.erb
@@ -1,0 +1,2 @@
+<button type="button" id="hello">Hello</button>
+<button type="button" id="goodbye">Goodbye</button>

--- a/sentry-rails/examples/rails-6.0/config/routes.rb
+++ b/sentry-rails/examples/rails-6.0/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get '500', :to => 'welcome#report_demo'
   root to: "welcome#index"
 
+  get 'appearance', to: 'welcome#appearance'
   get 'view_error', to: 'welcome#view_error'
   get 'worker_error', to: 'welcome#worker_error'
   get 'job_error', to: 'welcome#job_error'

--- a/sentry-rails/lib/sentry/rails/action_cable.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable.rb
@@ -1,0 +1,72 @@
+module Sentry
+  module Rails
+    module ActionCable
+      class ErrorHandler
+        ACTION_CABLE_NAME = 'ActionCable'
+
+        def self.capture(env, transaction_name:, extra_context: nil, &block)
+          Sentry.with_scope do |scope|
+            scope.set_rack_env(env)
+            scope.set_extras(action_cable: extra_context) if extra_context
+            scope.set_transaction_name("#{ACTION_CABLE_NAME}/#{transaction_name}")
+
+            begin
+              block.call
+            rescue Exception => e # rubocop:disable Lint/RescueException
+              Sentry::Rails.capture_exception(e)
+
+              raise
+            end
+          end
+        end
+      end
+
+      module Connection
+        private
+
+        def handle_open
+          ErrorHandler.capture(env, transaction_name: "#{self.class.name}#connect") do
+            super
+          end
+        end
+
+        def handle_close
+          ErrorHandler.capture(env, transaction_name: "#{self.class.name}#disconnect") do
+            super
+          end
+        end
+      end
+
+      module Channel
+        module Subscriptions
+          def self.included(base)
+            base.class_eval do
+              set_callback :subscribe, :around, ->(_, block) { sentry_capture(:subscribed, &block) }, prepend: true
+              set_callback :unsubscribe, :around, ->(_, block) { sentry_capture(:unsubscribed, &block) }, prepend: true
+            end
+          end
+
+          private
+
+          def sentry_capture(hook, &block)
+            extra_context = { params: params }
+
+            ErrorHandler.capture(connection.env, transaction_name: "#{self.class.name}##{hook}", extra_context: extra_context, &block)
+          end
+        end
+
+        module Actions
+          private
+
+          def dispatch_action(action, data)
+            extra_context = { params: params, data: data }
+
+            ErrorHandler.capture(connection.env, transaction_name: "#{self.class.name}##{action}", extra_context: extra_context) do
+              super
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sentry-rails/spec/sentry/rails/action_cable_spec.rb
+++ b/sentry-rails/spec/sentry/rails/action_cable_spec.rb
@@ -1,0 +1,85 @@
+if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
+  require "spec_helper"
+  require "action_cable/engine"
+  require "action_cable/connection/test_case"
+  require "action_cable/channel/test_case"
+
+  # ensure we can access `connection.env` in tests like we can in production
+  ActiveSupport.on_load :action_cable_channel_test_case do
+    class ::ActionCable::Channel::ConnectionStub
+      def env
+        @_env ||= ::ActionCable::Connection::TestRequest.create.env
+      end
+    end
+  end
+
+  class ChatChannel < ::ActionCable::Channel::Base
+    def subscribed
+      raise "foo"
+    end
+  end
+
+  class AppearanceChannel < ::ActionCable::Channel::Base
+    def appear
+      raise "foo"
+    end
+  end
+
+  RSpec.describe "Sentry::Rails::ActionCable" do
+    let(:transport) { Sentry.get_current_client.transport }
+
+    before(:all) do
+      make_basic_app
+      ::ActionCable.server.config.cable = { "adapter" => "test" }
+    end
+
+    describe ChatChannel do
+      include ActionCable::Channel::TestCase::Behavior
+
+      tests ChatChannel
+
+      it "captures errors during the subscribe" do
+        expect { subscribe room_id: 42 }.to raise_error('foo')
+
+        event = transport.events.last.to_json_compatible
+
+        expect(event).to include(
+          "transaction" => "ActionCable/ChatChannel#subscribed",
+          "extra" => {
+            "action_cable" => {
+              "params" => { "room_id" => 42 }
+            }
+          }
+        )
+
+        expect(Sentry.get_current_scope.extra).to eq({})
+      end
+    end
+
+    describe AppearanceChannel do
+      include ActionCable::Channel::TestCase::Behavior
+
+      tests AppearanceChannel
+
+      before { subscribe room_id: 42 }
+
+      it "captures errors during the action" do
+        expect { perform :appear, foo: 'bar' }.to raise_error('foo')
+
+        event = transport.events.last.to_json_compatible
+
+        expect(event).to include(
+          "transaction" => "ActionCable/AppearanceChannel#appear",
+          "extra" => {
+            "action_cable" => {
+              "params" => { "room_id" => 42 },
+              "data" => { "action" => "appear", "foo" => "bar" }
+            }
+          }
+        )
+
+        expect(Sentry.get_current_scope.extra).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi again @st0012! Sorry it took me a couple weeks to get back to this. I've reissued this now that 4.2 has already been released.

I mentioned this in https://github.com/getsentry/sentry-ruby/issues/470#issuecomment-708533493 (and https://github.com/getsentry/sentry-ruby/issues/470#issuecomment-709291341), and now that 4.x is reasonably stable, thought it worth getting this PR out there.

There are 5 types of hooks that Action Cable provides:

* `Connection#connect`
* `Connection#disconnect`
* `Channel#subscribed`
* `Channel#unsubscribed`
* `Channel` actions

Now, any exceptions raised within those hooks are captured by Sentry, and reported as `ActionCable/[...]` transactions. Additional context is included depending on the hook the exception was raised within.

A note/quirk: the Rack env that's included in the scope is from the `Connection`, and therefore has a URL of the cable `mount_path` (usually `/cable`) as well as the headers from that initial connection request.

Additionally, there is not currently a really clean way to hook in and set `user_context`. I don't know if that is a blocker for this integration, but wanted to make sure it was noted.

Finally, this is limited to Rails 6+, as the hooks used (`action_cable_connection` and `action_cable_channel`) weren't introduced until then (and neither were the test helpers).

Closes #470.