### PR TITLE
Prevent background workers from holding ActiveRecord connections

### DIFF
--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -10,12 +10,21 @@ on:
       - 'sentry-rails/**'
       - 'sentry-ruby/**'
 jobs:
-  test:
+  test-sentry-rails:
     defaults:
       run:
         working-directory: sentry-rails
     name: Test on ruby ${{ matrix.ruby_version }} and rails ${{ matrix.rails_version }}
     runs-on: ${{ matrix.os }}
+    services:
+      mysql:
+        image: mysql:5.7
+        ports:
+          - 3306
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: test
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     strategy:
       matrix:
         rails_version: [5.0.0, 5.1.0, 5.2.0, 6.0.0, 6.1.0]
@@ -41,31 +50,33 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Install sqlite
-      run: |
-        # See https://github.community/t5/GitHub-Actions/ubuntu-latest-Apt-repository-list-issues/td-p/41122/page/2
-        for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
-        sudo apt-get update
-        sudo apt-get install libsqlite3-dev
     - name: Set up Ruby ${{ matrix.ruby_version }}
       uses: ruby/setup-ruby@v1
       with:
         bundler: 1
         ruby-version: ${{ matrix.ruby_version }}
 
+    - name: Verify MySQL connection from host
+      run: |
+        sudo apt-get install -y mysql-client
+        mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports['3306'] }} -uroot -ppassword -e "SHOW DATABASES"
+
     - name: Build with Rails ${{ matrix.rails_version }}
       env:
         RAILS_VERSION: ${{ matrix.rails_version }}
+        DB_PORT: ${{ job.services.mysql.ports['3306'] }}
       run: |
+        sudo service mysql start
         bundle install --jobs 4 --retry 3
         bundle exec rake
+
   compare_allocation:
     defaults:
       run:
         working-directory: sentry-rails
     name: Compare memory allocation with ${{ matrix.ruby_version }} and rails ${{ matrix.rails_version }}
     runs-on: ${{ matrix.os }}
-    needs: test
+    needs: test-sentry-rails
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}
     strategy:

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -58,6 +58,7 @@ jobs:
 
     - name: Verify MySQL connection from host
       run: |
+        sudo service mysql start
         sudo apt-get install -y mysql-client
         mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports['3306'] }} -uroot -ppassword -e "SHOW DATABASES"
 
@@ -66,7 +67,6 @@ jobs:
         RAILS_VERSION: ${{ matrix.rails_version }}
         DB_PORT: ${{ job.services.mysql.ports['3306'] }}
       run: |
-        sudo service mysql start
         bundle install --jobs 4 --retry 3
         bundle exec rake
 
@@ -85,6 +85,13 @@ jobs:
         ruby_version: [2.6, 2.7]
         os: [ubuntu-latest]
     steps:
+
+    - name: Verify MySQL connection from host
+      run: |
+        sudo service mysql start
+        sudo apt-get install -y mysql-client
+        mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports['3306'] }} -uroot -ppassword -e "SHOW DATABASES"
+
     - name: Set up Ruby ${{ matrix.ruby_version }}
       uses: ruby/setup-ruby@v1
       with:

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -7,13 +7,9 @@ rails_version = ENV["RAILS_VERSION"]
 rails_version = "6.1.0" if rails_version.nil?
 
 gem 'activerecord-jdbcmysql-adapter', platform: :jruby
-gem "jdbc-sqlite3", platform: :jruby
+gem "jdbc-mysql", platform: :jruby
 
-if rails_version.to_f < 6
-  gem "sqlite3", "~> 1.3.0", platform: :ruby
-else
-  gem "sqlite3", platform: :ruby
-end
+gem "mysql2", platform: :ruby
 
 gem "rails", "~> #{rails_version}"
 gem "sprockets-rails"

--- a/sentry-rails/lib/sentry/rails.rb
+++ b/sentry-rails/lib/sentry/rails.rb
@@ -1,5 +1,6 @@
 require "sentry-ruby"
 require "sentry/integrable"
+require "sentry/rails/client"
 require "sentry/rails/configuration"
 require "sentry/rails/engine"
 require "sentry/rails/railtie"

--- a/sentry-rails/lib/sentry/rails/client.rb
+++ b/sentry-rails/lib/sentry/rails/client.rb
@@ -1,0 +1,12 @@
+module Sentry
+  class Client
+    def dispatch_background_event(event, hint)
+      Sentry.background_worker.perform do
+        # make sure the background worker returns AR connection if it accidentally acquire one during serialization
+        ActiveRecord::Base.connection_pool.with_connection do
+          send_event(event, hint)
+        end
+      end
+    end
+  end
+end

--- a/sentry-rails/spec/sentry/rails/client_spec.rb
+++ b/sentry-rails/spec/sentry/rails/client_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+
+RSpec.describe Sentry::Client, type: :request do
+  let(:transport) do
+    Sentry.get_current_client.transport
+  end
+
+  context "when serialization triggers ActiveRecord queries" do
+    before do
+      make_basic_app do |config|
+        config.background_worker_threads = 5
+        # simulate connection being obtained during event serialization
+        # this could happen when serializing breadcrumbs
+        config.before_send = lambda do |event, hint|
+          Post.count
+          event
+        end
+      end
+    end
+
+    it "doesn't hold the ActiveRecord connection after sending the event" do
+      threads = 5.times.map do |i|
+        Thread.new do
+          Sentry::Rails.capture_message("msg", hint: { index: i })
+        end
+      end
+
+      threads.join
+
+      sleep(0.1)
+
+      expect(transport.events.count).to eq(5)
+
+      pool = ActiveRecord::Base.connection_pool
+      expect(pool.stat[:busy]).to eq(1)
+    end
+  end
+
+  context "when doesn't serialization trigger ActiveRecord queries" do
+    before do
+      make_basic_app do |config|
+        config.background_worker_threads = 5
+      end
+    end
+
+    it "doesn't hold the ActiveRecord connection after sending the event" do
+      threads = 5.times.map do |i|
+        Thread.new do
+          Sentry::Rails.capture_message("msg", hint: { index: i })
+        end
+      end
+
+      threads.join
+
+      sleep(0.1)
+
+      expect(transport.events.count).to eq(5)
+
+      pool = ActiveRecord::Base.connection_pool
+      expect(pool.stat[:busy]).to eq(1)
+    end
+  end
+end

--- a/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
 
       span = transaction[:spans][0]
       expect(span[:op]).to eq("sql.active_record")
-      expect(span[:description]).to eq("SELECT \"posts\".* FROM \"posts\"")
+      expect(span[:description]).to eq("SELECT `posts`.* FROM `posts`")
       expect(span[:trace_id]).to eq(transaction.dig(:contexts, :trace, :trace_id))
     end
   end

--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
 
       first_span = transaction[:spans][0]
       expect(first_span[:op]).to eq("sql.active_record")
-      expect(first_span[:description]).to eq("SELECT \"posts\".* FROM \"posts\"")
+      expect(first_span[:description]).to eq("SELECT `posts`.* FROM `posts`")
       expect(first_span[:parent_span_id]).to eq(parent_span_id)
 
       # this is to make sure we calculate the timestamp in the correct scale (second instead of millisecond)
@@ -71,8 +71,8 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
 
       first_span = transaction[:spans][0]
       expect(first_span[:op]).to eq("sql.active_record")
-      expect(first_span[:description].squeeze("\s")).to eq(
-        'SELECT "posts".* FROM "posts" WHERE "posts"."id" = ? LIMIT ?'
+      expect(first_span[:description].squeeze("\s")).to match(
+        /SELECT `posts`.* FROM `posts` WHERE `posts`.`id` = \d+ LIMIT 1/
       )
       expect(first_span[:parent_span_id]).to eq(parent_span_id)
 

--- a/sentry-rails/spec/support/test_rails_app/app.rb
+++ b/sentry-rails/spec/support/test_rails_app/app.rb
@@ -10,13 +10,16 @@ require 'sentry/rails'
 
 ActiveSupport::Deprecation.silenced = true
 
+password = ENV["CI"].present? ? "password" : ""
+
 ActiveRecord::Base.establish_connection(
   adapter: "mysql2",
   database: "test",
-  port: ENV["DB_PORT"],
+  collation: "utf8_general_ci",
+  port: ENV["DB_PORT"] || 3306,
   host: "127.0.0.1",
   username: "root",
-  password: "password"
+  password: password
 )
 # ActiveRecord::Base.logger = Logger.new($stdout)
 ActiveRecord::Base.logger = Logger.new(nil)

--- a/sentry-rails/spec/support/test_rails_app/app.rb
+++ b/sentry-rails/spec/support/test_rails_app/app.rb
@@ -10,7 +10,8 @@ require 'sentry/rails'
 
 ActiveSupport::Deprecation.silenced = true
 
-ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+ActiveRecord::Base.establish_connection(adapter: "mysql2", database: "test")
+# ActiveRecord::Base.logger = Logger.new($stdout)
 ActiveRecord::Base.logger = Logger.new(nil)
 
 ActiveRecord::Schema.define do

--- a/sentry-rails/spec/support/test_rails_app/app.rb
+++ b/sentry-rails/spec/support/test_rails_app/app.rb
@@ -10,7 +10,14 @@ require 'sentry/rails'
 
 ActiveSupport::Deprecation.silenced = true
 
-ActiveRecord::Base.establish_connection(adapter: "mysql2", database: "test")
+ActiveRecord::Base.establish_connection(
+  adapter: "mysql2",
+  database: "test",
+  port: ENV["DB_PORT"],
+  host: "127.0.0.1",
+  username: "root",
+  password: "password"
+)
 # ActiveRecord::Base.logger = Logger.new($stdout)
 ActiveRecord::Base.logger = Logger.new(nil)
 


### PR DESCRIPTION
When the SDK's background workers serializing events for a Rails application, it could implicitly trigger database queries by serializing data that contain `ActiveRecord` models/records (e.g. when serializing breadcrumbs). And by triggering the queries, those workers will also obtain database connections from the connection pool and hold them forever. This will later cause the application to run out of available connections.

This PR solves the issue by using `ActiveRecord::ConnectionPool#with_connection` method to force background workers to release any connection they might obtain during the serialization work.