### PR TITLE
Correct type attribute's usages

### DIFF
--- a/sentry-rails/spec/sentry/send_event_job_spec.rb
+++ b/sentry-rails/spec/sentry/send_event_job_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Sentry::SendEventJob" do
 
       expect(transport.events.count).to eq(1)
       event = transport.events.first
-      expect(event.type).to eq("event")
+      expect(event.type).to eq(nil)
     end
 
     context "when ApplicationJob is not defined" do

--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Correct type attribute's usages [#1354](https://github.com/getsentry/sentry-ruby/pull/1354)
+
+
 ## 4.3.1
 
 - Add Sentry.set_context helper [#1337](https://github.com/getsentry/sentry-ruby/pull/1337)

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -100,7 +100,6 @@ module Sentry
     end
 
     def type
-      "event"
     end
 
     def to_hash

--- a/sentry-ruby/lib/sentry/transaction_event.rb
+++ b/sentry-ruby/lib/sentry/transaction_event.rb
@@ -2,6 +2,8 @@
 
 module Sentry
   class TransactionEvent < Event
+    TYPE = "transaction"
+
     ATTRIBUTES = %i(
       event_id level timestamp start_timestamp
       release environment server_name modules
@@ -17,7 +19,7 @@ module Sentry
     end
 
     def type
-      "transaction"
+      TYPE
     end
 
     def to_hash

--- a/sentry-ruby/spec/sentry/rake_spec.rb
+++ b/sentry-ruby/spec/sentry/rake_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe "rake auto-reporting" do
       message = `cd spec/support && bundle exec rake raise_exception 2>&1`
     end.join
 
-    expect(message).to match(/Sending event [abcdef0-9]+ to Sentry/)
+    expect(message).to match(/Sending envelope \[event\] [abcdef0-9]+ to Sentry/)
   end
 end

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Sentry::Transport do
         expect(subject.send_event(event)).to eq(event)
 
         expect(io.string).to match(
-          /INFO -- sentry: Sending event #{event.event_id} to Sentry/
+          /INFO -- sentry: Sending envelope \[event\] #{event.event_id} to Sentry/
         )
       end
     end


### PR DESCRIPTION
Based on [this discussion](https://github.com/getsentry/sentry-ruby/pull/1336/files#r596851969), normal events shouldn't have the `type` attribute and only transaction events should have `type: "transaction"`.

So this PR:
- removes `type: "event"` from normal events
- corrects `Transport`'s envelope generation logic: envelope's type is not equivalent to event's type
- corrects the logging message for sending envelopes