### PR TITLE
Add configuration option skip_rake_integration

### DIFF
--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -130,6 +130,9 @@ module Sentry
     # will not be sent to Sentry.
     attr_accessor :send_default_pii
 
+    # Allow to skip Sentry emails within rake tasks 
+    attr_accessor :skip_rake_integration
+
     # IP ranges for trusted proxies that will be skipped when calculating IP address.
     attr_accessor :trusted_proxies
 

--- a/sentry-ruby/lib/sentry/rake.rb
+++ b/sentry-ruby/lib/sentry/rake.rb
@@ -9,7 +9,7 @@ module Rake
         task_name = top_level_tasks.join(' ')
         scope.set_transaction_name(task_name)
         scope.set_tag("rake_task", task_name)
-      end if Sentry.initialized?
+      end if Sentry.initialized? && !Sentry.configuration.skip_rake_integration
 
       orig_display_error_messsage(ex)
     end

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -429,4 +429,12 @@ RSpec.describe Sentry::Configuration do
       expect(instance.var2). to eq 2
     end
   end
+
+  describe "#skip_rake_integration" do
+    it "returns true" do
+      subject.skip_rake_integration = true
+      expect(subject.skip_rake_integration).to eq(true)
+    end
+  end
+
 end

--- a/sentry-ruby/spec/sentry/rake_spec.rb
+++ b/sentry-ruby/spec/sentry/rake_spec.rb
@@ -12,4 +12,16 @@ RSpec.describe "rake auto-reporting" do
 
     expect(message).to match(/Sending envelope \[event\] [abcdef0-9]+ to Sentry/)
   end
+
+  it "skip sending report to Sentry when skip_rake_integration = true" do
+    message = ""
+
+    # if we change the directory in the current process, it'll affect other tests that relies on system call too
+    # e.g. release detection tests
+    Thread.new do
+      message = `cd spec/support && bundle exec rake raise_exception_without_rake_integration 2>&1`
+    end.join
+
+    expect(message).not_to match(/Sentry/)
+  end
 end

--- a/sentry-ruby/spec/support/Rakefile.rb
+++ b/sentry-ruby/spec/support/Rakefile.rb
@@ -9,3 +9,10 @@ end
 task :raise_exception do
   1/0
 end
+
+task :raise_exception_without_rake_integration do
+  Sentry.init do |config|
+    config.skip_rake_integration = true
+  end
+  1/0
+end


### PR DESCRIPTION
Add configuration option `skip_rake_integration`. As mentioned in https://github.com/getsentry/sentry-ruby/issues/1378#issuecomment-815415357