### PR TITLE
Add the third tracing state

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -45,6 +45,11 @@ The SDK now records a new `net.http` breadcrumb whenever the user makes a reques
 
 It'll determine whether the SDK should run in the debugging mode. Default is `false`. When set to true, SDK errors will be logged with backtrace.
 
+- Add the third tracing state [#1402](https://github.com/getsentry/sentry-ruby/pull/1402)
+  - `rate == 0` - Tracing enabled. Rejects all locally created transactions but  respects sentry-trace.
+  - `1 > rate > 0` - Tracing enabled. Samples locally created transactions  with the rate and respects sentry-trace.
+  - `rate < 0` or `rate > 1` - Tracing disabled.
+
 ### Refactorings
 
 - Let Transaction constructor take an optional hub argument [#1384](https://github.com/getsentry/sentry-ruby/pull/1384)

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -293,7 +293,7 @@ module Sentry
     end
 
     def tracing_enabled?
-      !!((@traces_sample_rate && @traces_sample_rate > 0.0) || @traces_sampler)
+      !!((@traces_sample_rate && @traces_sample_rate >= 0.0 && @traces_sample_rate <= 1.0) || @traces_sampler)
     end
 
     def stacktrace_builder

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -6,11 +6,19 @@ RSpec.describe Sentry::Configuration do
       expect(subject.tracing_enabled?).to eq(false)
     end
 
-    context "when traces_sample_rate == 0.0" do
+    context "when traces_sample_rate > 1.0" do
       it "returns false" do
-        subject.traces_sample_rate = 0
+        subject.traces_sample_rate = 1.1
 
         expect(subject.tracing_enabled?).to eq(false)
+      end
+    end
+
+    context "when traces_sample_rate == 0.0" do
+      it "returns true" do
+        subject.traces_sample_rate = 0
+
+        expect(subject.tracing_enabled?).to eq(true)
       end
     end
 

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Sentry::Transaction do
       Sentry.configuration
     end
 
-    context "when tracing is enabled" do
+    context "when tracing is enabled (> 0)" do
       before do
         configuration.traces_sample_rate = 1.0
       end
@@ -47,9 +47,26 @@ RSpec.describe Sentry::Transaction do
       end
     end
 
-    context "when tracing is disabled" do
+    context "when tracing is enabled (= 0)" do
       before do
         configuration.traces_sample_rate = 0.0
+      end
+
+      it "returns correctly-formatted value" do
+        child_transaction = described_class.from_sentry_trace(sentry_trace, op: "child")
+
+        expect(child_transaction.trace_id).to eq(subject.trace_id)
+        expect(child_transaction.parent_span_id).to eq(subject.span_id)
+        expect(child_transaction.parent_sampled).to eq(true)
+        # doesn't set the sampled value
+        expect(child_transaction.sampled).to eq(nil)
+        expect(child_transaction.op).to eq("child")
+      end
+    end
+
+    context "when tracing is disabled" do
+      before do
+        configuration.traces_sample_rate = nil
       end
 
       it "returns nil" do


### PR DESCRIPTION
- `rate == 0` - Tracing enabled. Rejects all locally created transactions but  respects sentry-trace.
- `1 > rate > 0` - Tracing enabled. Samples locally created transactions  with the rate and respects sentry-trace.
- `rate < 0` or `rate > 1` - Tracine disabled.