### PR TITLE
Remove unrecognizeable attribute

### DIFF
--- a/sentry-delayed_job/.craft.yml
+++ b/sentry-delayed_job/.craft.yml
@@ -2,7 +2,6 @@ minVersion: '0.13.2'
 github:
     owner: getsentry
     repo: sentry-ruby
-    projectPath: sentry-delayed_job
 changelogPolicy: simple
 preReleaseCommand: ruby ../.scripts/bump-version.rb
 releaseBranchPrefix: release-sentry-delayed_job

--- a/sentry-rails/.craft.yml
+++ b/sentry-rails/.craft.yml
@@ -2,7 +2,6 @@ minVersion: '0.13.2'
 github:
     owner: getsentry
     repo: sentry-ruby
-    projectPath: sentry-rails
 changelogPolicy: simple
 preReleaseCommand: ruby ../.scripts/bump-version.rb
 releaseBranchPrefix: release-sentry-rails

--- a/sentry-raven/.craft.yml
+++ b/sentry-raven/.craft.yml
@@ -2,7 +2,6 @@ minVersion: '0.13.2'
 github:
     owner: getsentry
     repo: sentry-ruby
-    projectPath: sentry-raven
 changelogPolicy: simple
 preReleaseCommand: ruby .scripts/bump-version.rb
 releaseBranchPrefix: release-sentry-raven

--- a/sentry-ruby/.craft.yml
+++ b/sentry-ruby/.craft.yml
@@ -2,7 +2,6 @@ minVersion: '0.13.2'
 github:
     owner: getsentry
     repo: sentry-ruby
-    projectPath: sentry-ruby
 changelogPolicy: simple
 preReleaseCommand: ruby ../.scripts/bump-version.rb
 releaseBranchPrefix: release-sentry-ruby

--- a/sentry-sidekiq/.craft.yml
+++ b/sentry-sidekiq/.craft.yml
@@ -2,7 +2,6 @@ minVersion: '0.13.2'
 github:
     owner: getsentry
     repo: sentry-ruby
-    projectPath: sentry-sidekiq
 changelogPolicy: simple
 preReleaseCommand: ruby ../.scripts/bump-version.rb
 releaseBranchPrefix: release-sentry-sidekiq


### PR DESCRIPTION
Right now the attribute cause this error when preparing a release:

```
✖ error Error: Cannot parse configuration file:
  data.github should NOT have additional properties
```

It requires a newer version of `craft` to read the new attribute. We can revert the change after the newer version is released.