### PR TITLE
Test sentry rails integration separately

### DIFF
--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -40,4 +40,4 @@ jobs:
     - name: Run specs
       run: |
         bundle install --jobs 4 --retry 3
-        bundle exec rake
+        make test

--- a/sentry-sidekiq/Makefile
+++ b/sentry-sidekiq/Makefile
@@ -1,3 +1,7 @@
 build:
 	bundle install
 	gem build sentry-sidekiq.gemspec
+
+test:
+	bundle exec rspec
+	WITH_SENTRY_RAILS=1 bundle exec rspec spec/sentry/rails_spec.rb

--- a/sentry-sidekiq/spec/sentry/rails_spec.rb
+++ b/sentry-sidekiq/spec/sentry/rails_spec.rb
@@ -1,3 +1,5 @@
+return unless ENV["WITH_SENTRY_RAILS"]
+
 require "rails"
 require "sentry-rails"
 require "spec_helper"


### PR DESCRIPTION
Most of the sentry-sidekiq tests should be run without sentry-rails and rails. And since there's no easy way to unload those gems in an RSpec process, we should use 2 processes to test them separately.