### PR TITLE
Always run builds for all integrations

### DIFF
--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -8,8 +8,8 @@ on:
       - \d+-\d+
   pull_request:
     paths:
-      - 'sentry-delayed_job/**'
-      - 'sentry-ruby/**'
+      - 'sentry-*/**'
+      - '!sentry-raven/**'
 jobs:
   test:
     defaults:

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -8,8 +8,8 @@ on:
       - \d+-\d+
   pull_request:
     paths:
-      - 'sentry-rails/**'
-      - 'sentry-ruby/**'
+      - 'sentry-*/**'
+      - '!sentry-raven/**'
 jobs:
   test:
     defaults:

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -8,7 +8,8 @@ on:
       - \d+-\d+
   pull_request:
     paths:
-      - 'sentry-ruby/**'
+      - 'sentry-*/**'
+      - '!sentry-raven/**'
 jobs:
   test:
     defaults:

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -8,8 +8,8 @@ on:
       - \d+-\d+
   pull_request:
     paths:
-      - 'sentry-sidekiq/**'
-      - 'sentry-ruby/**'
+      - 'sentry-*/**'
+      - '!sentry-raven/**'
 jobs:
   test:
     defaults:

--- a/sentry-sidekiq/Gemfile
+++ b/sentry-sidekiq/Gemfile
@@ -3,8 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in sentry-ruby.gemspec
 gemspec
 
-# TODO: Remove this if https://github.com/jruby/jruby/issues/6547 is addressed
-gem "i18n", "<= 1.8.7"
+gem "i18n", "~> 1.8.9"
 
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"


### PR DESCRIPTION
Although this may not help catching issues, it will make it easier to set merge blockers. 