### PR TITLE
Silence some ruby warnings

### DIFF
--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -405,7 +405,7 @@ module Sentry
     def sample_allowed?
       return true if sample_rate == 1.0
 
-      if Random::DEFAULT.rand >= sample_rate
+      if Random.rand >= sample_rate
         @errors << "Excluded by random sample"
         false
       else

--- a/sentry-ruby/lib/sentry/core_ext/object/deep_dup.rb
+++ b/sentry-ruby/lib/sentry/core_ext/object/deep_dup.rb
@@ -20,6 +20,7 @@ class Object
 end
 
 class Array
+  undef_method :deep_dup if method_defined?(:deep_dup)
   # Returns a deep copy of array.
   #
   #   array = [1, [2, 3]]

--- a/sentry-ruby/lib/sentry/core_ext/object/duplicable.rb
+++ b/sentry-ruby/lib/sentry/core_ext/object/duplicable.rb
@@ -115,6 +115,7 @@ class BigDecimal
 end
 
 class Method
+  undef_method :duplicable? if method_defined?(:duplicable?)
   # Methods are not duplicable:
   #
   #  method(:puts).duplicable? # => false

--- a/sentry-ruby/lib/sentry/transport/configuration.rb
+++ b/sentry-ruby/lib/sentry/transport/configuration.rb
@@ -2,7 +2,8 @@ module Sentry
   class Transport
     class Configuration
       attr_accessor :timeout, :open_timeout, :proxy, :ssl, :ssl_ca_file, :ssl_verification, :http_adapter, :faraday_builder,
-        :transport_class, :encoding
+        :encoding
+      attr_reader :transport_class
 
       def initialize
         @ssl_verification = true

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -195,13 +195,13 @@ RSpec.describe Sentry::Configuration do
     end
 
     it 'captured_allowed false when sampled' do
-      allow(Random::DEFAULT).to receive(:rand).and_return(0.76)
+      allow(Random).to receive(:rand).and_return(0.76)
       expect(subject.sending_allowed?).to eq(false)
       expect(subject.errors).to eq(["Excluded by random sample"])
     end
 
     it 'captured_allowed true when not sampled' do
-      allow(Random::DEFAULT).to receive(:rand).and_return(0.74)
+      allow(Random).to receive(:rand).and_return(0.74)
       expect(subject.sending_allowed?).to eq(true)
     end
   end

--- a/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Sentry::RequestInterface do
       it 'does not call #to_s for unnecessary env variables' do
         expect(mock).not_to receive(:to_s)
 
-        interface = described_class.build(env: env)
+        described_class.build(env: env)
       end
     end
   end
@@ -133,7 +133,7 @@ RSpec.describe Sentry::RequestInterface do
 
       new_env = env.merge("HTTP_FOO" => "BAR", "rails_object" => obj)
 
-      expect { interface = described_class.build(env: new_env) }.to_not raise_error
+      expect { described_class.build(env: new_env) }.to_not raise_error
     end
   end
 

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -10,15 +10,7 @@ RSpec.describe Sentry::Net::HTTP do
     ::Logger.new(string_io)
   end
 
-  original_buffered_io = Net::BufferedIO
-
-  before(:all) do
-    Net.send(:const_set, :BufferedIO, Net::WebMockNetBufferedIO)
-  end
-
-  after(:all) do
-    Net.send(:const_set, :BufferedIO, original_buffered_io)
-  end
+  before { stub_const('Net::BufferedIO', Net::WebMockNetBufferedIO) }
 
   class FakeSocket < StringIO
     def setsockopt(*args); end

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Sentry::Transport do
       before do
         configuration.logger = Logger.new(string_io)
         configuration.sample_rate = 0.5
-        allow(Random::DEFAULT).to receive(:rand).and_return(0.6)
+        allow(Random).to receive(:rand).and_return(0.6)
       end
 
       it "logs correct message" do


### PR DESCRIPTION
## Description
Describe your changes:
```
…/sentry-ruby-core-4.6.1/lib/sentry/core_ext/object/duplicable.rb:122: warning: method redefined; discarding old duplicable?
…/activesupport-6.1.4/lib/active_support/core_ext/object/duplicable.rb:36: warning: previous definition of duplicable? was here
…/sentry-ruby-core-4.6.1/lib/sentry/core_ext/object/deep_dup.rb:31: warning: method redefined; discarding old deep_dup
…/activesupport-6.1.4/lib/active_support/core_ext/object/deep_dup.rb:29: warning: previous definition of deep_dup was here
…/sentry-ruby-core-4.6.1/lib/sentry/transport/configuration.rb:14: warning: method redefined; discarding old transport_class=
…/sentry-ruby-core-4.6.1/lib/sentry/event.rb:78: warning: method redefined; discarding old timestamp=
…/sentry-ruby-core-4.6.1/lib/sentry/event.rb:82: warning: method redefined; discarding old level=
…/sentry-ruby-core-4.6.1/lib/sentry/event.rb:102: warning: method redefined; discarding old type
…/sentry-ruby-core-4.6.1/lib/sentry/transaction_event.rb:17: warning: method redefined; discarding old start_timestamp=
…/sentry-ruby-core-4.6.1/lib/sentry/transaction_event.rb:21: warning: method redefined; discarding old type
```
Not sure if we should `undef_method` or just not define our variants. As a corporation you probably want `undef_method` for extra-defined behavior.
Also could add [warning](https://github.com/jeremyevans/ruby-warning) gem to devdeps and enforce no-warnings via CI if desired.
