### PR TITLE
Make hub a required argument for Transaction constructor

### DIFF
--- a/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Sentry::Rails::Tracing::ActionControllerSubscriber, :subscriber, 
     end
 
     it "doesn't record spans" do
-      transaction = Sentry::Transaction.new(sampled: false)
+      transaction = Sentry::Transaction.new(sampled: false, hub: Sentry.get_current_hub)
       Sentry.get_current_scope.set_span(transaction)
 
       get "/world"

--- a/sentry-rails/spec/sentry/rails/tracing/action_view_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_view_subscriber_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Sentry::Rails::Tracing::ActionViewSubscriber, :subscriber, type: 
     end
 
     it "doesn't record spans" do
-      transaction = Sentry::Transaction.new(sampled: false)
+      transaction = Sentry::Transaction.new(sampled: false, hub: Sentry.get_current_hub)
       Sentry.get_current_scope.set_span(transaction)
 
       get "/view"

--- a/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
     end
 
     it "records database query events" do
-      transaction = Sentry::Transaction.new(sampled: true)
+      transaction = Sentry::Transaction.new(sampled: true, hub: Sentry.get_current_hub)
       Sentry.get_current_scope.set_span(transaction)
 
       Post.all.to_a
@@ -40,7 +40,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
     end
 
     it "doesn't record spans" do
-      transaction = Sentry::Transaction.new(sampled: false)
+      transaction = Sentry::Transaction.new(sampled: false, hub: Sentry.get_current_hub)
       Sentry.get_current_scope.set_span(transaction)
 
       Post.all.to_a

--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -143,7 +143,8 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
           op: "pageload",
           status: "ok",
           sampled: true,
-          name: "a/path"
+          name: "a/path",
+          hub: Sentry.get_current_hub
         )
       end
 

--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -23,6 +23,7 @@ The SDK now records a new `net.http` breadcrumb whenever the user makes a reques
 - Let Transaction constructor take an optional hub argument [#1384](https://github.com/getsentry/sentry-ruby/pull/1384)
 - Introduce LoggingHelper [#1385](https://github.com/getsentry/sentry-ruby/pull/1385)
 - Raise exception if a Transaction is initialized without a hub [#1391](https://github.com/getsentry/sentry-ruby/pull/1391)
+- Make hub a required argument for Transaction constructor [#1401](https://github.com/getsentry/sentry-ruby/pull/1401) 
 
 ## 4.3.2
 

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -14,16 +14,13 @@ module Sentry
 
     attr_reader :name, :parent_sampled, :hub, :configuration, :logger
 
-    def initialize(name: nil, parent_sampled: nil, hub: Sentry.get_current_hub, **options)
+    def initialize(name: nil, parent_sampled: nil, hub:, **options)
       super(**options)
 
       @name = name
       @parent_sampled = parent_sampled
       @transaction = self
       @hub = hub
-
-      raise Sentry::Error.new("please initialize the SDK with Sentry.init before initializing a Transaction") unless @hub
-
       @configuration = hub.configuration
       @logger = configuration.logger
       init_span_recorder

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -112,6 +112,15 @@ module Sentry
     end
 
     def finish(hub: nil)
+      if hub
+        log_warn(
+          <<~MSG
+            Specifying a different hub in `Transaction#finish` will be deprecated in version 5.0.
+            Please use `Hub#start_transaction` with the designated hub.
+          MSG
+        )
+      end
+
       hub ||= @hub
 
       super() # Span#finish doesn't take arguments

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -162,7 +162,8 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
           op: "pageload",
           status: "ok",
           sampled: true,
-          name: "a/path"
+          name: "a/path",
+          hub: Sentry.get_current_hub
         )
       end
       let(:stack) do
@@ -396,7 +397,8 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
             op: "pageload",
             status: "ok",
             sampled: true,
-            name: "a/path"
+            name: "a/path",
+            hub: Sentry.get_current_hub
           )
         end
 

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Sentry::Scope do
     new_breadcrumb
   end
 
+  let(:configuration) { Sentry::Configuration.new }
+  let(:client) { Sentry::Client.new(configuration) }
+  let(:hub) do
+    Sentry::Hub.new(client, subject)
+  end
+
   describe "#initialize" do
     it "contains correct defaults" do
       expect(subject.breadcrumbs).to be_a(Sentry::BreadcrumbBuffer)
@@ -51,7 +57,7 @@ RSpec.describe Sentry::Scope do
     it "deep-copies span as well" do
       perform_basic_setup
 
-      span = Sentry::Transaction.new(sampled: true)
+      span = Sentry::Transaction.new(sampled: true, hub: hub)
       subject.set_span(span)
       copy = subject.dup
 
@@ -138,7 +144,7 @@ RSpec.describe Sentry::Scope do
     end
 
     let(:transaction) do
-      Sentry::Transaction.new(op: "parent")
+      Sentry::Transaction.new(op: "parent", hub: hub)
     end
 
     context "with span in the scope" do

--- a/sentry-ruby/spec/sentry/span_spec.rb
+++ b/sentry-ruby/spec/sentry/span_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Sentry::Span do
     context "when the parent span has a span_recorder" do
       subject do
         # inherits the span recorder from the transaction
-        Sentry::Transaction.new.start_child
+        Sentry::Transaction.new(hub: Sentry.get_current_hub).start_child
       end
 
       it "gives the child span its span_recorder" do
@@ -124,7 +124,7 @@ RSpec.describe Sentry::Span do
 
     context "when the parent span has a transaction" do
       before do
-        subject.transaction = Sentry::Transaction.new
+        subject.transaction = Sentry::Transaction.new(hub: Sentry.get_current_hub)
       end
 
       it "gives the child span its transaction" do

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Sentry::Transport do
   let(:fake_time) { Time.now }
 
   let(:client) { Sentry::Client.new(configuration) }
+  let(:hub) do
+    Sentry::Hub.new(client, subject)
+  end
+
   subject { client.transport }
 
   describe "#encode" do
@@ -45,7 +49,7 @@ RSpec.describe Sentry::Transport do
 
     context "transaction event" do
       let(:transaction) do
-        Sentry::Transaction.new(name: "test transaction", op: "rack.request")
+        Sentry::Transaction.new(name: "test transaction", op: "rack.request", hub: hub)
       end
       let(:event) do
         client.event_from_transaction(transaction)

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Sentry do
 
       context "when given an transaction object" do
         it "adds sample decision to it" do
-          transaction = Sentry::Transaction.new
+          transaction = Sentry::Transaction.new(hub: Sentry.get_current_hub)
 
           described_class.start_transaction(transaction: transaction)
 
@@ -229,7 +229,7 @@ RSpec.describe Sentry do
         end
 
         it "provides proper sampling context to the traces_sampler" do
-          transaction = Sentry::Transaction.new(op: "foo")
+          transaction = Sentry::Transaction.new(op: "foo", hub: Sentry.get_current_hub)
 
           context = nil
           Sentry.configuration.traces_sampler = lambda do |sampling_context|
@@ -243,7 +243,7 @@ RSpec.describe Sentry do
         end
 
         it "passes parent_sampled to the sampling_context" do
-          transaction = Sentry::Transaction.new(parent_sampled: true)
+          transaction = Sentry::Transaction.new(parent_sampled: true, hub: Sentry.get_current_hub)
 
           context = nil
           Sentry.configuration.traces_sampler = lambda do |sampling_context|


### PR DESCRIPTION
This implements the change proposed in #1393.

Closes #1393 