### PR TITLE
fix: Fix changelog config in craft

### DIFF
--- a/sentry-delayed_job/.craft.yml
+++ b/sentry-delayed_job/.craft.yml
@@ -3,6 +3,7 @@ github:
     owner: getsentry
     repo: sentry-ruby
 changelogPolicy: simple
+changelog: sentry-delayed_job/CHANGELOG
 preReleaseCommand: ruby ../.scripts/bump-version.rb
 releaseBranchPrefix: release-sentry-delayed_job
 statusProvider:
@@ -17,4 +18,3 @@ targets:
           canonical: 'gem:sentry-delayed_job'
     - name: github
       tagPrefix: sentry-delayed_job-v
-      changelog: sentry-delayed_job/CHANGELOG

--- a/sentry-rails/.craft.yml
+++ b/sentry-rails/.craft.yml
@@ -3,6 +3,7 @@ github:
     owner: getsentry
     repo: sentry-ruby
 changelogPolicy: simple
+changelog: sentry-rails/CHANGELOG.md
 preReleaseCommand: ruby ../.scripts/bump-version.rb
 releaseBranchPrefix: release-sentry-rails
 statusProvider:
@@ -17,4 +18,3 @@ targets:
           canonical: 'gem:sentry-rails'
     - name: github
       tagPrefix: sentry-rails-v
-      changelog: sentry-rails/CHANGELOG.md

--- a/sentry-raven/.craft.yml
+++ b/sentry-raven/.craft.yml
@@ -3,6 +3,7 @@ github:
     owner: getsentry
     repo: sentry-ruby
 changelogPolicy: simple
+changelog: sentry-raven/CHANGELOG.md
 preReleaseCommand: ruby .scripts/bump-version.rb
 releaseBranchPrefix: release-sentry-raven
 statusProvider:
@@ -17,4 +18,3 @@ targets:
           canonical: 'gem:sentry-raven'
     - name: github
       tagPrefix: sentry-raven-v
-      changelog: sentry-raven/CHANGELOG.md

--- a/sentry-ruby/.craft.yml
+++ b/sentry-ruby/.craft.yml
@@ -3,6 +3,7 @@ github:
     owner: getsentry
     repo: sentry-ruby
 changelogPolicy: simple
+changelog: sentry-ruby/CHANGELOG.md
 preReleaseCommand: ruby ../.scripts/bump-version.rb
 releaseBranchPrefix: release-sentry-ruby
 statusProvider:
@@ -26,4 +27,3 @@ targets:
     - name: github
       onlyIfPresent: /^sentry-ruby-core-\d.*\.gem$/
       tagPrefix: sentry-ruby-v
-      changelog: sentry-ruby/CHANGELOG.md

--- a/sentry-sidekiq/.craft.yml
+++ b/sentry-sidekiq/.craft.yml
@@ -3,6 +3,7 @@ github:
     owner: getsentry
     repo: sentry-ruby
 changelogPolicy: simple
+changelog: sentry-sidekiq/CHANGELOG.md
 preReleaseCommand: ruby ../.scripts/bump-version.rb
 releaseBranchPrefix: release-sentry-sidekiq
 statusProvider:
@@ -17,4 +18,3 @@ targets:
           canonical: 'gem:sentry-sidekiq'
     - name: github
       tagPrefix: sentry-sidekiq-v
-      changelog: sentry-sidekiq/CHANGELOG.md


### PR DESCRIPTION
This is a fix up to https://github.com/getsentry/sentry-ruby/pull/1390#issuecomment-834143608
