### PR TITLE
Add isolated tests to sentry-rails

### DIFF
--- a/sentry-rails/Rakefile
+++ b/sentry-rails/Rakefile
@@ -5,4 +5,10 @@ RSpec::Core::RakeTask.new(:spec).tap do |task|
   task.rspec_opts = "--order rand"
 end
 
-task :default => :spec
+task :isolated_specs do
+  Dir["spec/isolated/*"].each do |file|
+    sh "bundle exec ruby #{file}"
+  end
+end
+
+task :default => [:spec, :isolated_specs]

--- a/sentry-rails/spec/isolated/active_job_activation.rb
+++ b/sentry-rails/spec/isolated/active_job_activation.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+# for https://github.com/getsentry/sentry-ruby/issues/1249
+require "active_job"
+require "sentry/rails"
+require "minitest/autorun"
+
+class TestApp < Rails::Application
+end
+
+IO_STUB = StringIO.new
+
+app = TestApp
+
+# to simulate jobs being load during the eager_load initializer
+app.initializer :eager_load! do
+  Object.class_eval <<~CODE
+    class ApplicationJob < ActiveJob::Base
+      self.logger = Logger.new(IO_STUB)
+      self.queue_adapter = :inline
+
+      rescue_from Exception do |exception|
+        logger.info(">>> RESCUED")
+      end
+    end
+
+    class ErrorJob < ApplicationJob
+      around_perform do |job, block|
+        result = block.call
+        logger.info(">>> I SHOULD NEVER BE EXECUTED!")
+      end
+
+      def perform
+        1/0
+      end
+    end
+  CODE
+end
+
+app.config.eager_load = true
+app.initializer :sentry do
+  Sentry.init do |config|
+    config.logger = Logger.new(nil)
+    config.dsn = 'https://2fb45f003d054a7ea47feb45898f7649@o447951.ingest.sentry.io/5434472'
+    config.background_worker_threads = 0
+  end
+end
+
+app.initialize!
+
+class ActiveJobExtensionsTest < ActiveSupport::TestCase
+  def test_the_extension_is_loaded_before_eager_load_is_called
+    ErrorJob.perform_later
+
+    log_result = IO_STUB.string
+    assert_match(/RESCUED/, log_result, "ApplicationJob's rescue_from should be called")
+    refute_match(/I SHOULD NEVER BE EXECUTED/, log_result, "ErrorJob's around_perform should not be triggered")
+  end
+end

--- a/sentry-rails/spec/isolated/active_job_activation.rb
+++ b/sentry-rails/spec/isolated/active_job_activation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # for https://github.com/getsentry/sentry-ruby/issues/1249
 require "active_job"
+require "active_support/all"
 require "sentry/rails"
 require "minitest/autorun"
 


### PR DESCRIPTION
Some initialization logics are hard to test with the normal RSpec setup. Isolate each cases into their own files will make it easier (but also slower).