### PR TITLE
Limit breadcrumb's message length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Fixes the issue mentioned in this [comment](https://github.com/getsentry/sentry-ruby/pull/1199#issuecomment-773069840)
 - Correct the timing of loading ActiveJobExtensions [#1464](https://github.com/getsentry/sentry-ruby/pull/1464)
   - Fixes [#1249](https://github.com/getsentry/sentry-ruby/issues/1249)
+- Limit breadcrumb's message length [#1465](https://github.com/getsentry/sentry-ruby/pull/1465)
 
 ## 4.5.0
 

--- a/sentry-ruby/lib/sentry/breadcrumb.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb.rb
@@ -2,15 +2,16 @@ module Sentry
   class Breadcrumb
     DATA_SERIALIZATION_ERROR_MESSAGE = "[data were removed due to serialization issues]"
 
-    attr_accessor :category, :data, :message, :level, :timestamp, :type
+    attr_accessor :category, :data, :level, :timestamp, :type
+    attr_reader :message
 
     def initialize(category: nil, data: nil, message: nil, timestamp: nil, level: nil, type: nil)
       @category = category
       @data = data || {}
       @level = level
-      @message = message
       @timestamp = timestamp || Sentry.utc_now.to_i
       @type = type
+      self.message = message
     end
 
     def to_hash
@@ -22,6 +23,10 @@ module Sentry
         timestamp: @timestamp,
         type: @type
       }
+    end
+
+    def message=(msg)
+      @message = (msg || "").byteslice(0..Event::MAX_MESSAGE_SIZE_IN_BYTES)
     end
 
     private

--- a/sentry-ruby/spec/sentry/breadcrumb_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb_spec.rb
@@ -30,6 +30,25 @@ RSpec.describe Sentry::Breadcrumb do
     )
   end
 
+  describe "#initialize" do
+    it "limits the maximum size of message" do
+      long_message = "a" * Sentry::Event::MAX_MESSAGE_SIZE_IN_BYTES * 2
+
+      crumb = described_class.new(message: long_message)
+      expect(crumb.message.length).to eq(Sentry::Event::MAX_MESSAGE_SIZE_IN_BYTES + 1)
+    end
+  end
+
+  describe "#message=" do
+    it "limits the maximum size of message" do
+      long_message = "a" * Sentry::Event::MAX_MESSAGE_SIZE_IN_BYTES * 2
+
+      crumb = described_class.new
+      crumb.message = long_message
+      expect(crumb.message.length).to eq(Sentry::Event::MAX_MESSAGE_SIZE_IN_BYTES + 1)
+    end
+  end
+
   describe "#to_hash" do
     it "serializes data correctly" do
       result = crumb.to_hash


### PR DESCRIPTION
`Sentry::Event`'s message has a `8096` size limit, which should also be applied to breadcrumb's message to prevent useless and even harmful data.

This should partially fix #1422 