### PR TITLE
Let Transaction constructor take an optional hub argument

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Refactorings
+
+- Let Transaction constructor take an optional hub argument [#1384](https://github.com/getsentry/sentry-ruby/pull/1384)
+
 ## 4.3.2
 
 - Correct type attribute's usages [#1354](https://github.com/getsentry/sentry-ruby/pull/1354)

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -21,6 +21,10 @@ module Sentry
       current_layer&.client
     end
 
+    def configuration
+      current_client.configuration
+    end
+
     def current_scope
       current_layer&.scope
     end
@@ -69,10 +73,10 @@ module Sentry
       @stack.pop
     end
 
-    def start_transaction(transaction: nil, configuration: Sentry.configuration, custom_sampling_context: {}, **options)
+    def start_transaction(transaction: nil, custom_sampling_context: {}, **options)
       return unless configuration.tracing_enabled?
 
-      transaction ||= Transaction.new(**options)
+      transaction ||= Transaction.new(**options.merge(hub: self))
 
       sampling_context = {
         transaction_context: transaction.to_hash,
@@ -81,7 +85,7 @@ module Sentry
 
       sampling_context.merge!(custom_sampling_context)
 
-      transaction.set_initial_sample_decision(configuration: current_client.configuration, sampling_context: sampling_context)
+      transaction.set_initial_sample_decision(sampling_context: sampling_context)
       transaction
     end
 

--- a/sentry-ruby/lib/sentry/span.rb
+++ b/sentry-ruby/lib/sentry/span.rb
@@ -21,7 +21,16 @@ module Sentry
     attr_reader :trace_id, :span_id, :parent_span_id, :sampled, :start_timestamp, :timestamp, :description, :op, :status, :tags, :data
     attr_accessor :span_recorder, :transaction
 
-    def initialize(description: nil, op: nil, status: nil, trace_id: nil, parent_span_id: nil, sampled: nil, start_timestamp: nil, timestamp: nil)
+    def initialize(
+      description: nil,
+      op: nil,
+      status: nil,
+      trace_id: nil,
+      parent_span_id: nil,
+      sampled: nil,
+      start_timestamp: nil,
+      timestamp: nil
+    )
       @trace_id = trace_id || SecureRandom.uuid.delete("-")
       @span_id = SecureRandom.hex(8)
       @parent_span_id = parent_span_id


### PR DESCRIPTION
1. This makes the SDK matches sentry-python's implementation.
2. Having a hub inside a Span/Transaction may be necessary for future  features.
3. This eliminates the optional configuration arguments in different  places, which makes it easier to understand and refactor.