### PR TITLE
Record breadcrumb for Net::HTTP requests

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 - Support category-based rate limiting [#1336](https://github.com/getsentry/sentry-ruby/pull/1336) 
 - Record request span from Net::HTTP library [#1381](https://github.com/getsentry/sentry-ruby/pull/1381)
+- Record breadcrumb for Net::HTTP requests [#1394](https://github.com/getsentry/sentry-ruby/pull/1394)
+
+With the new `http_logger` breadcrumbs logger:
+
+```ruby
+config.breadcrumbs_logger = [:http_logger]
+```
+
+The SDK now records a new `net.http` breadcrumb whenever the user makes a request with the `Net::HTTP` library.
+
+<img width="869" alt="net http breadcrumb" src="https://user-images.githubusercontent.com/5079556/114298326-5f7c3d80-9ae8-11eb-9108-222384a7f1a2.png">
 
 ### Refactorings
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -168,8 +168,6 @@ module Sentry
     LOG_PREFIX = "** [Sentry] ".freeze
     MODULE_SEPARATOR = "::".freeze
 
-    AVAILABLE_BREADCRUMBS_LOGGERS = [:sentry_logger, :active_support_logger].freeze
-
     # Post initialization callbacks are called at the end of initialization process
     # allowing extending the configuration of sentry-ruby by multiple extensions
     @@post_initialization_callbacks = []
@@ -227,10 +225,6 @@ module Sentry
         if logger.is_a?(Array)
           logger
         else
-          unless AVAILABLE_BREADCRUMBS_LOGGERS.include?(logger)
-            raise Sentry::Error, "Unsupported breadcrumbs logger. Supported loggers: #{AVAILABLE_BREADCRUMBS_LOGGERS}"
-          end
-
           Array(logger)
         end
 

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -1,15 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe Sentry::Configuration do
-  describe "#breadcrumbs_logger=" do
-    it "raises error when given an invalid option" do
-      expect { subject.breadcrumbs_logger = :foo }.to raise_error(
-        Sentry::Error,
-        'Unsupported breadcrumbs logger. Supported loggers: [:sentry_logger, :active_support_logger]'
-      )
-    end
-  end
-
   describe "#tracing_enabled?" do
     it "returns false by default" do
       expect(subject.tracing_enabled?).to eq(false)

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -1,5 +1,7 @@
 require "spec_helper"
 
+# we can't stub/mock these requests with tools like webmock
+# because they generally stub the request on the same level as the patch works
 RSpec.describe Sentry::Net::HTTP do
   context "with tracing enabled" do
     before do

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -3,13 +3,23 @@ require "spec_helper"
 # we can't stub/mock these requests with tools like webmock
 # because they generally stub the request on the same level as the patch works
 RSpec.describe Sentry::Net::HTTP do
+  let(:string_io) { StringIO.new }
+  let(:logger) do
+    ::Logger.new(string_io)
+  end
+
   context "with http_logger" do
     before do
       perform_basic_setup do |config|
         config.breadcrumbs_logger = [:http_logger]
+        config.transport.transport_class = Sentry::HTTPTransport
+        config.logger = logger
+        # the dsn needs to have a real host so we can make a real connection before sending a failed request
+        config.dsn = 'https://foobarbaz@o447951.ingest.sentry.io/5434472'
       end
     end
-    it "adds breadcrumbs" do
+
+    it "adds http breadcrumbs" do
       response = Net::HTTP.get_response(URI("https://github.com/getsentry/sentry-ruby?foo=bar"))
 
       expect(response.code).to eq("200")
@@ -17,16 +27,28 @@ RSpec.describe Sentry::Net::HTTP do
       expect(crumb.category).to eq("net.http")
       expect(crumb.data).to eq({ status: 200, method: "GET", url: "https://github.com/getsentry/sentry-ruby" })
     end
+
+    it "doesn't record breadcrumb for the SDK's request" do
+      Sentry.capture_message("foo")
+
+      # make sure the request was actually made
+      expect(string_io.string).to match(/bad sentry DSN public key/)
+      expect(Sentry.get_current_scope.breadcrumbs.peek).to be_nil
+    end
   end
 
   context "with tracing enabled" do
     before do
       perform_basic_setup do |config|
         config.traces_sample_rate = 1.0
+        config.transport.transport_class = Sentry::HTTPTransport
+        config.logger = logger
+        # the dsn needs to have a real host so we can make a real connection before sending a failed request
+        config.dsn = 'https://foobarbaz@o447951.ingest.sentry.io/5434472'
       end
     end
 
-    it "records the request's transaction" do
+    it "records the request's span" do
       transaction = Sentry.start_transaction
       Sentry.get_current_scope.set_span(transaction)
 
@@ -42,6 +64,17 @@ RSpec.describe Sentry::Net::HTTP do
       expect(request_span.start_timestamp).not_to eq(request_span.timestamp)
       expect(request_span.description).to eq("GET https://github.com/getsentry/sentry-ruby")
       expect(request_span.data).to eq({ status: 200 })
+    end
+
+    it "doesn't record span for the SDK's request" do
+      transaction = Sentry.start_transaction
+      Sentry.get_current_scope.set_span(transaction)
+
+      Sentry.capture_message("foo")
+
+      # make sure the request was actually made
+      expect(string_io.string).to match(/bad sentry DSN public key/)
+      expect(transaction.span_recorder.spans.count).to eq(1)
     end
 
     it "doesn't mess different requests' data together" do


### PR DESCRIPTION
### Usage

Add this to your config

```ruby
config.breadcrumbs_logger = [:http_logger]
```

And then you'll see `net.http` breadcrumbs appear whenever you make a request with the `Net::HTTP` library.

<img width="869" alt="net http breadcrumb" src="https://user-images.githubusercontent.com/5079556/114298326-5f7c3d80-9ae8-11eb-9108-222384a7f1a2.png">


Closes #778 