### PR TITLE
Support config.debug configuration option

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -18,6 +18,10 @@ The SDK now records a new `net.http` breadcrumb whenever the user makes a reques
 
 <img width="869" alt="net http breadcrumb" src="https://user-images.githubusercontent.com/5079556/114298326-5f7c3d80-9ae8-11eb-9108-222384a7f1a2.png">
 
+- Support config.debug configuration option [#1400](https://github.com/getsentry/sentry-ruby/pull/1400)
+
+It'll determine whether the SDK should run in the debugging mode. Default is `false`. When set to true, SDK errors will be logged with backtrace.
+
 ### Refactorings
 
 - Let Transaction constructor take an optional hub argument [#1384](https://github.com/getsentry/sentry-ruby/pull/1384)

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -38,7 +38,7 @@ module Sentry
 
       event
     rescue => e
-      log_error("Event capturing failed: #{e.message}")
+      log_error("Event capturing failed", e)
       nil
     end
 
@@ -88,7 +88,7 @@ module Sentry
       event
     rescue => e
       loggable_event_type = (event_type || "event").capitalize
-      log_error("#{loggable_event_type} sending failed: #{e.message}")
+      log_error("#{loggable_event_type} sending failed", e)
       log_info("Unreported #{loggable_event_type}: #{Event.get_log_message(event.to_hash)}")
       raise
     end
@@ -114,7 +114,7 @@ module Sentry
       end
     rescue => e
       loggable_event_type = event_hash["type"] || "event"
-      log_error("Async #{loggable_event_type} sending failed: #{e.message}")
+      log_error("Async #{loggable_event_type} sending failed", e)
       send_event(event, hint)
     end
   end

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -38,7 +38,7 @@ module Sentry
 
       event
     rescue => e
-      log_error("Event capturing failed", e)
+      log_error("Event capturing failed", e, debug: configuration.debug)
       nil
     end
 
@@ -88,8 +88,10 @@ module Sentry
       event
     rescue => e
       loggable_event_type = (event_type || "event").capitalize
-      log_error("#{loggable_event_type} sending failed", e)
-      log_info("Unreported #{loggable_event_type}: #{Event.get_log_message(event.to_hash)}")
+      log_error("#{loggable_event_type} sending failed", e, debug: configuration.debug)
+
+      event_info = Event.get_log_message(event.to_hash)
+      log_info("Unreported #{loggable_event_type}: #{event_info}")
       raise
     end
 
@@ -114,7 +116,7 @@ module Sentry
       end
     rescue => e
       loggable_event_type = event_hash["type"] || "event"
-      log_error("Async #{loggable_event_type} sending failed", e)
+      log_error("Async #{loggable_event_type} sending failed", e, debug: configuration.debug)
       send_event(event, hint)
     end
   end

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -89,7 +89,7 @@ module Sentry
     rescue => e
       loggable_event_type = (event_type || "event").capitalize
       log_error("#{loggable_event_type} sending failed: #{e.message}")
-      log_error("Unreported #{loggable_event_type}: #{Event.get_log_message(event.to_hash)}")
+      log_info("Unreported #{loggable_event_type}: #{Event.get_log_message(event.to_hash)}")
       raise
     end
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -309,7 +309,7 @@ module Sentry
         detect_release_from_capistrano ||
         detect_release_from_heroku
     rescue => e
-      log_error("Error detecting release: #{e.message}")
+      log_error("Error detecting release", e)
     end
 
     def excluded_exception?(incoming_exception)

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -72,6 +72,10 @@ module Sentry
     # RACK_ENV by default.
     attr_reader :environment
 
+    # Whether the SDK should run in the debugging mode. Default is false.
+    # If set to true, SDK errors will be logged with backtrace
+    attr_accessor :debug
+
     # the dsn value, whether it's set via `config.dsn=` or `ENV["SENTRY_DSN"]`
     attr_reader :dsn
 
@@ -173,6 +177,7 @@ module Sentry
     @@post_initialization_callbacks = []
 
     def initialize
+      self.debug = false
       self.background_worker_threads = Concurrent.processor_count
       self.max_breadcrumbs = BreadcrumbBuffer::DEFAULT_SIZE
       self.breadcrumbs_logger = []
@@ -309,7 +314,7 @@ module Sentry
         detect_release_from_capistrano ||
         detect_release_from_heroku
     rescue => e
-      log_error("Error detecting release", e)
+      log_error("Error detecting release", e, debug: debug)
     end
 
     def excluded_exception?(incoming_exception)

--- a/sentry-ruby/lib/sentry/utils/logging_helper.rb
+++ b/sentry-ruby/lib/sentry/utils/logging_helper.rb
@@ -1,8 +1,11 @@
 module Sentry
   module LoggingHelper
-    def log_error(message, exception)
+    def log_error(message, exception, debug: false)
+      message = "#{message}: #{exception.message}"
+      message += "\n#{exception.backtrace.join("\n")}" if debug
+
       logger.error(LOGGER_PROGNAME) do
-        "#{message}: #{exception.message}"
+        message
       end
     end
 

--- a/sentry-ruby/lib/sentry/utils/logging_helper.rb
+++ b/sentry-ruby/lib/sentry/utils/logging_helper.rb
@@ -1,7 +1,9 @@
 module Sentry
   module LoggingHelper
-    def log_error(message)
-      logger.error(LOGGER_PROGNAME) { message }
+    def log_error(message, exception)
+      logger.error(LOGGER_PROGNAME) do
+        "#{message}: #{exception.message}"
+      end
     end
 
     def log_info(message)


### PR DESCRIPTION
This PR adds the new `debug` config option:

```ruby
config.debug = true # default is false
```

As of now, SDK related errors are only logged with their error messages. 

For example, assume we have this `before_send` callback:

```ruby
  config.before_send = lambda do |event, hint|
    foo
  end
```

The SDK only logs this

```
Event sending failed: undefined local variable or method `foo' for main:Object
```

This is inconvenient for our users to debug their customization on the SDK. It also makes determining/reporting SDK issues harder (see https://github.com/getsentry/sentry-ruby/issues/1383#issuecomment-813143453 for example).

So with when the new `config.debug` option set with `true`, it will log SDK errors with backtrace, just like we normally treat errors in our applications.

```
Event sending failed: undefined local variable or method `foo' for main:Object
/Users/st0012/projects/sentry-ruby/sentry-rails/examples/rails-6.0/config/initializers/sentry.rb:10:in `block (2 levels) in <main>'
/Users/st0012/projects/sentry-ruby/sentry-ruby/lib/sentry/client.rb:78:in `send_event'
/Users/st0012/projects/sentry-ruby/sentry-ruby/lib/sentry/client.rb:102:in `block in dispatch_background_event'
```


Closes #1297 