### PR TITLE
set_initial_sample_decision should always respect the original decision

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Disable tracing if events are not allowed to be sent [#1421](https://github.com/getsentry/sentry-ruby/pull/1421)
+- `set_initial_sample_decision` should always respect the original decision [#1423](https://github.com/getsentry/sentry-ruby/pull/1423)
 
 ## 4.4.0-beta.0
 

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -65,7 +65,6 @@ module Sentry
 
     def set_initial_sample_decision(sampling_context:)
       unless configuration.tracing_enabled?
-        @sampled = false
         return
       end
 

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -157,12 +157,14 @@ RSpec.describe Sentry::Transaction do
         allow(Sentry.configuration).to receive(:tracing_enabled?).and_return(false)
       end
 
-      it "sets @sampled to false and return" do
-        allow(Sentry.configuration).to receive(:tracing_enabled?).and_return(false)
+      it "skips the sampling process" do
+        transaction = described_class.new(sampled: nil, hub: Sentry.get_current_hub)
+        transaction.set_initial_sample_decision(sampling_context: {})
+        expect(transaction.sampled).to eq(nil)
 
         transaction = described_class.new(sampled: true, hub: Sentry.get_current_hub)
         transaction.set_initial_sample_decision(sampling_context: {})
-        expect(transaction.sampled).to eq(false)
+        expect(transaction.sampled).to eq(true)
       end
     end
 


### PR DESCRIPTION
This is to address the issue found in this comment https://github.com/getsentry/sentry-ruby/pull/1421#discussion_r622870135