### PR TITLE
Make tracing subscribers configurable

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Features
+
+- Make tracing subscribers configurable [#1344](https://github.com/getsentry/sentry-ruby/pull/1344) 
+
+```ruby
+# current default:
+# - Sentry::Rails::Tracing::ActionControllerSubscriber
+# - Sentry::Rails::Tracing::ActionViewSubscriber
+# - Sentry::Rails::Tracing::ActiveRecordSubscriber
+
+# you can add a new subscriber
+config.rails.tracing_subscribers << MySubscriber
+# or replace the set completely
+config.rails.tracing_subscribers = [MySubscriber]
+```
+
+### Bug Fixes
+
 - Report exceptions from the interceptor middleware for exceptions app [#1379](https://github.com/getsentry/sentry-ruby/pull/1379)
   - Fixes [#1371](https://github.com/getsentry/sentry-ruby/issues/1371)
 

--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -1,3 +1,7 @@
+require "sentry/rails/tracing/action_controller_subscriber"
+require "sentry/rails/tracing/action_view_subscriber"
+require "sentry/rails/tracing/active_record_subscriber"
+
 module Sentry
   class Configuration
     attr_reader :rails
@@ -47,10 +51,16 @@ module Sentry
       # In those cases, we should skip ActiveJob's reporting to avoid duplicated reports.
       attr_accessor :skippable_job_adapters
 
+      attr_accessor :tracing_subscribers
+
       def initialize
         @report_rescued_exceptions = true
-        # TODO: Remove this in 4.2.0
         @skippable_job_adapters = []
+        @tracing_subscribers = Set.new([
+          Sentry::Rails::Tracing::ActionControllerSubscriber,
+          Sentry::Rails::Tracing::ActionViewSubscriber,
+          Sentry::Rails::Tracing::ActiveRecordSubscriber
+        ])
       end
     end
   end

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -89,6 +89,8 @@ module Sentry
 
     def activate_tracing
       if Sentry.configuration.tracing_enabled?
+        subscribers = Sentry.configuration.rails.tracing_subscribers
+        Sentry::Rails::Tracing.register_subscribers(subscribers)
         Sentry::Rails::Tracing.subscribe_tracing_events
         Sentry::Rails::Tracing.patch_active_support_notifications
       end

--- a/sentry-rails/lib/sentry/rails/tracing.rb
+++ b/sentry-rails/lib/sentry/rails/tracing.rb
@@ -1,18 +1,19 @@
-require "sentry/rails/tracing/abstract_subscriber"
-require "sentry/rails/tracing/active_record_subscriber"
-require "sentry/rails/tracing/action_controller_subscriber"
-require "sentry/rails/tracing/action_view_subscriber"
-
 module Sentry
   module Rails
     module Tracing
-      AVAILABLE_SUBSCRIBERS = [ActionViewSubscriber, ActiveRecordSubscriber, ActionControllerSubscriber]
+      def self.register_subscribers(subscribers)
+        @subscribers = subscribers
+      end
+
+      def self.subscribers
+        @subscribers
+      end
 
       def self.subscribe_tracing_events
         # need to avoid duplicated subscription
         return if @subscribed
 
-        AVAILABLE_SUBSCRIBERS.each(&:subscribe!)
+        subscribers.each(&:subscribe!)
 
         @subscribed = true
       end
@@ -20,7 +21,7 @@ module Sentry
       def self.unsubscribe_tracing_events
         return unless @subscribed
 
-        AVAILABLE_SUBSCRIBERS.each(&:unsubscribe!)
+        subscribers.each(&:unsubscribe!)
 
         @subscribed = false
       end

--- a/sentry-rails/lib/sentry/rails/tracing/action_controller_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/action_controller_subscriber.rb
@@ -1,3 +1,5 @@
+require "sentry/rails/tracing/abstract_subscriber"
+
 module Sentry
   module Rails
     module Tracing

--- a/sentry-rails/lib/sentry/rails/tracing/action_view_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/action_view_subscriber.rb
@@ -1,3 +1,5 @@
+require "sentry/rails/tracing/abstract_subscriber"
+
 module Sentry
   module Rails
     module Tracing

--- a/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
@@ -1,3 +1,5 @@
+require "sentry/rails/tracing/abstract_subscriber"
+
 module Sentry
   module Rails
     module Tracing

--- a/sentry-rails/spec/sentry/rails/configuration_spec.rb
+++ b/sentry-rails/spec/sentry/rails/configuration_spec.rb
@@ -18,4 +18,22 @@ RSpec.describe Sentry::Rails::Configuration do
       expect(subject.report_rescued_exceptions).to eq(true)
     end
   end
+
+  describe "#tracing_subscribers" do
+    class MySubscriber; end
+
+    it "returns the default subscribers" do
+      expect(subject.tracing_subscribers.size).to eq(3)
+    end
+
+    it "is customizable" do
+      subject.tracing_subscribers << MySubscriber
+      expect(subject.tracing_subscribers.size).to eq(4)
+    end
+
+    it "is replaceable" do
+      subject.tracing_subscribers = [MySubscriber]
+      expect(subject.tracing_subscribers.size).to eq(1)
+    end
+  end
 end

--- a/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Sentry::Rails::Tracing::ActionControllerSubscriber, :subscriber, 
     before do
       make_basic_app do |config|
         config.traces_sample_rate = 1.0
+        config.rails.tracing_subscribers = [described_class]
       end
     end
 
@@ -19,9 +20,9 @@ RSpec.describe Sentry::Rails::Tracing::ActionControllerSubscriber, :subscriber, 
 
       transaction = transport.events.first.to_hash
       expect(transaction[:type]).to eq("transaction")
-      expect(transaction[:spans].count).to eq(2)
+      expect(transaction[:spans].count).to eq(1)
 
-      span = transaction[:spans][1]
+      span = transaction[:spans][0]
       expect(span[:op]).to eq("process_action.action_controller")
       expect(span[:description]).to eq("HelloController#world")
       expect(span[:trace_id]).to eq(transaction.dig(:contexts, :trace, :trace_id))

--- a/sentry-rails/spec/sentry/rails/tracing/action_view_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_view_subscriber_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Sentry::Rails::Tracing::ActionViewSubscriber, :subscriber, type: 
     before do
       make_basic_app do |config|
         config.traces_sample_rate = 1.0
+        config.rails.tracing_subscribers = [described_class]
       end
     end
 
@@ -19,7 +20,7 @@ RSpec.describe Sentry::Rails::Tracing::ActionViewSubscriber, :subscriber, type: 
 
       transaction = transport.events.first.to_hash
       expect(transaction[:type]).to eq("transaction")
-      expect(transaction[:spans].count).to eq(2)
+      expect(transaction[:spans].count).to eq(1)
 
       span = transaction[:spans][0]
       expect(span[:op]).to eq("render_template.action_view")

--- a/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
     before do
       make_basic_app do |config|
         config.traces_sample_rate = 1.0
+        config.rails.tracing_subscribers = [described_class]
       end
     end
 

--- a/sentry-rails/spec/spec_helper.rb
+++ b/sentry-rails/spec/spec_helper.rb
@@ -35,11 +35,11 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.before :each, :subscriber do
+  config.before :each do
     Sentry::Rails::Tracing.patch_active_support_notifications
   end
 
-  config.after :each, :subscriber do
+  config.after :each do
     Sentry::Rails::Tracing.unsubscribe_tracing_events
     Sentry::Rails::Tracing.remove_active_support_notifications_patch
   end


### PR DESCRIPTION
Users can now configure tracing subscribers like:

```ruby
config.rails.tracing_subscribers << MySubscriber
# or replace the set completely
config.rails.tracing_subscribers = [MySubscriber]
```