### PR TITLE
Rails.logger methods return breadcrumbs instead of true when breadcrumbs logging is enabled

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Fixes [#1307](https://github.com/getsentry/sentry-ruby/issues/1307)
 - Refactor tracing implementation [#1309](https://github.com/getsentry/sentry-ruby/pull/1309)
 - Allow configuring BreadcrumbBuffer's size limit [#1310](https://github.com/getsentry/sentry-ruby/pull/1310)
+- Return nil from logger methods instead of breadcrumb buffer [#1299](https://github.com/getsentry/sentry-ruby/pull/1299)
 
 ## 4.2.2
 

--- a/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb
@@ -14,6 +14,7 @@ module Sentry
       def add(*args, &block)
         super
         add_breadcrumb(*args, &block)
+        nil
       end
 
       def add_breadcrumb(severity, message = nil, progname = nil)

--- a/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe "Sentry::Breadcrumbs::SentryLogger" do
     expect(breadcrumb.message).to eq("foo")
   end
 
+  it "does not affect the return of the logger call" do
+    expect(logger.info("foo")).to be_nil
+  end
+
   it "ignores traces with #{Sentry::LOGGER_PROGNAME}" do
     logger.info(Sentry::LOGGER_PROGNAME) { "foo" }
 


### PR DESCRIPTION
I started writing a bug issue, then thought I'd make the code change and see if any tests fail, and go from there. Saves creating a separate PR when the code change is this small is all =) (at least, small right now, who knows it could balloon! or just be rejected, that's fine also =))

**Describe the bug**

Without configuring `breadcrumbs_logger`, `Rails.logger.info` returns `true` (or `nil` depending on the app).

After configuring `breadcrumbs_logger`, `Rails.logger.info` returns the entire breadcrumb buffer: https://github.com/getsentry/sentry-ruby/blob/sentry-ruby-v4.2.2/sentry-ruby/lib/sentry/breadcrumb_buffer.rb#L16

This is because `Logger` methods return the last value, and since Sentry's logger [prepends](https://github.com/getsentry/sentry-ruby/blob/sentry-rails-v4.2.2/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb#L87) the `add` method and [calls super](https://github.com/getsentry/sentry-ruby/blob/sentry-rails-v4.2.2/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb#L15), it's the last method to run, so it's return value will be returned.

Unfortunately our (big) app has been logging at the end of lots of methods, and it's been ok up til now because we haven't cared about the return value and luckily the return value has been `true` or `nil`. However now, with adding breadcrumb logging, we're getting unexpectedly big return values.

Of course, we should be controlling our return values, and we will be putting the work in to do this, but it's a lot of work at the moment. So I'm wondering if this is required functionality of the Sentry logger, or it's possible to change? It feels odd to me for breadcrumbs data to be exposed through the logging interface.

Thanks in advance,
Henry

**To Reproduce**

In a `rails console`, regardless of env:
```rb
logger = ActiveSupport::Logger.new(STDOUT)
logger.info('hello')
```

This is for reproducing in a console, but it occurs in our app (even in testing) through `Rails.logger`. I can't seem to reproduce it with `Rails.logger` in a console, only with `ActiveSupport::Logger.new`, but the output detailed below is what I also get from `Rails.logger`.

**Expected behavior**
```bash
$ RAILS_ENV=test RACK_ENV=test bundle exec rails c
Loading test environment (Rails 6.0.3.5)
irb(main):001:0> logger=ActiveSupport::Logger.new(STDOUT)
=> #<ActiveSupport::Logger:0x00007fbf0d8572c0 @level=0, @progname=nil, @default_formatter=#<Logger::Formatter:0x00007fbf0d857180 @datetime_format=nil>, @formatter=#<ActiveSupport::Logger::SimpleFormatter:0x00007fbf0d857090 @datetime_format=nil>, @logdev=#<Logger::LogDevice:0x00007fbf0d857130 @shift_period_suffix=nil, @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @mon_mutex=#<Thread::Mutex:0x00007fbf0d8570b8>, @mon_mutex_owner_object_id=70229271165080, @mon_owner=nil, @mon_count=0>>
irb(main):002:0> logger.info('hello')
hello
=> nil
```

**Actual behavior**
```bash
$ RAILS_ENV=test RACK_ENV=test bundle exec rails c
Loading test environment (Rails 6.0.3.5)
irb(main):001:0> logger=ActiveSupport::Logger.new(STDOUT)
=> #<ActiveSupport::Logger:0x00007fbf0d8572c0 @level=0, @progname=nil, @default_formatter=#<Logger::Formatter:0x00007fbf0d857180 @datetime_format=nil>, @formatter=#<ActiveSupport::Logger::SimpleFormatter:0x00007fbf0d857090 @datetime_format=nil>, @logdev=#<Logger::LogDevice:0x00007fbf0d857130 @shift_period_suffix=nil, @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @mon_mutex=#<Thread::Mutex:0x00007fbf0d8570b8>, @mon_mutex_owner_object_id=70229271165080, @mon_owner=nil, @mon_count=0>>
irb(main):002:0> logger.info('hello')
hello
=> [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, #<Sentry::Breadcrumb:0x00007fbf0d8239e8 @category="logger", @data={}, @level="info", @message="hello", @timestamp=1614349479, @type="info">]
irb(main):003:0> logger.info('hello')
hello
=> nil
```

It seems the first log always returns the breadcrumbs. If it doesn't, adding a breadcrumb will cause the next log to return the breadcrumbs:
```bash
# continuation of previous shell
irb(main):004:0> Rails.logger.add_breadcrumb(Logger::INFO, 'a breadcrumb')
=> [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, #<Sentry::Breadcrumb:0x00007fbf0d8239e8 @category="logger", @data={}, @level="info", @message="hello", @timestamp=1614349479, @type="info">, #<Sentry::Breadcrumb:0x00007fbf0df55dd8 @category="logger", @data={}, @level="info", @message="a breadcrumb", @timestamp=1614349612, @type="info">]
irb(main):005:0> logger.info('hello')
hello
=> [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, #<Sentry::Breadcrumb:0x00007fbf0d8239e8 @category="logger", @data={}, @level="info", @message="hello", @timestamp=1614349479, @type="info">, #<Sentry::Breadcrumb:0x00007fbf0df55dd8 @category="logger", @data={}, @level="info", @message="a breadcrumb", @timestamp=1614349612, @type="info">, #<Sentry::Breadcrumb:0x00007fbf0df59b18 @category="logger", @data={}, @level="info", @message="hello", @timestamp=1614349613, @type="info">]
```

**Environment**
 - Ruby Version: 2.6.6
 - SDK Version: 4.2.2
 - Integration Versions (if any):
  - Rails 6.0.3.5

**Raven Config**

This is not necessary but could be helpful.

```ruby
Sentry.init do |config|
  config.dsn = Rails.configuration.sentry.fetch(:sentry_dsn)
  config.enabled_environments = %w[production staging]
  config.send_default_pii = true

  filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
  # See https://docs.sentry.io/platforms/ruby/guides/rails/configuration/filtering/#using-beforesend
  config.before_send = lambda do |event, _hint|
    # note1: if you have config.async configured, the event here will be a Hash instead of an Event object
    # note2: the code below is just an example, you should adjust the logic based on your needs
    event.request.data = filter.filter(event.request.data)
    event
  end

  config.breadcrumbs_logger = [:sentry_logger]

  config.traces_sample_rate = 0.5
end
```