### PR TITLE
Correct the timing of loading ActiveJobExtensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Remove response from breadcrumb and span [#1463](https://github.com/getsentry/sentry-ruby/pull/1463)
   - Fixes the issue mentioned in this [comment](https://github.com/getsentry/sentry-ruby/pull/1199#issuecomment-773069840)
+- Correct the timing of loading ActiveJobExtensions [#1464](https://github.com/getsentry/sentry-ruby/pull/1464)
+  - Fixes [#1249](https://github.com/getsentry/sentry-ruby/issues/1249)
 
 ## 4.5.0
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-ruby/issues/1249