### PR TITLE
Fix original user context mutated in block

### DIFF
--- a/sentry-raven/lib/raven/instance.rb
+++ b/sentry-raven/lib/raven/instance.rb
@@ -179,7 +179,7 @@ module Raven
       original_user_context = context.user
 
       if options
-        context.user.merge!(options)
+        context.user = context.user.merge(options)
       else
         context.user = {}
       end

--- a/sentry-raven/spec/raven/instance_spec.rb
+++ b/sentry-raven/spec/raven/instance_spec.rb
@@ -292,6 +292,17 @@ RSpec.describe Raven::Instance do
         end
         expect(subject.context.user).to eq previous_user_context
       end
+
+      it "resets with nested blocks" do
+        subject.context.user = {}
+        subject.user_context(id: 9999) do
+          subject.user_context(email: 'foo@bar.com') do
+            expect(subject.context.user).to eq(id: 9999, email: 'foo@bar.com')
+          end
+          expect(subject.context.user).to eq(id: 9999)
+        end
+        expect(subject.context.user).to eq({})
+      end
     end
   end
 

--- a/sentry-raven/spec/raven/instance_spec.rb
+++ b/sentry-raven/spec/raven/instance_spec.rb
@@ -284,13 +284,12 @@ RSpec.describe Raven::Instance do
       end
 
       it "sets user context only in the block" do
-        subject.context.user = previous_user_context = { id: 9999 }
-        new_user_context = { id: 1 }
+        subject.context.user = { id: 9999 }
 
-        subject.user_context(new_user_context) do
-          expect(subject.context.user).to eq new_user_context
+        subject.user_context(id: 1) do
+          expect(subject.context.user).to eq(id: 1)
         end
-        expect(subject.context.user).to eq previous_user_context
+        expect(subject.context.user).to eq(id: 9999)
       end
 
       it "resets with nested blocks" do

--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix NoMethodError when SDK's dsn is nil [#1433](https://github.com/getsentry/sentry-ruby/pull/1433)
 - fix: Update protocol version to 7 [#1434](https://github.com/getsentry/sentry-ruby/pull/1434)
   - Fixes [#867](https://github.com/getsentry/sentry-ruby/issues/867)
+- fix: user_context with block does not reset context after block exits
 
 ## 4.4.1
 


### PR DESCRIPTION
using `.merge!` in `user_context` resulted in the original context being mutated. The "sets user context only in the block" spec appeared to pass but the line `expect(subject.context.user).to eq previous_user_context` was misleading because `previous_user_context` had been mutated. So it looks like it's asserting `expect(subject.context.user).to eq(id: 9999)` but it was actually asserting `expect(subject.context.user).to eq(id: 1)` which was incorrect.

I added a second spec for nested calls but that wouldn't be necessary to demonstrate the fix.