### PR TITLE
Report exceptions from the interceptor middleware for exceptions app

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Report exceptions from the interceptor middleware for exceptions app [#1379](https://github.com/getsentry/sentry-ruby/pull/1379)
+  - Fixes [#1371](https://github.com/getsentry/sentry-ruby/issues/1371)
+
 ## 4.3.3
 
 - Correctly set the SDK's logger in sentry-rails [#1363](https://github.com/getsentry/sentry-ruby/pull/1363)

--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -12,6 +12,7 @@ module Sentry
       private
 
       def collect_exception(env)
+        return nil if env["sentry.already_captured"]
         super || env["action_dispatch.exception"] || env["sentry.rescued_exception"]
       end
 

--- a/sentry-rails/lib/sentry/rails/rescued_exception_interceptor.rb
+++ b/sentry-rails/lib/sentry/rails/rescued_exception_interceptor.rb
@@ -20,11 +20,20 @@ module Sentry
             copied_env = scope.rack_env.dup
             copied_env["sentry.original_transaction"] = scope.transaction_name
             scope.set_rack_env(copied_env)
+
+            if report_rescued_exceptions?
+              Sentry::Rails.capture_exception(e)
+              env["sentry.already_captured"] = true
+            end
           end
 
-          env["sentry.rescued_exception"] = e if Sentry.configuration.rails.report_rescued_exceptions
+          env["sentry.rescued_exception"] = e if report_rescued_exceptions?
           raise e
         end
+      end
+
+      def report_rescued_exceptions?
+        Sentry.configuration.rails.report_rescued_exceptions
       end
     end
   end

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -166,7 +166,10 @@ RSpec.describe Sentry::Rails, type: :request do
       it "sets transaction to ControllerName#method" do
         get "/exception"
 
-        expect(transport.events.last.transaction).to eq("HelloController#exception")
+        expect(transport.events.count).to eq(1)
+        last_event = transport.events.last
+        expect(last_event.transaction).to eq("HelloController#exception")
+        expect(response.body).to match(last_event.event_id)
 
         get "/posts"
 

--- a/sentry-rails/spec/support/test_rails_app/app.rb
+++ b/sentry-rails/spec/support/test_rails_app/app.rb
@@ -55,7 +55,7 @@ class HelloController < ActionController::Base
   end
 
   def reporting
-    head :ok
+    render plain: Sentry.last_event_id
   end
 
   def view_exception
@@ -104,8 +104,6 @@ def make_basic_app
     Sentry.init do |config|
       config.release = 'beta'
       config.dsn = "http://12345:67890@sentry.localdomain:3000/sentry/42"
-      # for speeding up request specs
-      config.rails.report_rescued_exceptions = false
       config.transport.transport_class = Sentry::DummyTransport
       # for sending events synchronously
       config.background_worker_threads = 0


### PR DESCRIPTION
Currently, the SDK only reports exceptions from the `CaptureExceptions` middleware, which happens **after** Rails' exceptions app being invoked.

This means that it's impossible to fetch and display the event's event id in exceptions app.

So this PR does 2 things:

1. If the app is going to show the exceptions app, the SDK captures the exception in advance from the interceptor middleware.
2. When the above happens, it also hints the `CaptureExceptions` middleware **not to** capture the exception again.

Fixes #1371 