### PR TITLE
Sentry.add_breadcrumb should call Hub#add_breadcrumb

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Add Sentry.set_context helper [#1337](https://github.com/getsentry/sentry-ruby/pull/1337)
 - Fix handle the case where the logger messages is not of String type [#1341](https://github.com/getsentry/sentry-ruby/pull/1341)
 - Don't report Sentry::ExternalError to Sentry [#1353](https://github.com/getsentry/sentry-ruby/pull/1353)
+- Sentry.add_breadcrumb should call Hub#add_breadcrumb [#1358](https://github.com/getsentry/sentry-ruby/pull/1358)
+  - Fixes [#1357](https://github.com/getsentry/sentry-ruby/issues/1357)
 
 ## 4.3.0
 

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -80,7 +80,7 @@ module Sentry
 
     # Takes an instance of Sentry::Breadcrumb and stores it to the current active scope.
     def add_breadcrumb(breadcrumb)
-      get_current_scope.breadcrumbs.record(breadcrumb)
+      get_current_hub.add_breadcrumb(breadcrumb)
     end
 
     # Returns the current active hub.

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -80,7 +80,7 @@ module Sentry
 
     # Takes an instance of Sentry::Breadcrumb and stores it to the current active scope.
     def add_breadcrumb(breadcrumb)
-      get_current_hub.add_breadcrumb(breadcrumb)
+      get_current_hub&.add_breadcrumb(breadcrumb)
     end
 
     # Returns the current active hub.

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -222,6 +222,18 @@ RSpec.describe Sentry do
 
       expect(described_class.get_current_scope.breadcrumbs.peek).to eq(crumb)
     end
+
+    it "triggers before_breadcrumb callback" do
+      Sentry.configuration.before_breadcrumb = lambda do |breadcrumb, hint|
+        nil
+      end
+
+      crumb = Sentry::Breadcrumb.new(message: "foo")
+
+      described_class.add_breadcrumb(crumb)
+
+      expect(described_class.get_current_scope.breadcrumbs.peek).to eq(nil)
+    end
   end
 
   describe ".set_tags" do


### PR DESCRIPTION
Instead of directly adding the breadcrumb to the scope.

Fixes #1357 