### PR TITLE
Allow delayed job's exceptions to be reported to sentry until the last job retry

### DIFF
--- a/sentry-delayed_job/CHANGELOG.md
+++ b/sentry-delayed_job/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.3.1
+- Add the `report_after_job_retries` configuration option to only report an exception to Sentry if this is the last job's retry after multiple exceptions. [#1364](https://github.com/getsentry/sentry-ruby/pull/1364)
+
 ## 4.3.0
 
 - No integration-specific changes

--- a/sentry-delayed_job/lib/sentry-delayed_job.rb
+++ b/sentry-delayed_job/lib/sentry-delayed_job.rb
@@ -1,6 +1,7 @@
 require "delayed_job"
 require "sentry-ruby"
 require "sentry/integrable"
+require "sentry/delayed_job/configuration"
 require "sentry/delayed_job/version"
 require "sentry/delayed_job/plugin"
 

--- a/sentry-delayed_job/lib/sentry/delayed_job/configuration.rb
+++ b/sentry-delayed_job/lib/sentry/delayed_job/configuration.rb
@@ -1,0 +1,21 @@
+module Sentry
+  class Configuration
+    attr_reader :delayed_job
+
+    add_post_initialization_callback do
+      @delayed_job = Sentry::DelayedJob::Configuration.new
+    end
+  end
+
+  module DelayedJob
+    class Configuration
+      # Set this option to true if you want Sentry to only capture the last job
+      # retry if it fails.
+      attr_accessor :report_after_job_retries
+
+      def initialize
+        @report_after_job_retries = false
+      end
+    end
+  end
+end

--- a/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
+++ b/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
@@ -13,12 +13,16 @@ module Sentry
             begin
               block.call(job, *args)
             rescue Exception => e
-              Sentry::DelayedJob.capture_exception(e, hint: { background: false })
+              capture_exception(e, job)
 
               raise
             end
           end
         end
+      end
+
+      def self.capture_exception(exception, job)
+        Sentry::DelayedJob.capture_exception(exception, hint: { background: false }) if report?(job)
       end
 
       def self.generate_extra(job)
@@ -42,6 +46,14 @@ module Sentry
         end
 
         extra
+      end
+
+      def self.report?(job)
+        return true unless Sentry.configuration.delayed_job.report_after_job_retries
+
+        # We use the predecessor because the job's attempts haven't been increased to the new
+        # count at this point.
+        job.attempts >= Delayed::Worker.max_attempts.pred
       end
     end
   end

--- a/sentry-delayed_job/spec/sentry/delayed_job/configuration_spec.rb
+++ b/sentry-delayed_job/spec/sentry/delayed_job/configuration_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe Sentry::DelayedJob::Configuration do
+  it "adds #delayed_job option to Sentry::Configuration" do
+    config = Sentry::Configuration.new
+
+    expect(config.delayed_job).to be_a(described_class)
+  end
+
+  describe "#report_after_job_retries" do
+    it "has correct default value" do
+      expect(subject.report_after_job_retries).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Thanks for your Pull Request 🎉 

**Please keep these instructions in mind so we can review it more efficiently:**

- Add the references of all the related issues/PRs in the description
- Whether it's a new feature or a bug fix, make sure they're covered by new test cases
- If this PR contains any refactoring work, please give it its own commit(s)
- Finally, please add an entry to the corresponding changelog


**Other Notes**
- We squash all commits before merging
- We generally review new PRs within a week
- If you have any question, you can ask for feedback in our [discord community](https://discord.gg/Ww9hbqr) first

## Description
Describe your changes:
This change adds a configuration option for the delayed job integration to only report 
an exception to Sentry if this is the last job's retry after multiple exceptions.

This change is useful for workflows where you set up a small amount of retries and
are comfortable with just having a single error report per job, for example if your
mailing provider has temporary outages.

Co-authored-by: Oscar Zatarain <ozatarain@hotmail.com>
