### PR TITLE
Allow configuring BreadcrumbBuffer's size limit

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Ignore sentry-trace when tracing is not enabled [#1308](https://github.com/getsentry/sentry-ruby/pull/1308)
   - Fixes [#1307](https://github.com/getsentry/sentry-ruby/issues/1307)
 - Refactor tracing implementation [#1309](https://github.com/getsentry/sentry-ruby/pull/1309)
+- Allow configuring BreadcrumbBuffer's size limit [#1310](https://github.com/getsentry/sentry-ruby/pull/1310)
 
 ## 4.2.2
 

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -68,7 +68,7 @@ module Sentry
       config = Configuration.new
       yield(config) if block_given?
       client = Client.new(config)
-      scope = Scope.new
+      scope = Scope.new(breadcrumb_buffer_limit: config.breadcrumb_buffer_limit)
       hub = Hub.new(client, scope)
       Thread.current[THREAD_LOCAL] = hub
       @main_hub = hub

--- a/sentry-ruby/lib/sentry/breadcrumb_buffer.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb_buffer.rb
@@ -6,8 +6,8 @@ module Sentry
 
     attr_accessor :buffer
 
-    def initialize(size = 100)
-      @buffer = Array.new(size)
+    def initialize(size = nil)
+      @buffer = Array.new(size || 100)
     end
 
     def record(crumb)

--- a/sentry-ruby/lib/sentry/breadcrumb_buffer.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb_buffer.rb
@@ -2,12 +2,13 @@ require "sentry/breadcrumb"
 
 module Sentry
   class BreadcrumbBuffer
+    DEFAULT_SIZE = 100
     include Enumerable
 
     attr_accessor :buffer
 
     def initialize(size = nil)
-      @buffer = Array.new(size || 100)
+      @buffer = Array.new(size || DEFAULT_SIZE)
     end
 
     def record(crumb)

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -62,6 +62,9 @@ module Sentry
     # - :active_support_logger
     attr_reader :breadcrumbs_logger
 
+    # Max number of breadcrumbs a breadcrumb buffer can hold
+    attr_accessor :breadcrumb_buffer_limit
+
     # Number of lines of code context to capture, or nil for none
     attr_accessor :context_lines
 
@@ -172,6 +175,7 @@ module Sentry
 
     def initialize
       self.background_worker_threads = Concurrent.processor_count
+      self.breadcrumb_buffer_limit = BreadcrumbBuffer::DEFAULT_SIZE
       self.breadcrumbs_logger = []
       self.context_lines = 3
       self.environment = environment_from_env

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -9,7 +9,8 @@ module Sentry
 
     attr_reader(*ATTRIBUTES)
 
-    def initialize
+    def initialize(breadcrumb_buffer_limit: nil)
+      @breadcrumb_buffer_limit = breadcrumb_buffer_limit
       set_default_value
     end
 
@@ -47,7 +48,7 @@ module Sentry
     end
 
     def clear_breadcrumbs
-      @breadcrumbs = BreadcrumbBuffer.new
+      set_new_breadcrumb_buffer
     end
 
     def dup
@@ -171,7 +172,6 @@ module Sentry
     private
 
     def set_default_value
-      @breadcrumbs = BreadcrumbBuffer.new
       @contexts = { :os => self.class.os_context, :runtime => self.class.runtime_context }
       @extra = {}
       @tags = {}
@@ -182,7 +182,13 @@ module Sentry
       @event_processors = []
       @rack_env = {}
       @span = nil
+      set_new_breadcrumb_buffer
     end
+
+    def set_new_breadcrumb_buffer
+      @breadcrumbs = BreadcrumbBuffer.new(@breadcrumb_buffer_limit)
+    end
+
 
     class << self
       def os_context

--- a/sentry-ruby/spec/sentry/breadcrumb_buffer_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb_buffer_spec.rb
@@ -37,6 +37,24 @@ RSpec.describe Sentry::BreadcrumbBuffer do
     )
   end
 
+  describe "#record" do
+    subject do
+      described_class.new(1)
+    end
+
+    it "doesn't exceed the size limit" do
+      subject.record(crumb_1)
+
+      expect(subject.buffer.size).to eq(1)
+
+      subject.record(crumb_2)
+
+      expect(subject.buffer.size).to eq(1)
+
+      expect(subject.peek).to eq(crumb_2)
+    end
+  end
+
   describe "#to_hash" do
     it "doesn't break because of 1 problematic crumb" do
       subject.record(crumb_1)

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe Sentry::Scope do
       expect(subject.fingerprint).to eq([])
       expect(subject.transaction_names).to eq([])
     end
+
+    it "allows setting breadcrumb buffer's size limit" do
+      scope = described_class.new(breadcrumb_buffer_limit: 10)
+      expect(scope.breadcrumbs.buffer.count).to eq(10)
+    end
   end
 
   describe "#dup" do
@@ -65,6 +70,10 @@ RSpec.describe Sentry::Scope do
   end
 
   describe "#clear_breadcrumbs" do
+    subject do
+      described_class.new(breadcrumb_buffer_limit: 10)
+    end
+
     before do
       subject.add_breadcrumb(new_breadcrumb)
 
@@ -75,6 +84,7 @@ RSpec.describe Sentry::Scope do
       subject.clear_breadcrumbs
 
       expect(subject.breadcrumbs.empty?).to eq(true)
+      expect(subject.breadcrumbs.buffer.size).to eq(10)
     end
   end
 

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe Sentry do
         expect(subject.get_main_hub).to eq(current_hub)
       end
     end
+
+    it "initializes Scope with correct breadcrumb_buffer_limit" do
+      described_class.init do |config|
+        config.breadcrumb_buffer_limit = 1
+      end
+
+      current_scope = described_class.get_current_scope
+      expect(current_scope.breadcrumbs.buffer.size).to eq(1)
+    end
   end
 
   describe "#clone_hub_to_current_thread" do


### PR DESCRIPTION
Added a new option `breadcrumb_buffer_limit`:

```ruby
Sentry.init do |config|
  config.breadcrumb_buffer_limit = 20
end
```

The default value is `100`. If a new crumb is being added when the buffer is full, the buffer will remove the oldest crumb first.

closes #1305 