### PR TITLE
Use context for delayed_job's job info

### DIFF
--- a/sentry-delayed_job/CHANGELOG.md
+++ b/sentry-delayed_job/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
+### Features
+
 - Add the `report_after_job_retries` configuration option to only report an exception to Sentry if this is the last job's retry after multiple exceptions. [#1364](https://github.com/getsentry/sentry-ruby/pull/1364)
+- Use context for delayed_job's job info [#1395](https://github.com/getsentry/sentry-ruby/pull/1395)
 
 ## 4.3.1
 

--- a/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
+++ b/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Sentry::DelayedJob do
     expect(transport.events.count).to eq(1)
     event = transport.events.last.to_hash
     expect(event[:message]).to eq("report")
-    expect(event[:extra][:"delayed_job.id"]).to eq(enqueued_job.id.to_s)
+    expect(event[:contexts][:"Delayed-Job"][:id]).to eq(enqueued_job.id.to_s)
     expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id.to_s, "delayed_job.queue" => nil })
   end
 
@@ -204,7 +204,7 @@ RSpec.describe Sentry::DelayedJob do
         event = transport.events.last.to_hash
         expect(event[:message]).to eq("report from ActiveJob")
         expect(event[:tags]).to match({ "delayed_job.id" => anything, "delayed_job.queue" => "default", number: 1 })
-        expect(event.dig(:extra, :"active_job.job_class")).to eq("ReportingJob")
+        expect(event[:contexts][:"Active-Job"][:job_class]).to eq("ReportingJob")
       end
     end
 
@@ -231,7 +231,7 @@ RSpec.describe Sentry::DelayedJob do
         event = transport.events.last.to_hash
         expect(event.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
         expect(event[:tags]).to match({ "delayed_job.id" => anything, "delayed_job.queue" => "default", number: 2 })
-        expect(event.dig(:extra, :"active_job.job_class")).to eq("FailedJob")
+        expect(event[:contexts][:"Active-Job"][:job_class]).to eq("FailedJob")
       end
     end
   end


### PR DESCRIPTION
This should improve job information's readability.

**Before:**

<img width="70%" alt="job info in extra" src="https://user-images.githubusercontent.com/5079556/114307133-de856c00-9b10-11eb-8967-cd0e67e80539.png">

**After:**

<img width="70%" alt="job info in context" src="https://user-images.githubusercontent.com/5079556/114307135-e2b18980-9b10-11eb-9fc4-af885bf0f68d.png">
