### PR TITLE
Fix NoMethodError when SDK's dsn is nil

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.4.2
+
+- Fix NoMethodError when SDK's dsn is nil [#1433](https://github.com/getsentry/sentry-ruby/pull/1433)
+
 ## 4.4.1
 
 - Apply patches when initializing the SDK [#1432](https://github.com/getsentry/sentry-ruby/pull/1432)

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -71,8 +71,8 @@ module Sentry
       end
 
       def from_sentry_sdk?
-        dsn_host = Sentry.configuration.dsn.host
-        dsn_host == self.address
+        dsn = Sentry.configuration.dsn
+        dsn && dsn.host == self.address
       end
 
       def extract_request_info(req)

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -72,6 +72,23 @@ RSpec.describe Sentry::Net::HTTP do
       expect(string_io.string).to match(/bad sentry DSN public key/)
       expect(Sentry.get_current_scope.breadcrumbs.peek).to be_nil
     end
+
+    context "when dsn is nil" do
+      before do
+        Sentry.configuration.instance_variable_set(:@dsn, nil)
+      end
+      it "doesn't cause error" do
+        stub_normal_response
+
+        response = Net::HTTP.get_response(URI("http://example.com/path?foo=bar"))
+
+        expect(response.code).to eq("200")
+        crumb = Sentry.get_current_scope.breadcrumbs.peek
+        expect(crumb.category).to eq("net.http")
+        expect(crumb.data).to eq({ status: 200, method: "GET", url: "http://example.com/path" })
+      end
+    end
+
   end
 
   context "with tracing enabled" do


### PR DESCRIPTION
Users may choose deactivating the SDK by simply not setting the dsn. But the current http_logger doesn't handle such case and would cause error.