### PR TITLE
Compress event payload by default

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Refactor tracing implementation [#1309](https://github.com/getsentry/sentry-ruby/pull/1309)
 - Allow configuring BreadcrumbBuffer's size limit [#1310](https://github.com/getsentry/sentry-ruby/pull/1310)
 - Return nil from logger methods instead of breadcrumb buffer [#1299](https://github.com/getsentry/sentry-ruby/pull/1299)
+- Compress event payload by default [#1314](https://github.com/getsentry/sentry-ruby/pull/1314)
 
 ## 4.2.2
 

--- a/sentry-ruby/lib/sentry/transport/configuration.rb
+++ b/sentry-ruby/lib/sentry/transport/configuration.rb
@@ -1,12 +1,14 @@
 module Sentry
   class Transport
     class Configuration
-      attr_accessor :timeout, :open_timeout, :proxy, :ssl, :ssl_ca_file, :ssl_verification, :http_adapter, :faraday_builder, :transport_class
+      attr_accessor :timeout, :open_timeout, :proxy, :ssl, :ssl_ca_file, :ssl_verification, :http_adapter, :faraday_builder,
+        :transport_class, :encoding
 
       def initialize
         @ssl_verification = true
         @open_timeout = 1
         @timeout = 2
+        @encoding = HTTPTransport::GZIP_ENCODING
       end
 
       def transport_class=(klass)


### PR DESCRIPTION
Rules:
- If `config.transport.encoding == "gzip"` and the event envelope's  size is larger than 30kb, the envelope will be compressed.
- If `config.transport.encoding == "gzip"` but the event envelope's  size is smaller than 30kb, the envelope won't be compressed.
- If `config.transport.encoding != "gzip"`, the event won't be  compressed regardless how but it is.