### PR TITLE
fix: Update protocol version to 7

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 4.4.2
 
 - Fix NoMethodError when SDK's dsn is nil [#1433](https://github.com/getsentry/sentry-ruby/pull/1433)
+- fix: Update protocol version to 7 [#1434](https://github.com/getsentry/sentry-ruby/pull/1434)
+  - Fixes [#867](https://github.com/getsentry/sentry-ruby/issues/867)
 
 ## 4.4.1
 

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -3,7 +3,7 @@ require "base64"
 
 module Sentry
   class Transport
-    PROTOCOL_VERSION = '5'
+    PROTOCOL_VERSION = '7'
     USER_AGENT = "sentry-ruby/#{Sentry::VERSION}"
 
     include LoggingHelper

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Sentry::Transport do
   describe "#generate_auth_header" do
     it "generates an auth header" do
       expect(subject.send(:generate_auth_header)).to eq(
-        "Sentry sentry_version=5, sentry_client=sentry-ruby/#{Sentry::VERSION}, sentry_timestamp=#{fake_time.to_i}, " \
+        "Sentry sentry_version=7, sentry_client=sentry-ruby/#{Sentry::VERSION}, sentry_timestamp=#{fake_time.to_i}, " \
         "sentry_key=12345, sentry_secret=67890"
       )
     end
@@ -159,7 +159,7 @@ RSpec.describe Sentry::Transport do
       configuration.server = "https://66260460f09b5940498e24bb7ce093a0@sentry.io/42"
 
       expect(subject.send(:generate_auth_header)).to eq(
-        "Sentry sentry_version=5, sentry_client=sentry-ruby/#{Sentry::VERSION}, sentry_timestamp=#{fake_time.to_i}, " \
+        "Sentry sentry_version=7, sentry_client=sentry-ruby/#{Sentry::VERSION}, sentry_timestamp=#{fake_time.to_i}, " \
         "sentry_key=66260460f09b5940498e24bb7ce093a0"
       )
     end


### PR DESCRIPTION
Modern SDKs use protocol version 7.

The version triggers different code paths during ingestion, and so the modern Ruby SDK should also use v7.

See https://develop.sentry.dev/sdk/overview/#authentication.

Fixes #867