### PR TITLE
Add sentry_trace connection example

### DIFF
--- a/sentry-rails/examples/rails-6.0/app/controllers/welcome_controller.rb
+++ b/sentry-rails/examples/rails-6.0/app/controllers/welcome_controller.rb
@@ -5,6 +5,18 @@ class WelcomeController < ApplicationController
     1 / 0
   end
 
+  def connect_trace
+    transaction = Sentry.get_current_scope.get_transaction
+    # see the sinatra example under the `sentry-ruby` folder
+    uri = URI("http://localhost:4567/connect_trace")
+    http = Net::HTTP.new(uri.host, uri.port)
+    request = Net::HTTP::Get.new(uri.request_uri)
+    request["SENTRY_TRACE"] = transaction.to_sentry_trace
+    response = http.request(request)
+
+    render plain: response.code
+  end
+
   def view_error
   end
 

--- a/sentry-rails/examples/rails-6.0/config/routes.rb
+++ b/sentry-rails/examples/rails-6.0/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get '500', :to => 'welcome#report_demo'
   root to: "welcome#index"
 
+  get 'connect_trace', to: 'welcome#connect_trace'
   get 'view_error', to: 'welcome#view_error'
   get 'worker_error', to: 'welcome#worker_error'
   get 'job_error', to: 'welcome#job_error'

--- a/sentry-ruby/examples/sinatra/app.rb
+++ b/sentry-ruby/examples/sinatra/app.rb
@@ -11,3 +11,8 @@ use Sentry::Rack::CaptureExceptions
 get "/exception" do
   1/0
 end
+
+get "/connect_trace" do
+  event = Sentry.capture_message("sentry-trace test")
+  event.event_id
+end


### PR DESCRIPTION
- Parent: sentry-rails' example app
- Child: sentry-ruby's sinatra example

Usage:

1. `$ cd sentry-rails/examples/rails-6.0`
2. `$ bundle exec rails s`
3. `$ cd sentry-ruby/examples/sinatra`
4. `$ bundle exec ruby app.rb`
5. Visit `http://localhost:3000/connect_trace` in browser

<img width="70%" alt="connect sentry trace" src="https://user-images.githubusercontent.com/5079556/118290513-17966f00-b509-11eb-9bfa-0440c46fae79.png">
