### PR TITLE
Refactor tracing implementation

### DIFF
--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -29,11 +29,14 @@ module Sentry
         Sentry::Rails.capture_exception(exception)
       end
 
-      def finish_transaction(transaction, status_code)
-        if @assets_regex.nil? || !transaction.name.match?(@assets_regex)
-          transaction.set_http_status(status_code)
-          transaction.finish
+      def start_transaction(env, scope)
+        transaction = super
+
+        if @assets_regex && transaction.name.match?(@assets_regex)
+          transaction.instance_variable_set(:@sampled, false)
         end
+
+        transaction
       end
     end
   end

--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -29,10 +29,10 @@ module Sentry
         Sentry::Rails.capture_exception(exception)
       end
 
-      def finish_span(span, status_code)
-        if @assets_regex.nil? || !span.name.match?(@assets_regex)
-          span.set_http_status(status_code)
-          span.finish
+      def finish_transaction(transaction, status_code)
+        if @assets_regex.nil? || !transaction.name.match?(@assets_regex)
+          transaction.set_http_status(status_code)
+          transaction.finish
         end
       end
     end

--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Refactor interface construction [#1296](https://github.com/getsentry/sentry-ruby/pull/1296)
 - Ignore sentry-trace when tracing is not enabled [#1308](https://github.com/getsentry/sentry-ruby/pull/1308)
   - Fixes [#1307](https://github.com/getsentry/sentry-ruby/issues/1307)
+- Refactor tracing implementation [#1309](https://github.com/getsentry/sentry-ruby/pull/1309)
 
 ## 4.2.2
 

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -71,7 +71,7 @@ module Sentry
 
     def start_transaction(transaction: nil, **options)
       transaction ||= Transaction.new(**options)
-      transaction.set_initial_sample_desicion
+      transaction.set_initial_sample_decision
       transaction
     end
 

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -69,9 +69,9 @@ module Sentry
       @stack.pop
     end
 
-    def start_transaction(transaction: nil, **options)
+    def start_transaction(transaction: nil, configuration: Sentry.configuration, **options)
       transaction ||= Transaction.new(**options)
-      transaction.set_initial_sample_decision
+      transaction.set_initial_sample_decision(configuration: current_client.configuration)
       transaction
     end
 

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -16,10 +16,7 @@ module Sentry
           scope.set_transaction_name(env["PATH_INFO"]) if env["PATH_INFO"]
           scope.set_rack_env(env)
 
-          sentry_trace = env["HTTP_SENTRY_TRACE"]
-          transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, name: scope.transaction_name, op: transaction_op) if sentry_trace
-          transaction ||= Sentry.start_transaction(name: scope.transaction_name, op: transaction_op)
-
+          transaction = start_transaction(env, scope)
           scope.set_span(transaction)
 
           begin
@@ -55,6 +52,13 @@ module Sentry
       def capture_exception(exception)
         Sentry.capture_exception(exception)
       end
+
+      def start_transaction(env, scope)
+        sentry_trace = env["HTTP_SENTRY_TRACE"]
+        transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, name: scope.transaction_name, op: transaction_op) if sentry_trace
+        transaction || Sentry.start_transaction(name: scope.transaction_name, op: transaction_op)
+      end
+
 
       def finish_transaction(transaction, status_code)
         transaction.set_http_status(status_code)

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -25,8 +25,8 @@ module Sentry
       @span_recorder.add(self)
     end
 
-    def self.from_sentry_trace(sentry_trace, **options)
-      return unless Sentry.configuration.tracing_enabled?
+    def self.from_sentry_trace(sentry_trace, configuration: Sentry.configuration, **options)
+      return unless configuration.tracing_enabled?
       return unless sentry_trace
 
       match = SENTRY_TRACE_REGEXP.match(sentry_trace)
@@ -68,8 +68,8 @@ module Sentry
       copy
     end
 
-    def set_initial_sample_decision(sampling_context = {})
-      unless Sentry.configuration.tracing_enabled?
+    def set_initial_sample_decision(sampling_context: {}, configuration: Sentry.configuration)
+      unless configuration.tracing_enabled?
         @sampled = false
         return
       end
@@ -78,9 +78,9 @@ module Sentry
 
       transaction_description = generate_transaction_description
 
-      logger = Sentry.configuration.logger
-      sample_rate = Sentry.configuration.traces_sample_rate
-      traces_sampler = Sentry.configuration.traces_sampler
+      logger = configuration.logger
+      sample_rate = configuration.traces_sample_rate
+      traces_sampler = configuration.traces_sampler
 
       if traces_sampler.is_a?(Proc)
         sampling_context = sampling_context.merge(

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -68,7 +68,7 @@ module Sentry
       copy
     end
 
-    def set_initial_sample_desicion(sampling_context = {})
+    def set_initial_sample_decision(sampling_context = {})
       unless Sentry.configuration.tracing_enabled?
         @sampled = false
         return

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Sentry::Transaction do
     end
   end
 
-  describe "#set_initial_sample_desicion" do
+  describe "#set_initial_sample_decision" do
     before do
       perform_basic_setup
     end
@@ -135,7 +135,7 @@ RSpec.describe Sentry::Transaction do
         allow(Sentry.configuration).to receive(:tracing_enabled?).and_return(false)
 
         transaction = described_class.new(sampled: true)
-        transaction.set_initial_sample_desicion
+        transaction.set_initial_sample_decision
         expect(transaction.sampled).to eq(false)
       end
     end
@@ -150,11 +150,11 @@ RSpec.describe Sentry::Transaction do
       context "when the transaction already has a decision" do
         it "doesn't change it" do
           transaction = described_class.new(sampled: true)
-          transaction.set_initial_sample_desicion
+          transaction.set_initial_sample_decision
           expect(transaction.sampled).to eq(true)
 
           transaction = described_class.new(sampled: false)
-          transaction.set_initial_sample_desicion
+          transaction.set_initial_sample_decision
           expect(transaction.sampled).to eq(false)
         end
       end
@@ -170,7 +170,7 @@ RSpec.describe Sentry::Transaction do
             "[Tracing] Starting <rack.request> transaction"
           )
 
-          subject.set_initial_sample_desicion
+          subject.set_initial_sample_decision
           expect(subject.sampled).to eq(true)
         end
 
@@ -180,14 +180,14 @@ RSpec.describe Sentry::Transaction do
             "[Tracing] Discarding <rack.request> transaction because it's not included in the random sample (sampling rate = 0.5)"
           )
 
-          subject.set_initial_sample_desicion
+          subject.set_initial_sample_decision
           expect(subject.sampled).to eq(false)
         end
 
         it "accepts integer traces_sample_rate" do
           Sentry.configuration.traces_sample_rate = 1
 
-          subject.set_initial_sample_desicion
+          subject.set_initial_sample_decision
           expect(subject.sampled).to eq(true)
         end
       end
@@ -197,7 +197,7 @@ RSpec.describe Sentry::Transaction do
           Sentry.configuration.traces_sampler = ""
 
           expect do
-            subject.set_initial_sample_desicion
+            subject.set_initial_sample_decision
           end.not_to raise_error
         end
 
@@ -208,7 +208,7 @@ RSpec.describe Sentry::Transaction do
             sampling_context = context
           end
 
-          subject.set_initial_sample_desicion(foo: "bar")
+          subject.set_initial_sample_decision(foo: "bar")
 
           # transaction_context's sampled attribute will be the old value
           expect(sampling_context[:transaction_context].keys).to eq(subject.to_hash.keys)
@@ -222,7 +222,7 @@ RSpec.describe Sentry::Transaction do
           )
 
           Sentry.configuration.traces_sampler = -> (_) { "foo" }
-          subject.set_initial_sample_desicion
+          subject.set_initial_sample_decision
 
           expect(subject.sampled).to eq(false)
         end
@@ -234,17 +234,17 @@ RSpec.describe Sentry::Transaction do
 
           subject = described_class.new
           Sentry.configuration.traces_sampler = -> (_) { true }
-          subject.set_initial_sample_desicion
+          subject.set_initial_sample_decision
           expect(subject.sampled).to eq(true)
 
           subject = described_class.new
           Sentry.configuration.traces_sampler = -> (_) { 1.0 }
-          subject.set_initial_sample_desicion
+          subject.set_initial_sample_decision
           expect(subject.sampled).to eq(true)
 
           subject = described_class.new
           Sentry.configuration.traces_sampler = -> (_) { 1 }
-          subject.set_initial_sample_desicion
+          subject.set_initial_sample_decision
           expect(subject.sampled).to eq(true)
         end
 
@@ -255,12 +255,12 @@ RSpec.describe Sentry::Transaction do
 
           subject = described_class.new
           Sentry.configuration.traces_sampler = -> (_) { false }
-          subject.set_initial_sample_desicion
+          subject.set_initial_sample_decision
           expect(subject.sampled).to eq(false)
 
           subject = described_class.new
           Sentry.configuration.traces_sampler = -> (_) { 0.0 }
-          subject.set_initial_sample_desicion
+          subject.set_initial_sample_decision
           expect(subject.sampled).to eq(false)
         end
       end


### PR DESCRIPTION
1. Fix a stupid typo on `Transaction#set_initial_sample_decision`
2. Rename some of the methods/variables in `CaptureExceptions` middleware
3. Make `CaptureExceptions` more customizable on starting transactions
4. Make performance monitoring work with the multi-configuration setup