### PR TITLE
fix(tracing): Never send transactions if tracing is disabled

### DIFF
--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -164,6 +164,8 @@ module Sentry
 
     # Takes or initializes a new Sentry::Transaction and makes a sampling decision for it.
     def start_transaction(**options)
+      return unless configuration.tracing_enabled?
+
       get_current_hub&.start_transaction(**options)
     end
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -293,7 +293,7 @@ module Sentry
     end
 
     def tracing_enabled?
-      !!((@traces_sample_rate && @traces_sample_rate > 0.0) || @traces_sampler)
+      !!(@traces_sampler || (@traces_sample_rate.is_a?(Numeric) && @traces_sample_rate >= 0.0 && @traces_sample_rate <= 1.0))
     end
 
     def stacktrace_builder

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -70,6 +70,8 @@ module Sentry
     end
 
     def start_transaction(transaction: nil, configuration: Sentry.configuration, **options)
+      return unless configuration.tracing_enabled?
+
       transaction ||= Transaction.new(**options)
       transaction.set_initial_sample_decision(configuration: current_client.configuration)
       transaction

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -54,6 +54,8 @@ module Sentry
       end
 
       def start_transaction(env, scope)
+        return unless Sentry.configuration.tracing_enabled?
+
         sentry_trace = env["HTTP_SENTRY_TRACE"]
         transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, name: scope.transaction_name, op: transaction_op) if sentry_trace
         transaction || Sentry.start_transaction(name: scope.transaction_name, op: transaction_op)

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -57,8 +57,11 @@ module Sentry
         return unless Sentry.configuration.tracing_enabled?
 
         sentry_trace = env["HTTP_SENTRY_TRACE"]
-        transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, name: scope.transaction_name, op: transaction_op) if sentry_trace
-        transaction || Sentry.start_transaction(name: scope.transaction_name, op: transaction_op)
+        options = {name: scope.transaction_name, op: transaction_op}
+
+        # if tracing is disabled, these will both return nil
+        transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, **options) if sentry_trace
+        Sentry.start_transaction(transaction: transaction, **options)
       end
 
 

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -119,6 +119,9 @@ module Sentry
     end
 
     def finish(hub: nil)
+      # it's unlikely we'd get this far if tracing is disabled, but just in case...
+      return unless Sentry.configuration.tracing_enabled?
+
       super() # Span#finish doesn't take arguments
 
       if @name.nil?

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -33,7 +33,13 @@ module Sentry
       return if match.nil?
       trace_id, parent_span_id, sampled_flag = match[1..3]
 
-      sampled = sampled_flag != "0"
+      if sampled_flag == "1"
+        parent_sampled = true
+      elsif sampled_flag == "0"
+        parent_sampled = false
+      else
+        parent_sampled = nil
+      end
 
 
       new(trace_id: trace_id, parent_span_id: parent_span_id, parent_sampled: parent_sampled, **options)

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -11,23 +11,33 @@ RSpec.describe Sentry::Configuration do
   end
 
   describe "#tracing_enabled?" do
-    it "returns false by default" do
-      expect(subject.tracing_enabled?).to eq(false)
-    end
-
-    context "when traces_sample_rate == 0.0" do
+    context "when neither traces_sample_rate nor traces_sampler is set" do
       it "returns false" do
-        subject.traces_sample_rate = 0.0
-
         expect(subject.tracing_enabled?).to eq(false)
       end
     end
 
-    context "when traces_sample_rate > 0" do
+    context "when traces_sample_rate == 0.0" do
+      it "returns true" do
+        subject.traces_sample_rate = 0.0
+
+        expect(subject.tracing_enabled?).to eq(true)
+      end
+    end
+
+    context "when traces_sample_rate > 0 and <= 1" do
       it "returns true" do
         subject.traces_sample_rate = 0.1
 
         expect(subject.tracing_enabled?).to eq(true)
+      end
+    end
+
+    context "when traces_sample_rate > 1" do
+      it "returns false" do
+        subject.traces_sample_rate = 1.1
+
+        expect(subject.tracing_enabled?).to eq(false)
       end
     end
 

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -182,6 +182,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
 
         stack.call(env)
 
+
         transaction = transport.events.last
         expect(transaction.type).to eq("transaction")
         expect(transaction.timestamp).not_to be_nil
@@ -215,7 +216,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
         allow(Random).to receive(:rand).and_return(0.4)
       end
 
-      it "starts a span and finishes it" do
+      it "starts a transaction and finishes it" do
         app = ->(_) do
           [200, {}, ["ok"]]
         end
@@ -282,9 +283,9 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
       end
     end
 
-    context "when traces_sample_rate is not set" do
+    context "when tracing is disabled" do
       before do
-        Sentry.configuration.traces_sample_rate = nil
+        allow(Sentry.configuration).to receive(:tracing_enabled?).and_return(false)
       end
 
       let(:stack) do


### PR DESCRIPTION
**EDIT:** I've realized this contains a breaking change, so I'm going to close this in favor of #1326, which has a smaller scope, and apply the spec-fixing parts of this separately.

--------------------------------------------------------------

This fixes an edge case where an upstream SDK would send a `sentry-trace` header without a sampling decision, and that lack of a "no" decision would be read as a "yes," causing transactions to be sent from the downstream SDK, in spite of `traces_sample_rate` being either unset or set to `0`.

There are a number of changes included here, which together both fix the bug and bring the SDK better in line with the [performance spec](https://develop.sentry.dev/sdk/performance/):

- The criteria for tracing being enabled have been changed so that a) `0` is now a valid sample rate but b) no number outside of the interval `0,1]` is and nothing that isn't a number is.

- In every place where it's relevant, the SDK now bails immediately if tracing is disabled. (This used to happen in some but not all places.) New locations include multiple `start_transaction` functions/methods (which create a transaction and/or set  its sampling decision) and `transaction.finish`(which ultimately decides whether or not to create an event out of the transaction).

- Because this means transactions will sometimes not be created where they previously were, checks are put in place so transaction-y stuff is only done if the transaction actually exists.

- The logic for parsing the sampling portion of an incoming `sentry-trace` SDK header has been made more explicit, so that each of the three cases (incoming yes, incoming no, and incoming undecided) are handled explicitly. (This is, in and of itself, the primary fix for the aforementioned bug.)

- The logic handling converting an incoming parent transaction's sampling decision into a newly-created child's sampling decision has been moved to the method setting the transaction's sampling decision via `traces_sample_rate` or `traces_sampler`. This has two advantages: first, all the logic is in one place, and second, it allows us to use the proper precedence order for different ways of setting the sampling decision, rather than putting the parent's decision ahead of everything else.

- The `transaction.set_initial_sample_decision` method now doesn't set a sampling decision at all if tracing is disabled, to better differentiate, if we ever need to, between that situation and a tracing-enabled-but-transaction-not-sampled situation.

- The `transaction.finish` method no longer checks the parent's sampling decision, because it is always handled when the transaction is started.

- Finally, tests have been added and modified as necessary.