### PR TITLE
Fix handle the case where the logger messages is not of String type

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add Sentry.set_context helper [#1337](https://github.com/getsentry/sentry-ruby/pull/1337)
+- Fix handle the case where the logger messages is not of String type [#1341](https://github.com/getsentry/sentry-ruby/pull/1341)
 
 ## 4.3.0
 

--- a/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb
@@ -50,7 +50,7 @@ module Sentry
           end
         end
 
-        return if ignored_logger?(progname) || message.empty?
+        return if ignored_logger?(progname) || message == ""
 
         # some loggers will add leading/trailing space as they (incorrectly, mind you)
         # think of logging as a shortcut to std{out,err}

--- a/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe "Sentry::Breadcrumbs::SentryLogger" do
     expect(breadcrumb.level).to eq("info")
     expect(breadcrumb.message).to eq("foo")
   end
+  
+  it "records non-String message" do
+    logger.info(200)
+    expect(breadcrumbs.peek.message).to eq("200")
+  end
 
   it "does not affect the return of the logger call" do
     expect(logger.info("foo")).to be_nil


### PR DESCRIPTION
## Description
Passing something other (like Integer) than a String type to the logger will fail because there is no "empty?" method.
Fixed based on old raven source
https://github.com/getsentry/sentry-ruby/blob/master/sentry-raven/lib/raven/breadcrumbs/sentry_logger.rb#L22