### PR TITLE
Allow toggling background sending on the fly

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- Allow toggling background sending on the fly [#1447](https://github.com/getsentry/sentry-ruby/pull/1447) 
+
 ## 4.4.2
 
 - Fix NoMethodError when SDK's dsn is nil [#1433](https://github.com/getsentry/sentry-ruby/pull/1433)

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -30,7 +30,7 @@ module Sentry
 
       if async_block = configuration.async
         dispatch_async_event(async_block, event, hint)
-      elsif hint.fetch(:background, true)
+      elsif configuration.background_worker_threads != 0 && hint.fetch(:background, true)
         dispatch_background_event(event, hint)
       else
         send_event(event, hint)

--- a/sentry-ruby/spec/sentry/client/event_sending_spec.rb
+++ b/sentry-ruby/spec/sentry/client/event_sending_spec.rb
@@ -112,6 +112,16 @@ RSpec.describe Sentry::Client do
           expect(transport.events.count).to eq(1)
         end
       end
+
+      context "with config.background_worker_threads set to 0 on the fly" do
+        it "sends the event immediately" do
+          configuration.background_worker_threads = 0
+
+          subject.capture_event(event, scope)
+
+          expect(transport.events.count).to eq(1)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
In some cases, being able to disable background sending globally is crucial for both users and the SDK itself.

For example, Rails supports having different modes for running the application (server, console, runner, task...etc). In the runner or task mode, the process is killed right after script is returned, usually before the background worker have the chance to send the events. Here's an example issue: https://github.com/getsentry/sentry-ruby/issues/1324

Although Rails provides callbacks for different modes, they're ran after the SDK initialization. And under the current setup, it's not possible to temporarily bypass background sending globally past the SDK initialization stage. So we can't disable the background workers in those callbacks.

To solve the problem, this commit makes it possible to bypass background worker even after it's been initialized.

