### PR TITLE
feat: Exclude transaction based on hosts and paths configuration

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add thread_id to Exception interface [#1291](https://github.com/getsentry/sentry-ruby/pull/1291)
 - always convert trusted proxies to string [#1288](https://github.com/getsentry/sentry-ruby/pull/1288)
   - fixes [#1274](https://github.com/getsentry/sentry-ruby/issues/1274)
+- Add ability to exclude transactions from paths and hosts [#1331](https://github.com/getsentry/sentry-ruby/pull/1331)
 
 ## 4.2.1
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -80,6 +80,9 @@ module Sentry
     # You should probably append to this rather than overwrite it.
     attr_accessor :excluded_exceptions
 
+    # Hash of transaction paths and hosts that should never be sent. 
+    attr_accessor :excluded_transactions
+
     # Boolean to check nested exceptions when deciding if to exclude. Defaults to false
     attr_accessor :inspect_exception_causes_for_exclusion
     alias inspect_exception_causes_for_exclusion? inspect_exception_causes_for_exclusion
@@ -177,6 +180,7 @@ module Sentry
       self.enabled_environments = []
       self.exclude_loggers = []
       self.excluded_exceptions = IGNORE_DEFAULT.dup
+      self.excluded_transactions = { paths: [], hosts: []}
       self.inspect_exception_causes_for_exclusion = true
       self.linecache = ::Sentry::LineCache.new
       self.logger = ::Sentry::Logger.new(STDOUT)
@@ -386,6 +390,10 @@ module Sentry
       else
         true
       end
+    end
+
+    def transaction_allowed?(path, host)
+      !excluded_transactions[:paths].include?(path) && !excluded_transactions[:hosts].include?(host)
     end
 
     # Try to resolve the hostname to an FQDN, but fall back to whatever

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -20,6 +20,7 @@ module Sentry
           span = Sentry::Transaction.from_sentry_trace(sentry_trace, name: scope.transaction_name, op: transaction_op) if sentry_trace
           span ||= Sentry.start_transaction(name: scope.transaction_name, op: transaction_op)
 
+          span.manual_exclude(env['HTTP_HOST'], env["PATH_INFO"]) if env["PATH_INFO"]
           scope.set_span(span)
 
           begin

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -117,6 +117,12 @@ module Sentry
       end
     end
 
+    def manual_exclude(host, path, configuration: Sentry.configuration)
+      return if Sentry.configuration.transaction_allowed?(host, path)
+
+      @sampled = false
+   end
+
     def finish(hub: nil)
       super() # Span#finish doesn't take arguments
 

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -10,6 +10,42 @@ RSpec.describe Sentry::Configuration do
     end
   end
 
+  describe "transaction_allowed?" do
+    subject { service.send(:transaction_allowed?, path, host) }
+    let(:service) { described_class.new }
+    let(:host) { '' }
+    let(:path) { '' }
+
+    context 'without exclusion' do
+      it { is_expected.to be true }
+    end
+ 
+    context 'with exclusion' do
+      let(:excluded_transactions) do
+          { hosts: [host],
+            paths: [path] }
+      end
+      before do
+        expect(service).to receive(:excluded_transactions).once.and_return(excluded_transactions)
+      end
+      context 'with excluded host' do
+        let(:host) { 'some.thing' }
+ 
+        it 'excludes host' do
+          expect(subject).to be false
+        end
+      end
+ 
+      context 'with excluded host' do
+        let(:path) { 'some/thing' }
+ 
+        it 'excludes host' do
+          expect(subject).to be false
+        end
+      end
+    end
+  end
+
   describe "#tracing_enabled?" do
     it "returns false by default" do
       expect(subject.tracing_enabled?).to eq(false)


### PR DESCRIPTION
Signed-off-by: Brice <brice.bene@gmail.com>

Thanks for your Pull Request 🎉 

**Please keep these instructions in mind so we can review it more efficiently:**

- Add the references of all the related issues/PRs in the description
- Whether it's a new feature or a bug fix, make sure they're covered by new test cases
- If this PR contains any refactoring work, please give it its own commit(s)
- Finally, please add an entry to the corresponding changelog


**Other Notes**
- We squash all commits before merging
- We generally review new PRs within a week
- If you have any question, you can ask for feedback in our [discord community](https://discord.gg/Ww9hbqr) first

## Description
Allow exclusion of transactions from paths and hosts

Sentry.init do |config|
  # ...
  config.excluded_transactions[:paths] += ['/heartbeat']
  config.excluded_transactions[:hosts] += ['api.your-domain.com']
  # ...
end
