### PR TITLE
ci(release): Fix changelog entry paths in craft config

### DIFF
--- a/sentry-delayed_job/.craft.yml
+++ b/sentry-delayed_job/.craft.yml
@@ -11,9 +11,10 @@ artifactProvider:
   name: github
 targets:
     - name: gem
-    - name: github
-      tagPrefix: sentry-delayed_job-v
     - name: registry
       type: sdk
       config:
           canonical: 'gem:sentry-delayed_job'
+    - name: github
+      tagPrefix: sentry-delayed_job-v
+      changelog: sentry-delayed_job/CHANGELOG

--- a/sentry-rails/.craft.yml
+++ b/sentry-rails/.craft.yml
@@ -11,9 +11,10 @@ artifactProvider:
   name: github
 targets:
     - name: gem
-    - name: github
-      tagPrefix: sentry-rails-v
     - name: registry
       type: sdk
       config:
           canonical: 'gem:sentry-rails'
+    - name: github
+      tagPrefix: sentry-rails-v
+      changelog: sentry-rails/CHANGELOG.md

--- a/sentry-raven/.craft.yml
+++ b/sentry-raven/.craft.yml
@@ -11,9 +11,10 @@ artifactProvider:
   name: github
 targets:
     - name: gem
-    - name: github
-      tagPrefix: sentry-raven-v
     - name: registry
       type: sdk
       config:
           canonical: 'gem:sentry-raven'
+    - name: github
+      tagPrefix: sentry-raven-v
+      changelog: sentry-raven/CHANGELOG.md

--- a/sentry-ruby/.craft.yml
+++ b/sentry-ruby/.craft.yml
@@ -13,9 +13,6 @@ targets:
     # we always need to make sure sentry-ruby-core is present when pushing to any target
     - name: gem
       onlyIfPresent: /^sentry-ruby-core-\d.*\.gem$/
-    - name: github
-      onlyIfPresent: /^sentry-ruby-core-\d.*\.gem$/
-      tagPrefix: sentry-ruby-v
     - name: registry
       onlyIfPresent: /^sentry-ruby-core-\d.*\.gem$/
       type: sdk
@@ -26,3 +23,7 @@ targets:
       type: sdk
       config:
           canonical: 'gem:sentry-ruby-core'
+    - name: github
+      onlyIfPresent: /^sentry-ruby-core-\d.*\.gem$/
+      tagPrefix: sentry-ruby-v
+      changelog: sentry-ruby/CHANGELOG.md

--- a/sentry-sidekiq/.craft.yml
+++ b/sentry-sidekiq/.craft.yml
@@ -11,9 +11,10 @@ artifactProvider:
   name: github
 targets:
     - name: gem
-    - name: github
-      tagPrefix: sentry-sidekiq-v
     - name: registry
       type: sdk
       config:
           canonical: 'gem:sentry-sidekiq'
+    - name: github
+      tagPrefix: sentry-sidekiq-v
+      changelog: sentry-sidekiq/CHANGELOG.md


### PR DESCRIPTION
Since we do per-directory releases in this repo, we need to tell Craft where the changelog for each project is (otherwise it just looks at the repo root). This is why our GitHub releases were lacking release notes. This PR also moves the GitHub target to the last to ensure all main targets are published before creating a GitHub release tag.
