### PR TITLE
Fix `Sentry::Utils::RealIP` not filtering trusted proxies when part of IP subnet passed as `IPAddr` to `trusted_proxies`.

### DIFF
--- a/sentry-ruby/lib/sentry/utils/real_ip.rb
+++ b/sentry-ruby/lib/sentry/utils/real_ip.rb
@@ -29,7 +29,13 @@ module Sentry
         @client_ip = client_ip
         @real_ip = real_ip
         @forwarded_for = forwarded_for
-        @trusted_proxies = (LOCAL_ADDRESSES + Array(trusted_proxies)).map { |proxy| IPAddr.new(proxy.to_s) }.uniq
+        @trusted_proxies = (LOCAL_ADDRESSES + Array(trusted_proxies)).map do |proxy|
+          if proxy.is_a?(IPAddr)
+            proxy
+          else
+            IPAddr.new(proxy.to_s)
+          end
+        end.uniq
       end
 
       def calculate_ip

--- a/sentry-ruby/spec/sentry/utils/real_ip_spec.rb
+++ b/sentry-ruby/spec/sentry/utils/real_ip_spec.rb
@@ -101,4 +101,17 @@ RSpec.describe Sentry::Utils::RealIp do
       expect(subject.calculate_ip).to eq("2001:db8:a0b:12f0::1")
     end
   end
+  
+  context "when custom proxies are provided as IPAddr as IP subnet" do
+    subject do
+      Sentry::Utils::RealIp.new(
+        :forwarded_for => "2.2.2.2, 3.3.3.3, 4.4.4.4",
+        :trusted_proxies => [IPAddr.new("4.4.4.0/24")]
+      )
+    end
+
+    it "should return the first IP not in the trusted proxy list" do
+      expect(subject.calculate_ip).to eq("3.3.3.3")
+    end
+  end
 end


### PR DESCRIPTION
Filtering trusted proxies based on list of IP subnets passed as instances of `IPAddr` got broken in #1288.

When calling `IPAddr#to_s` resulting string doesn't contain the IP mask. Therefore when creating `IPAddr` again from this string IP mask is lost and filtering trusted proxies is broken.

I changed `Sentry::Utils::RealIP` to only call `.to_s` when trusted proxy entry is not an instance of `IPAddr`. This keeps complete information about defined IP subnet as trusted proxy and makes filtering work as expected.

I've also added a test for this case.

This PR also fixes `Sentry::Utils::RealIP` with proxies loaded from Rails' `config.action_dispatch.trusted_proxies` because they are stored as instances of `IPAddr`.