### PR TITLE
Don't force ActiveJob to load during initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Correct the timing of loading ActiveJobExtensions, take 2 [#1494](https://github.com/getsentry/sentry-ruby/pull/1494)
+
 ## 4.6.0
 
 ### Features


### PR DESCRIPTION
Since the 4.5.1 release, setting `Rails.application.config.active_job.foo = bar` in an initializers file (eg config/initializers/foo.rb) would be ignored.

As soon as ActiveJob::Base is referenced, it applies Rails.application.config.active_job, and any further changes to that config are ignored. By loading ActiveJob::Base before eager_load, it prevents ActiveJob being configured in, eg, config/initializers/new_framework_defaults.rb

How about using `ActiveSupport.on_load(:active_job)` instead?

This tweaks the behaviour in https://github.com/getsentry/sentry-ruby/pull/1464 which was introduced to fix https://github.com/getsentry/sentry-ruby/issues/1249, would be good to confirm that the original issue poster isn't affected by this new fix.

I tried to add a test but found it kind of tricky. ActiveJob::Base is already loaded by the time we call `make_basic_app` in specs, so it seems impossible to hook in early enough to test the failure case.

cc @CroneKorkN, @st0012 