### PR TITLE
Don't assign Rails.logger if it's not present

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.3.4
+
+- Don't assign Rails.logger if it's not present [#1387](https://github.com/getsentry/sentry-ruby/pull/1387)
+  - Fixes [#1386](https://github.com/getsentry/sentry-ruby/issues/1386)
+
 ## 4.3.3
 
 - Correctly set the SDK's logger in sentry-rails [#1363](https://github.com/getsentry/sentry-ruby/pull/1363)

--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -5,7 +5,17 @@ module Sentry
     add_post_initialization_callback do
       @rails = Sentry::Rails::Configuration.new
       @excluded_exceptions = @excluded_exceptions.concat(Sentry::Rails::IGNORE_DEFAULT)
-      @logger = ::Rails.logger
+
+      if ::Rails.logger
+        @logger = ::Rails.logger
+      else
+        @logger.warn(Sentry::LOGGER_PROGNAME) do
+          <<~MSG
+          sentry-rails can't detect Rails.logger. it may be caused by misplacement of the SDK initialization code
+          please make sure you place the Sentry.init block under the `config/initializers` folder, e.g. `config/initializers/sentry.rb`
+          MSG
+        end
+      end
     end
   end
 

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -28,18 +28,28 @@ RSpec.describe Sentry::Rails, type: :request do
       expect(app.middleware.find_index(Sentry::Rails::RescuedExceptionInterceptor)).to eq(app.middleware.count - 1)
     end
 
-    it "sets Sentry.configuration.logger correctly" do
-      expect(Sentry.configuration.logger).to eq(Rails.logger)
-    end
-
-    it "respects the logger set by user" do
-      logger = ::Logger.new(nil)
-
-      make_basic_app do |config|
-        config.logger = logger
+    describe "logger detection" do
+      it "sets Sentry.configuration.logger correctly" do
+        expect(Sentry.configuration.logger).to eq(Rails.logger)
       end
 
-      expect(Sentry.configuration.logger).to eq(logger)
+      it "respects the logger set by user" do
+        logger = ::Logger.new(nil)
+
+        make_basic_app do |config|
+          config.logger = logger
+        end
+
+        expect(Sentry.configuration.logger).to eq(logger)
+      end
+
+      it "doesn't cause error if Rails::Logger is not present during SDK initialization" do
+        Rails.logger = nil
+
+        Sentry.init
+
+        expect(Sentry.configuration.logger).to be_a(Sentry::Logger)
+      end
     end
 
     it "sets Sentry.configuration.project_root correctly" do


### PR DESCRIPTION
It should fallback to the original Sentry logger and tell the user there may be an mis-configuration in his/her application.
