### PR TITLE
Build gem source in batch prepare workflow

### DIFF
--- a/.github/workflows/prepare_batch_release.yml
+++ b/.github/workflows/prepare_batch_release.yml
@@ -24,3 +24,8 @@ jobs:
         with:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
+      - name: Archive Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.sha }}
+          path: sentry*/*.gem

--- a/.scripts/batch_release.rb
+++ b/.scripts/batch_release.rb
@@ -37,8 +37,12 @@ GEMS.each do |gem_name|
   update_version_file(gem_name, version)
 end
 
-return if is_patch_version_bump
+unless is_patch_version_bump
+  INTEGRATIONS.each do |gem_name|
+    update_gemspec_dependency(gem_name, version)
+  end
+end
 
-INTEGRATIONS.each do |gem_name|
-  update_gemspec_dependency(gem_name, version)
+GEMS.each do |gem_name|
+  puts(`cd #{gem_name}; make build`)
 end


### PR DESCRIPTION
Instead of writing another "batch build" workflow, I find it easier to just prepare + build all gems in the same workflow and then upload the artifacts right away.