### PR TITLE
Prevent background workers from holding ActiveRecord connections

### DIFF
--- a/sentry-rails/.gitignore
+++ b/sentry-rails/.gitignore
@@ -5,6 +5,7 @@
 /doc/
 /pkg/
 /spec/reports/
+/spec/support/test_rails_app/db
 /tmp/
 
 # rspec failure tracking

--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Support performance monitoring on ActiveJob execution [#1304](https://github.com/getsentry/sentry-ruby/pull/1304)
+- Prevent background workers from holding ActiveRecord connections [#1320](https://github.com/getsentry/sentry-ruby/pull/1320)
 
 ## 4.2.2
 

--- a/sentry-rails/lib/sentry/rails.rb
+++ b/sentry-rails/lib/sentry/rails.rb
@@ -1,5 +1,6 @@
 require "sentry-ruby"
 require "sentry/integrable"
+require "sentry/rails/background_worker"
 require "sentry/rails/configuration"
 require "sentry/rails/engine"
 require "sentry/rails/railtie"

--- a/sentry-rails/lib/sentry/rails/background_worker.rb
+++ b/sentry-rails/lib/sentry/rails/background_worker.rb
@@ -1,0 +1,14 @@
+module Sentry
+  class BackgroundWorker
+    alias_method :original_perform, :perform
+
+    def perform(&block)
+      @executor.post do
+        # make sure the background worker returns AR connection if it accidentally acquire one during serialization
+        ActiveRecord::Base.connection_pool.with_connection do
+          block.call
+        end
+      end
+    end
+  end
+end

--- a/sentry-rails/spec/sentry/rails/client_spec.rb
+++ b/sentry-rails/spec/sentry/rails/client_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+
+RSpec.describe Sentry::Client, type: :request do
+  let(:transport) do
+    Sentry.get_current_client.transport
+  end
+
+  context "when serialization triggers ActiveRecord queries" do
+    before do
+      make_basic_app do |config|
+        config.background_worker_threads = 5
+        # simulate connection being obtained during event serialization
+        # this could happen when serializing breadcrumbs
+        config.before_send = lambda do |event, hint|
+          Post.count
+          event
+        end
+      end
+    end
+
+    it "doesn't hold the ActiveRecord connection after sending the event" do
+      threads = 5.times.map do |i|
+        Thread.new do
+          Sentry::Rails.capture_message("msg", hint: { index: i })
+        end
+      end
+
+      threads.join
+
+      sleep(0.1)
+
+      expect(transport.events.count).to eq(5)
+
+      pool = ActiveRecord::Base.connection_pool
+      expect(pool.stat[:busy]).to eq(1)
+    end
+  end
+
+  context "when doesn't serialization trigger ActiveRecord queries" do
+    before do
+      make_basic_app do |config|
+        config.background_worker_threads = 5
+      end
+    end
+
+    it "doesn't hold the ActiveRecord connection after sending the event" do
+      threads = 5.times.map do |i|
+        Thread.new do
+          Sentry::Rails.capture_message("msg", hint: { index: i })
+        end
+      end
+
+      threads.join
+
+      sleep(0.1)
+
+      expect(transport.events.count).to eq(5)
+
+      pool = ActiveRecord::Base.connection_pool
+      expect(pool.stat[:busy]).to eq(1)
+    end
+  end
+end

--- a/sentry-rails/spec/support/test_rails_app/app.rb
+++ b/sentry-rails/spec/support/test_rails_app/app.rb
@@ -10,7 +10,11 @@ require 'sentry/rails'
 
 ActiveSupport::Deprecation.silenced = true
 
-ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+# need to init app before establish connection so sqlite can place the database file under the correct project root
+class TestApp < Rails::Application
+end
+
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "db")
 ActiveRecord::Base.logger = Logger.new(nil)
 
 ActiveRecord::Schema.define do
@@ -28,9 +32,6 @@ end
 
 class Comment < ActiveRecord::Base
   belongs_to :post
-end
-
-class TestApp < Rails::Application
 end
 
 class PostsController < ActionController::Base


### PR DESCRIPTION
When the SDK's background workers serializing events for a Rails application, it could implicitly trigger database queries by serializing data that contain ActiveRecord models/records (e.g. when serializing breadcrumbs). And by triggering the queries, those workers will also obtain database connections from the connection pool and hold them forever. This will later cause the application to run out of available connections.

This PR solves the issue by using `ActiveRecord::ConnectionPool#with_connection` method to force background workers to release any connection they might obtain during the serialization work.