### PR TITLE
Fix sampling decision with sentry-trace and add more tests

### DIFF
--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -32,6 +32,8 @@ module Sentry
       def start_transaction(env, scope)
         transaction = super
 
+        return unless transaction
+
         if @assets_regex && transaction.name.match?(@assets_regex)
           transaction.instance_variable_set(:@sampled, false)
         end

--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -29,6 +29,7 @@ config.max_breadcrumbs = 10
 - Return nil from logger methods instead of breadcrumb buffer [#1299](https://github.com/getsentry/sentry-ruby/pull/1299)
 - Exceptions with nil message shouldn't cause issues [#1327](https://github.com/getsentry/sentry-ruby/pull/1327)
   - Fixes [#1323](https://github.com/getsentry/sentry-ruby/issues/1323)
+- Fix sampling decision with sentry-trace and add more tests [#1326](https://github.com/getsentry/sentry-ruby/pull/1326)
 
 ## 4.2.2
 

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -70,6 +70,8 @@ module Sentry
     end
 
     def start_transaction(transaction: nil, configuration: Sentry.configuration, **options)
+      return unless configuration.tracing_enabled?
+
       transaction ||= Transaction.new(**options)
       transaction.set_initial_sample_decision(configuration: current_client.configuration)
       transaction

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -55,8 +55,9 @@ module Sentry
 
       def start_transaction(env, scope)
         sentry_trace = env["HTTP_SENTRY_TRACE"]
-        transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, name: scope.transaction_name, op: transaction_op) if sentry_trace
-        transaction || Sentry.start_transaction(name: scope.transaction_name, op: transaction_op)
+        options = { name: scope.transaction_name, op: transaction_op }
+        transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, **options) if sentry_trace
+        Sentry.start_transaction(transaction: transaction, **options)
       end
 
 

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -17,7 +17,7 @@ module Sentry
           scope.set_rack_env(env)
 
           transaction = start_transaction(env, scope)
-          scope.set_span(transaction)
+          scope.set_span(transaction) if transaction
 
           begin
             response = @app.call(env)
@@ -62,6 +62,8 @@ module Sentry
 
 
       def finish_transaction(transaction, status_code)
+        return unless transaction
+
         transaction.set_http_status(status_code)
         transaction.finish
       end

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -33,7 +33,12 @@ module Sentry
       return if match.nil?
       trace_id, parent_span_id, sampled_flag = match[1..3]
 
-      sampled = sampled_flag != "0"
+      sampled =
+        if sampled_flag.nil?
+          nil
+        else
+          sampled_flag != "0"
+        end
 
       new(trace_id: trace_id, parent_span_id: parent_span_id, parent_sampled: sampled, sampled: sampled, **options)
     end

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -178,19 +178,31 @@ RSpec.describe Sentry do
   end
 
   describe ".start_transaction" do
-    it "starts a new transaction" do
-      transaction = described_class.start_transaction(op: "foo")
-      expect(transaction).to be_a(Sentry::Transaction)
-      expect(transaction.op).to eq("foo")
+    context "when tracing is enabled" do
+      before do
+        Sentry.configuration.traces_sample_rate = 1.0
+      end
+
+      it "starts a new transaction" do
+        transaction = described_class.start_transaction(op: "foo")
+        expect(transaction).to be_a(Sentry::Transaction)
+        expect(transaction.op).to eq("foo")
+      end
+
+      context "when given an transaction object" do
+        it "adds sample decision to it" do
+          transaction = Sentry::Transaction.new
+
+          described_class.start_transaction(transaction: transaction)
+
+          expect(transaction.sampled).to eq(true)
+        end
+      end
     end
 
-    context "when given an transaction object" do
-      it "adds sample decision to it" do
-        transaction = Sentry::Transaction.new
-
-        described_class.start_transaction(transaction: transaction)
-
-        expect(transaction.sampled).to eq(false)
+    context "when tracing is disabled" do
+      it "returns nil" do
+        expect(described_class.start_transaction(op: "foo")).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
1. Corrected `sentry-trace`'s sampling bit interpretation.
   - empty bit means let the receiver SDK make the sampling decision
2. `Hub#start_transaction` should return `nil` when tracing is disabled
3. transaction generated from `sentry-trace` should still go through `Hub#start_transaction`
4. Added more test cases to cover all the combinations described in this picture
<img width="50%" alt="trace sampling vs tracing activation" src="https://user-images.githubusercontent.com/5079556/110910376-33846580-834c-11eb-8d6a-e4f80fbe8f4a.png">
