### PR TITLE
Minimize sentry-rails' dependency requirement

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.3
+
+- Minimize sentry-rails' dependency requirement [#1352](https://github.com/getsentry/sentry-ruby/pull/1352)
+
 ## 4.3.2
 
 - Avoid recording SendEventJob's transaction [#1351](https://github.com/getsentry/sentry-ruby/pull/1351)
@@ -9,8 +13,6 @@
 
 - Only apply background worker patch if ActiveRecord is loaded [#1350](https://github.com/getsentry/sentry-ruby/pull/1350)
   - Fixes [#1342](https://github.com/getsentry/sentry-ruby/issues/1342) and [#1346](https://github.com/getsentry/sentry-ruby/issues/1346)
-- Avoid recording SendEventJob's transaction [#1351](https://github.com/getsentry/sentry-ruby/pull/1351)
-  - Fixes [#1348](https://github.com/getsentry/sentry-ruby/issues/1348)
 
 ## 4.3.0
 

--- a/sentry-rails/examples/minimum-rails/app.rb
+++ b/sentry-rails/examples/minimum-rails/app.rb
@@ -1,0 +1,68 @@
+require "bundler/inline"
+
+gemfile(true) do
+  source 'https://rubygems.org'
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+  ruby '> 2.6'
+  gem 'sentry-rails', path: "../../"
+  gem 'railties', '~> 6.0.0'
+  gem "pry"
+end
+
+require "pry"
+require "action_view/railtie"
+require "action_controller/railtie"
+require 'sentry-rails'
+
+Sentry.init do |config|
+  config.dsn = 'https://2fb45f003d054a7ea47feb45898f7649@o447951.ingest.sentry.io/5434472'
+  config.logger = Logger.new($stdout)
+end
+
+ActiveSupport::Deprecation.silenced = true
+
+class TestApp < Rails::Application
+end
+
+class TestController < ActionController::Base
+  include Rails.application.routes.url_helpers
+
+  def exception
+    raise "foo"
+  end
+end
+
+def app
+  return @app if @app
+
+  app = Class.new(TestApp) do
+    def self.name
+      "RailsTestApp"
+    end
+  end
+
+  app.config.root = __dir__
+  app.config.hosts = nil
+  app.config.consider_all_requests_local = false
+
+  app.config.logger = Logger.new($stdout)
+  app.config.log_level = :debug
+  Rails.logger = app.config.logger
+
+  app.routes.append do
+    get "/exception" => "test#exception"
+  end
+
+  app.initialize!
+  Rails.application = app
+  @app = app
+  app
+end
+
+require "rack/test"
+include Rack::Test::Methods
+
+get "/exception"
+
+sleep(2) # wait for the background_worker

--- a/sentry-rails/lib/sentry/rails.rb
+++ b/sentry-rails/lib/sentry/rails.rb
@@ -1,3 +1,4 @@
+require "rails"
 require "sentry-ruby"
 require "sentry/integrable"
 require "sentry/rails/configuration"

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -1,4 +1,3 @@
-require "rails"
 require "sentry/rails/capture_exceptions"
 require "sentry/rails/rescued_exception_interceptor"
 require "sentry/rails/backtrace_cleaner"

--- a/sentry-rails/sentry-rails.gemspec
+++ b/sentry-rails/sentry-rails.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails", ">= 5.0"
+  spec.add_dependency "railties", ">= 5.0"
   spec.add_dependency "sentry-ruby-core", "~> 4.3.0"
 end

--- a/sentry-rails/spec/sentry/rails/controller_methods_spec.rb
+++ b/sentry-rails/spec/sentry/rails/controller_methods_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require "sentry/rails/controller_methods"
 
 RSpec.describe Sentry::Rails::ControllerMethods do
   include described_class

--- a/sentry-rails/spec/support/test_rails_app/app.rb
+++ b/sentry-rails/spec/support/test_rails_app/app.rb
@@ -103,7 +103,7 @@ def make_basic_app
 
     Sentry.init do |config|
       config.release = 'beta'
-      config.dsn = "dummy://12345:67890@sentry.localdomain:3000/sentry/42"
+      config.dsn = "http://12345:67890@sentry.localdomain:3000/sentry/42"
       # for speeding up request specs
       config.rails.report_rescued_exceptions = false
       config.transport.transport_class = Sentry::DummyTransport


### PR DESCRIPTION
1. `sentry-rails` will only require `railties` and its dependencies as dependency. so users won't need to have `rails` installed anymore.
2. `sentry-rails` should now work with minimum Rails apps (e.g. without ActiveRecord).

closes #1340 