### PR TITLE
Check Scope#set_context's value argument

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -52,6 +52,10 @@ It'll determine whether the SDK should run in the debugging mode. Default is `fa
 - Raise exception if a Transaction is initialized without a hub [#1391](https://github.com/getsentry/sentry-ruby/pull/1391)
 - Make hub a required argument for Transaction constructor [#1401](https://github.com/getsentry/sentry-ruby/pull/1401) 
 
+### Bug Fixes
+
+- Check `Scope#set_context`'s value argument [#1415](https://github.com/getsentry/sentry-ruby/pull/1415)
+
 ## 4.3.2
 
 - Correct type attribute's usages [#1354](https://github.com/getsentry/sentry-ruby/pull/1354)

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -130,6 +130,7 @@ module Sentry
     end
 
     def set_context(key, value)
+      check_argument_type!(value, Hash)
       @contexts.merge!(key => value)
     end
 

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -49,24 +49,29 @@ RSpec.describe Sentry::Hub do
 
       it "merges the contexts/tags/extrac with what the scope already has" do
         scope.set_tags(old_tag: true)
-        scope.set_contexts(old_context: true)
+        scope.set_contexts({ character: { name: "John", age: 25 }})
         scope.set_extras(old_extra: true)
 
         subject.send(
           capture_helper,
           capture_subject,
           tags: { new_tag: true },
-          contexts: { new_context: true },
+          contexts: { another_character: { name: "Jane", age: 20 }},
           extra: { new_extra: true }
         )
 
         event = transport.events.last
         expect(event.tags).to eq({ new_tag: true, old_tag: true })
-        expect(event.contexts).to include({ new_context: true, old_context: true })
+        expect(event.contexts).to include(
+          {
+            character: { name: "John", age: 25 },
+            another_character: { name: "Jane", age: 20 }
+          }
+        )
         expect(event.extra).to eq({ new_extra: true, old_extra: true })
 
         expect(scope.tags).to eq(old_tag: true)
-        expect(scope.contexts).to include(old_context: true)
+        expect(scope.contexts).to include({ character: { name: "John", age: 25 }})
         expect(scope.extra).to eq(old_extra: true)
       end
     end

--- a/sentry-ruby/spec/sentry/scope/setters_spec.rb
+++ b/sentry-ruby/spec/sentry/scope/setters_spec.rb
@@ -106,12 +106,26 @@ RSpec.describe Sentry::Scope do
   end
 
   describe "#set_context" do
+    it "raises error when passed non-hash value" do
+      expect do
+        subject.set_context(:character, "John")
+      end.to raise_error(ArgumentError)
+    end
+
     it "merges the key value with existing context" do
-      subject.set_contexts({bar: "baz"})
+      subject.set_context(:character, { name: "John" })
+      expect(subject.contexts).to include({ character: { name: "John" }})
 
-      subject.set_context(:foo, "bar")
+      subject.set_context(:character, { name: "John", age: 25 })
+      expect(subject.contexts).to include({ character: { name: "John", age: 25 }})
 
-      expect(subject.contexts).to include({foo: "bar", bar: "baz"})
+      subject.set_context(:another_character, { name: "Jane", age: 20 })
+      expect(subject.contexts).to include(
+        {
+          character: { name: "John", age: 25 },
+          another_character: { name: "Jane", age: 20 }
+        }
+      )
     end
   end
 


### PR DESCRIPTION
A context's value should always be an object when sent to Sentry. So the SDK should make sure users pass the right type of value (A Ruby Hash).

