### PR TITLE
Correctly set the SDK's logger in sentry-rails

### DIFF
--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -5,6 +5,7 @@ module Sentry
     add_post_initialization_callback do
       @rails = Sentry::Rails::Configuration.new
       @excluded_exceptions = @excluded_exceptions.concat(Sentry::Rails::IGNORE_DEFAULT)
+      @logger = ::Rails.logger
     end
   end
 

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -16,7 +16,6 @@ module Sentry
       next unless Sentry.initialized?
 
       configure_project_root
-      configure_sentry_logger
       configure_trusted_proxies
       extend_controller_methods if defined?(ActionController)
       extend_active_job if defined?(ActiveJob)
@@ -30,10 +29,6 @@ module Sentry
 
     def configure_project_root
       Sentry.configuration.project_root = ::Rails.root.to_s
-    end
-
-    def configure_sentry_logger
-      Sentry.configuration.logger = ::Rails.logger
     end
 
     def configure_trusted_proxies

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -32,11 +32,20 @@ RSpec.describe Sentry::Rails, type: :request do
       expect(Sentry.configuration.logger).to eq(Rails.logger)
     end
 
+    it "respects the logger set by user" do
+      logger = ::Logger.new(nil)
+
+      make_basic_app do |config|
+        config.logger = logger
+      end
+
+      expect(Sentry.configuration.logger).to eq(logger)
+    end
+
     it "sets Sentry.configuration.project_root correctly" do
       expect(Sentry.configuration.project_root).to eq(Rails.root.to_s)
     end
 
-   
     it "doesn't clobber a manually configured release" do
       expect(Sentry.configuration.release).to eq('beta')
     end
@@ -171,7 +180,7 @@ RSpec.describe Sentry::Rails, type: :request do
       end
     end
   end
-  
+
   context "with trusted proxies set" do
     before do
       make_basic_app do |config, app|


### PR DESCRIPTION
`sentry-rails` shouldn't set the logger in the `after_initialize` callback, as it'll always override what the user sets in `Sentry.init`.

Instead, it should set the logger with the SDK's `post_initialization` configuration callback.

Closes #1361 