### PR TITLE
Move active job context filter to sentry-rails

### DIFF
--- a/sentry-rails/CHANGELOG.md
+++ b/sentry-rails/CHANGELOG.md
@@ -18,6 +18,11 @@ config.rails.tracing_subscribers << MySubscriber
 config.rails.tracing_subscribers = [MySubscriber]
 ```
 
+
+### Refactorings
+
+- Move active job context filter to sentry-rails [#1406](https://github.com/getsentry/sentry-ruby/pull/1406)
+
 ### Bug Fixes
 
 - Report exceptions from the interceptor middleware for exceptions app [#1379](https://github.com/getsentry/sentry-ruby/pull/1379)

--- a/sentry-rails/lib/sentry/rails/active_job_context_filter.rb
+++ b/sentry-rails/lib/sentry/rails/active_job_context_filter.rb
@@ -1,0 +1,69 @@
+module Sentry
+  module Rails
+    class ActiveJobContextFilter
+      ACTIVEJOB_RESERVED_PREFIX_REGEX = /^_aj_/.freeze
+
+      def transaction_name_prefix
+        ::ActiveJob.name
+      end
+
+      attr_reader :context
+
+      def initialize(context)
+        @context = context
+        @has_global_id = defined?(GlobalID)
+      end
+
+      # Once an ActiveJob is queued, ActiveRecord references get serialized into
+      # some internal reserved keys, such as _aj_globalid.
+      #
+      # The problem is, if this job in turn gets queued back into ActiveJob with
+      # these magic reserved keys, ActiveJob will throw up and error. We want to
+      # capture these and mutate the keys so we can sanely report it.
+      def filtered
+        filter_context(context)
+      end
+
+      def transaction_name
+        class_name = (context["wrapped"] || context["class"] ||
+                      (context[:job] && (context[:job]["wrapped"] || context[:job]["class"]))
+                    )
+
+        if class_name
+          "#{transaction_name_prefix}/#{class_name}"
+        elsif context[:event]
+          "#{transaction_name_prefix}/#{context[:event]}"
+        else
+          transaction_name_prefix
+        end
+      end
+
+      private
+
+      def filter_context(hash)
+        case hash
+        when Array
+          hash.map { |arg| filter_context(arg) }
+        when Hash
+          Hash[hash.map { |key, value| filter_context_hash(key, value) }]
+        else
+          if has_global_id? && hash.is_a?(GlobalID)
+            hash.to_s
+          else
+            hash
+          end
+        end
+      end
+
+      def filter_context_hash(key, value)
+        key = key.to_s.sub(ACTIVEJOB_RESERVED_PREFIX_REGEX, "") if key.match(ACTIVEJOB_RESERVED_PREFIX_REGEX)
+        [key, filter_context(value)]
+      end
+
+      def has_global_id?
+        @has_global_id
+      end
+    end
+  end
+end
+

--- a/sentry-rails/spec/sentry/rails/active_job_context_filter_spec.rb
+++ b/sentry-rails/spec/sentry/rails/active_job_context_filter_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
+require "active_job"
+require "sentry/rails/active_job_context_filter"
 
-RSpec.describe Sentry::Sidekiq::ContextFilter do
+RSpec.describe Sentry::Rails::ActiveJobContextFilter do
   describe "#filtered" do
     subject(:context_filter) { described_class.new(context) }
 
@@ -44,7 +46,7 @@ RSpec.describe Sentry::Sidekiq::ContextFilter do
       let(:context) { { "class" => "FooJob" } }
 
       it "extracts the class" do
-        expect(context_filter.transaction_name).to eq("Sidekiq/FooJob")
+        expect(context_filter.transaction_name).to eq("ActiveJob/FooJob")
       end
     end
 
@@ -52,7 +54,7 @@ RSpec.describe Sentry::Sidekiq::ContextFilter do
       let(:context) { { "wrapped" => "FooJob", "class" => "WrapperJob" } }
 
       it "extracts the wrapped class" do
-        expect(context_filter.transaction_name).to eq("Sidekiq/FooJob")
+        expect(context_filter.transaction_name).to eq("ActiveJob/FooJob")
       end
     end
 
@@ -60,7 +62,7 @@ RSpec.describe Sentry::Sidekiq::ContextFilter do
       let(:context) { { job: { "class" => "FooJob" } } }
 
       it "extracts the class" do
-        expect(context_filter.transaction_name).to eq("Sidekiq/FooJob")
+        expect(context_filter.transaction_name).to eq("ActiveJob/FooJob")
       end
     end
 
@@ -68,7 +70,7 @@ RSpec.describe Sentry::Sidekiq::ContextFilter do
       let(:context) { { job: { "wrapped" => "FooJob", "class" => "WrapperJob" } } }
 
       it "extracts the wrapped class" do
-        expect(context_filter.transaction_name).to eq("Sidekiq/FooJob")
+        expect(context_filter.transaction_name).to eq("ActiveJob/FooJob")
       end
     end
 
@@ -76,7 +78,7 @@ RSpec.describe Sentry::Sidekiq::ContextFilter do
       let(:context) { { event: "startup" } }
 
       it "extracts the event name" do
-        expect(context_filter.transaction_name).to eq("Sidekiq/startup")
+        expect(context_filter.transaction_name).to eq("ActiveJob/startup")
       end
     end
 
@@ -84,7 +86,7 @@ RSpec.describe Sentry::Sidekiq::ContextFilter do
       let(:context) { { foo: "bar" } }
 
       it "extracts nothing" do
-        expect(context_filter.transaction_name).to eq("Sidekiq")
+        expect(context_filter.transaction_name).to eq("ActiveJob")
       end
     end
   end

--- a/sentry-sidekiq/CHANGELOG.md
+++ b/sentry-sidekiq/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Refactorings
+
+- Move active job context filter to sentry-rails [#1406](https://github.com/getsentry/sentry-ruby/pull/1406)
+
 ## 4.3.0
 
 ### Features

--- a/sentry-sidekiq/lib/sentry/sidekiq/context_filter.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/context_filter.rb
@@ -1,64 +1,12 @@
+require "sentry/rails/active_job_context_filter"
+
 module Sentry
   module Sidekiq
-    class ContextFilter
-      ACTIVEJOB_RESERVED_PREFIX_REGEX = /^_aj_/.freeze
+    class ContextFilter < Sentry::Rails::ActiveJobContextFilter
       SIDEKIQ_NAME = "Sidekiq".freeze
 
-      attr_reader :context
-
-      def initialize(context)
-        @context = context
-        @has_global_id = defined?(GlobalID)
-      end
-
-      # Once an ActiveJob is queued, ActiveRecord references get serialized into
-      # some internal reserved keys, such as _aj_globalid.
-      #
-      # The problem is, if this job in turn gets queued back into ActiveJob with
-      # these magic reserved keys, ActiveJob will throw up and error. We want to
-      # capture these and mutate the keys so we can sanely report it.
-      def filtered
-        filter_context(context)
-      end
-
-      def transaction_name
-        class_name = (context["wrapped"] || context["class"] ||
-                      (context[:job] && (context[:job]["wrapped"] || context[:job]["class"]))
-                    )
-
-        if class_name
-          "#{SIDEKIQ_NAME}/#{class_name}"
-        elsif context[:event]
-          "#{SIDEKIQ_NAME}/#{context[:event]}"
-        else
-          SIDEKIQ_NAME
-        end
-      end
-
-      private
-
-      def filter_context(hash)
-        case hash
-        when Array
-          hash.map { |arg| filter_context(arg) }
-        when Hash
-          Hash[hash.map { |key, value| filter_context_hash(key, value) }]
-        else
-          if has_global_id? && hash.is_a?(GlobalID)
-            hash.to_s
-          else
-            hash
-          end
-        end
-      end
-
-      def filter_context_hash(key, value)
-        key = key.to_s.sub(ACTIVEJOB_RESERVED_PREFIX_REGEX, "") if key.match(ACTIVEJOB_RESERVED_PREFIX_REGEX)
-        [key, filter_context(value)]
-      end
-
-      def has_global_id?
-        @has_global_id
+      def transaction_name_prefix
+        SIDEKIQ_NAME
       end
     end
   end


### PR DESCRIPTION
Since context filter's job is to clean active job entries in the job payload, it should be implemented by `sentry-rails` so we can use it in different background job integrations as well, like `sentry-delayed_job`. 