### PR TITLE
Use debug log level for send event log statements

### DIFF
--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -66,7 +66,7 @@ module Sentry
 
       event_id = event_hash[:event_id] || event_hash["event_id"]
       event_type = event_hash[:type] || event_hash["type"]
-      configuration.logger.info(LOGGER_PROGNAME) { "Sending #{event_type} #{event_id} to Sentry" }
+      configuration.logger.debug(LOGGER_PROGNAME) { "Sending #{event_type} #{event_id} to Sentry" }
       encode(event_hash)
     end
   end

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Sentry::Transport do
   let(:io) { StringIO.new }
-  let(:logger) { Logger.new(io) }
+  let(:logger) { Logger.new(io, :debug) }
   let(:configuration) do
     Sentry::Configuration.new.tap do |config|
       config.server = 'http://12345:67890@sentry.localdomain/sentry/42'
@@ -115,7 +115,7 @@ RSpec.describe Sentry::Transport do
         expect(subject.send_event(event)).to eq(event)
 
         expect(io.string).to match(
-          /INFO -- sentry: Sending event #{event.event_id} to Sentry/
+          /DEBUG -- sentry: Sending event #{event.event_id} to Sentry/
         )
       end
     end


### PR DESCRIPTION
For applications that trigger large volumes of events, these log statements can quickly incur large costs from 3rd party logging services. We should have the option to disable them without having to set the log level application-wide to `warn` or higher.

The 4.3.0 release appears to be responsible for a large increase in the number of these log statements. Our application went from generating ~30k log statements per day on v4.2.2 to ~6M per day on v4.3.0.