### PR TITLE
Apply patches when initializing the SDK

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.4.1
+
+- Apply patches when initializing the SDK [#1432](https://github.com/getsentry/sentry-ruby/pull/1432)
+
 ## 4.4.0
 
 ### Features

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -84,4 +84,7 @@ module Sentry
   end
 end
 
-Net::HTTP.send(:prepend, Sentry::Net::HTTP)
+Sentry.register_patch do
+  patch = Sentry::Net::HTTP
+  Net::HTTP.send(:prepend, patch) unless Net::HTTP.ancestors.include?(patch)
+end


### PR DESCRIPTION
This new change has 2 benefits:
1. It gives the SDK more control on how/when to apply the patches.
2. By applying patches later (usually in app initialization phase), we can avoid the conflict between different patching approaches.

The 2 patching approaches are `alias` and `prepend`. When 2 gems patch the same class in this order, it'll cause "stack level too deep" error:

```
# gem requiring phase
prepend <- sentry-ruby
alias <- gems like scout_apm or rack-mini-profiler
```

After this commit, we can almost be certain that the order would be:

```
# gem requiring phase
alias <- gems like scout_apm or rack-mini-profiler
----
# app initialization phase
prepend <- sentry-ruby
```

And thus avoid the error.