### PR TITLE
Disable tracing if events are not allowed to be sent

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- Disable tracing if events are not allowed to be sent [#1421](https://github.com/getsentry/sentry-ruby/pull/1421)
+
 ## 4.4.0-beta.0
 
 ### Features

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -293,7 +293,7 @@ module Sentry
     end
 
     def tracing_enabled?
-      !!((@traces_sample_rate && @traces_sample_rate >= 0.0 && @traces_sample_rate <= 1.0) || @traces_sampler)
+      !!((@traces_sample_rate && @traces_sample_rate >= 0.0 && @traces_sample_rate <= 1.0) || @traces_sampler) && sending_allowed?
     end
 
     def stacktrace_builder

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -2,39 +2,66 @@ require 'spec_helper'
 
 RSpec.describe Sentry::Configuration do
   describe "#tracing_enabled?" do
-    it "returns false by default" do
-      expect(subject.tracing_enabled?).to eq(false)
+    context "when sending not allowed" do
+      before do
+        allow(subject).to receive(:sending_allowed?).and_return(false)
+      end
+
+      context "when traces_sample_rate > 0" do
+        it "returns false" do
+          subject.traces_sample_rate = 0.1
+
+          expect(subject.tracing_enabled?).to eq(false)
+        end
+      end
+
+      context "when traces_sampler is set" do
+        it "returns false" do
+          subject.traces_sampler = proc { true }
+
+          expect(subject.tracing_enabled?).to eq(false)
+        end
+      end
     end
+    context "when sending allowed" do
+      before do
+        allow(subject).to receive(:sending_allowed?).and_return(true)
+      end
 
-    context "when traces_sample_rate > 1.0" do
-      it "returns false" do
-        subject.traces_sample_rate = 1.1
-
+      it "returns false by default" do
         expect(subject.tracing_enabled?).to eq(false)
       end
-    end
 
-    context "when traces_sample_rate == 0.0" do
-      it "returns true" do
-        subject.traces_sample_rate = 0
+      context "when traces_sample_rate > 1.0" do
+        it "returns false" do
+          subject.traces_sample_rate = 1.1
 
-        expect(subject.tracing_enabled?).to eq(true)
+          expect(subject.tracing_enabled?).to eq(false)
+        end
       end
-    end
 
-    context "when traces_sample_rate > 0" do
-      it "returns true" do
-        subject.traces_sample_rate = 0.1
+      context "when traces_sample_rate == 0.0" do
+        it "returns true" do
+          subject.traces_sample_rate = 0
 
-        expect(subject.tracing_enabled?).to eq(true)
+          expect(subject.tracing_enabled?).to eq(true)
+        end
       end
-    end
 
-    context "when traces_sampler is set" do
-      it "returns true" do
-        subject.traces_sampler = proc { true }
+      context "when traces_sample_rate > 0" do
+        it "returns true" do
+          subject.traces_sample_rate = 0.1
 
-        expect(subject.tracing_enabled?).to eq(true)
+          expect(subject.tracing_enabled?).to eq(true)
+        end
+      end
+
+      context "when traces_sampler is set" do
+        it "returns true" do
+          subject.traces_sampler = proc { true }
+
+          expect(subject.tracing_enabled?).to eq(true)
+        end
       end
     end
   end

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -268,6 +268,25 @@ RSpec.describe Sentry do
           expect(context).to include({ foo: "bar" })
         end
       end
+
+      context "when event reporting is not enabled" do
+        let(:string_io) { StringIO.new }
+        let(:logger) do
+          ::Logger.new(string_io)
+        end
+        before do
+          Sentry.configuration.logger = logger
+          Sentry.configuration.enabled_environments = ["production"]
+        end
+
+        it "sets @sampled to false and return" do
+          transaction = described_class.start_transaction
+          expect(transaction).to eq(nil)
+          expect(string_io.string).not_to include(
+            "[Tracing]"
+          )
+        end
+      end
     end
 
     context "when tracing is disabled" do


### PR DESCRIPTION
Users can enable/disable the SDK's event sending with `enabled_environments` config option. And when the current environment doesn't match the `enabled_environments`, the SDK will not send any events. But currently, the SDK would still start transactions under such condition.

Even though those transactions would not be sent later (stopped by `Client#send_event`), it'd still create sampling logs, which are noisy and confusing to users.

So this commit fixes the issue by making tracing activation aware of the event sending state.