### PR TITLE
Change to reduced dependencies

### DIFF
--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -15,7 +15,9 @@ else
   gem "sqlite3", platform: :ruby
 end
 
-gem "rails", "~> #{rails_version}"
+gem "activejob", "~> #{rails_version}"
+gem "actionpack", "~> #{rails_version}"
+gem "activerecord", "~> #{rails_version}"
 gem "sprockets-rails"
 
 gem "rspec", "~> 3.0"

--- a/sentry-rails/sentry-rails.gemspec
+++ b/sentry-rails/sentry-rails.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails", ">= 5.0"
+  spec.add_dependency "actionpack", ">= 5.0"
+  spec.add_dependency "activejob", ">= 5.0"
+  spec.add_dependency "activerecord", ">= 5.0"
   spec.add_dependency "sentry-ruby-core", "~> 4.3.0"
 end


### PR DESCRIPTION
  Change to reduced dependencies

  * Changes to depend exclusively on the rails subcomponents that are
    required to get specs passing.
  * Removes the need to pull in other rails dependencies that sentry-rails
    currently does NOT integrate with.
  * Improves compatibility with more ruby projects due reduced dependency
    footprint.