### PR TITLE
Return delayed job when the SDK is not initialized

### DIFF
--- a/sentry-delayed_job/CHANGELOG.md
+++ b/sentry-delayed_job/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.3.1
+
+- Return delayed job when the SDK is not initialized [#1373](https://github.com/getsentry/sentry-ruby/pull/1373)
+  - Fixes [#1334](https://github.com/getsentry/sentry-ruby/issues/1334)
+
 ## 4.3.0
 
 - No integration-specific changes

--- a/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
+++ b/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
@@ -6,6 +6,8 @@ module Sentry
     class Plugin < ::Delayed::Plugin
       callbacks do |lifecycle|
         lifecycle.around(:invoke_job) do |job, *args, &block|
+          next block.call(job, *args) unless Sentry.initialized?
+
           Sentry.with_scope do |scope|
             scope.set_extras(**generate_extra(job))
             scope.set_tags("delayed_job.queue" => job.queue, "delayed_job.id" => job.id.to_s)

--- a/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
+++ b/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
@@ -207,3 +207,21 @@ RSpec.describe Sentry::DelayedJob do
   end
 end
 
+
+RSpec.describe Sentry::DelayedJob, "not initialized" do
+  class Thing
+    def self.invoked_method; end
+  end
+
+  it "doesn't swallow jobs" do
+    expect(Thing).to receive(:invoked_method)
+    Delayed::Job.delete_all
+    expect(Delayed::Job.count).to eq(0)
+
+    Thing.delay.invoked_method
+    expect(Delayed::Job.count).to eq(1)
+
+    Delayed::Worker.new.run(Delayed::Job.last)
+    expect(Delayed::Job.count).to eq(0)
+  end
+end


### PR DESCRIPTION
Fixes #1334 