### PR TITLE
ci: Use the latest 1.x version of release action

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -21,7 +21,7 @@ jobs:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0
       - name: Prepare release
-        uses: getsentry/action-prepare-release@v1.1
+        uses: getsentry/action-prepare-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         with:


### PR DESCRIPTION
We have added auto-resume support when a publish fails with v1.2 of `action-prepare-release`. This patch moves the version identifier to 1.x from 1.1.x to get the new features automatically.
