### PR TITLE
DSN#server shouldn't include path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 - Declare `resque` as `sentry-resque`'s dependency [#1503](https://github.com/getsentry/sentry-ruby/pull/1503)
   - Fixes [#1502](https://github.com/getsentry/sentry-ruby/issues/1502)
+- `DSN#server` shouldn't include path [#1505](https://github.com/getsentry/sentry-ruby/pull/1505)
 
 ## 4.6.1
 

--- a/sentry-ruby/lib/sentry/dsn.rb
+++ b/sentry-ruby/lib/sentry/dsn.rb
@@ -37,7 +37,6 @@ module Sentry
     def server
       server = "#{scheme}://#{host}"
       server += ":#{port}" unless port == PORT_MAP[scheme]
-      server += path
       server
     end
 

--- a/sentry-ruby/spec/sentry/dsn_spec.rb
+++ b/sentry-ruby/spec/sentry/dsn_spec.rb
@@ -25,4 +25,10 @@ RSpec.describe Sentry::DSN do
       expect(subject.envelope_endpoint).to eq("/sentry/api/42/envelope/")
     end
   end
+
+  describe "#server" do
+    it "returns scheme + host" do
+      expect(subject.server).to eq("http://sentry.localdomain:3000")
+    end
+  end
 end

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Sentry::HTTPTransport do
 
     subject
 
-    expect(string_io.string).to include("sentry: Sentry HTTP Transport connecting to http://sentry.localdomain/sentry")
+    expect(string_io.string).to include("sentry: Sentry HTTP Transport connecting to http://sentry.localdomain")
   end
 
   describe "customizations" do


### PR DESCRIPTION
The path will be applied to `DSN#envelope_endpoint` anyway, so if `#server` also contains the path it'll be repeated.