### PR TITLE
Fix sampling decision precedence

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Correct type attribute's usages [#1354](https://github.com/getsentry/sentry-ruby/pull/1354)
-
+- Fix sampling decision precedence [#1335](https://github.com/getsentry/sentry-ruby/pull/1335)
 
 ## 4.3.1
 

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -69,11 +69,19 @@ module Sentry
       @stack.pop
     end
 
-    def start_transaction(transaction: nil, configuration: Sentry.configuration, **options)
+    def start_transaction(transaction: nil, configuration: Sentry.configuration, custom_sampling_context: {}, **options)
       return unless configuration.tracing_enabled?
 
       transaction ||= Transaction.new(**options)
-      transaction.set_initial_sample_decision(configuration: current_client.configuration)
+
+      sampling_context = {
+        transaction_context: transaction.to_hash,
+        parent_sampled: transaction.parent_sampled
+      }
+
+      sampling_context.merge!(custom_sampling_context)
+
+      transaction.set_initial_sample_decision(configuration: current_client.configuration, sampling_context: sampling_context)
       transaction
     end
 

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -33,14 +33,14 @@ module Sentry
       return if match.nil?
       trace_id, parent_span_id, sampled_flag = match[1..3]
 
-      sampled =
+      parent_sampled =
         if sampled_flag.nil?
           nil
         else
           sampled_flag != "0"
         end
 
-      new(trace_id: trace_id, parent_span_id: parent_span_id, parent_sampled: sampled, sampled: sampled, **options)
+      new(trace_id: trace_id, parent_span_id: parent_span_id, parent_sampled: parent_sampled, **options)
     end
 
     def to_hash
@@ -84,17 +84,21 @@ module Sentry
       transaction_description = generate_transaction_description
 
       logger = configuration.logger
-      sample_rate = configuration.traces_sample_rate
       traces_sampler = configuration.traces_sampler
 
-      if traces_sampler.is_a?(Proc)
-        sampling_context = sampling_context.merge(
-          parent_sampled: @parent_sampled,
-          transaction_context: self.to_hash
-        )
+      sample_rate =
+        if traces_sampler.is_a?(Proc)
+          sampling_context = sampling_context.merge(
+            parent_sampled: @parent_sampled,
+            transaction_context: self.to_hash
+          )
 
-        sample_rate = traces_sampler.call(sampling_context)
-      end
+          traces_sampler.call(sampling_context)
+        elsif !@parent_sampled.nil?
+          @parent_sampled
+        else
+          configuration.traces_sample_rate
+        end
 
       unless [true, false].include?(sample_rate) || (sample_rate.is_a?(Numeric) && sample_rate >= 0.0 && sample_rate <= 1.0)
         @sampled = false

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -279,6 +279,24 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
           expect(transaction).to eq(nil)
         end
       end
+
+      context "when traces_sampler is set" do
+        let(:trace) do
+          "#{external_transaction.trace_id}-#{external_transaction.span_id}-1"
+        end
+
+        it "passes parent_sampled to the sampling_context" do
+          parent_sampled = false
+
+          Sentry.configuration.traces_sampler = lambda do |sampling_context|
+            parent_sampled = sampling_context[:parent_sampled]
+          end
+
+          stack.call(env)
+
+          expect(parent_sampled).to eq(true)
+        end
+      end
     end
 
     context "when the transaction is sampled" do

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe Sentry::Transaction do
         expect(child_transaction.trace_id).to eq(subject.trace_id)
         expect(child_transaction.parent_span_id).to eq(subject.span_id)
         expect(child_transaction.parent_sampled).to eq(true)
-        expect(child_transaction.sampled).to eq(true)
+        # doesn't set the sampled value
+        expect(child_transaction.sampled).to eq(nil)
         expect(child_transaction.op).to eq("child")
       end
 
@@ -142,7 +143,7 @@ RSpec.describe Sentry::Transaction do
     end
 
     context "when tracing is enabled" do
-      let(:subject) { described_class.new(op: "rack.request", parent_sampled: true) }
+      let(:subject) { described_class.new(op: "rack.request") }
 
       before do
         allow(Sentry.configuration).to receive(:tracing_enabled?).and_return(true)
@@ -213,7 +214,6 @@ RSpec.describe Sentry::Transaction do
 
           # transaction_context's sampled attribute will be the old value
           expect(sampling_context[:transaction_context].keys).to eq(subject.to_hash.keys)
-          expect(sampling_context[:parent_sampled]).to eq(true)
           expect(sampling_context[:foo]).to eq("bar")
         end
 


### PR DESCRIPTION
1. When traces_sampler is set, the sentry-trace's sampling decision should be put into sampling context to let the user make explicit decision. Currently it forces the transaction to be sampled, which is wrong.
2. The value of traces_sample_rate should have a lower priority than the  traces_sampler and the value of parent_sampled.