### PR TITLE
Generate Security Header Endpoint with Sentry.csp_report_uri from DSN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
+### Features
+
 - Support after-retry reporting to `sentry-sidekiq` [#1532](https://github.com/getsentry/sentry-ruby/pull/1532)
+- Generate Security Header Endpoint with `Sentry.csp_report_uri` from dsn [#1507](https://github.com/getsentry/sentry-ruby/pull/1507)
 
 ## 4.6.5
 

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -90,6 +90,18 @@ module Sentry
       @background_worker = Sentry::BackgroundWorker.new(config)
     end
 
+    # Returns an uri for security policy reporting that's generated from the given DSN
+    # (To learn more about security policy reporting: https://docs.sentry.io/product/security-policy-reporting/)
+    #
+    # It returns nil if
+    #
+    # 1. The SDK is not initialized yet.
+    # 2. The DSN is not provided or is invalid.
+    def csp_report_uri
+      return unless initialized?
+      configuration.csp_report_uri
+    end
+
     # Returns the main thread's active hub.
     def get_main_hub
       @main_hub

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -324,6 +324,15 @@ module Sentry
       log_error("Error detecting release", e, debug: debug)
     end
 
+    def csp_report_uri
+      if dsn && dsn.valid?
+        uri = dsn.csp_report_uri
+        uri += "&sentry_release=#{CGI.escape(release)}" if release && !release.empty?
+        uri += "&sentry_environment=#{CGI.escape(environment)}" if environment && !environment.empty?
+        uri
+      end
+    end
+
     private
 
     def excluded_exception?(incoming_exception)

--- a/sentry-ruby/lib/sentry/dsn.rb
+++ b/sentry-ruby/lib/sentry/dsn.rb
@@ -40,6 +40,10 @@ module Sentry
       server
     end
 
+    def csp_report_uri
+      "#{server}/api/#{project_id}/security/?sentry_key=#{public_key}"
+    end
+
     def envelope_endpoint
       "#{path}/api/#{project_id}/envelope/"
     end

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -1,6 +1,39 @@
 require 'spec_helper'
 
 RSpec.describe Sentry::Configuration do
+  describe "#csp_report_uri" do
+    it "returns nil if the dsn is not present" do
+      expect(subject.csp_report_uri).to eq(nil)
+    end
+
+    it "returns nil if the dsn is not valid" do
+      subject.dsn = "foo"
+      expect(subject.csp_report_uri).to eq(nil)
+    end
+
+    context "when the DSN is present" do
+      before do
+        subject.release = nil
+        subject.environment = nil
+        subject.dsn = DUMMY_DSN
+      end
+
+      it "returns the uri" do
+        expect(subject.csp_report_uri).to eq("http://sentry.localdomain/api/42/security/?sentry_key=12345")
+      end
+
+      it "adds sentry_release param when there's release information" do
+        subject.release = "test-release"
+        expect(subject.csp_report_uri).to eq("http://sentry.localdomain/api/42/security/?sentry_key=12345&sentry_release=test-release")
+      end
+
+      it "adds sentry_environment param when there's environment information" do
+        subject.environment = "test-environment"
+        expect(subject.csp_report_uri).to eq("http://sentry.localdomain/api/42/security/?sentry_key=12345&sentry_environment=test-environment")
+      end
+    end
+  end
+
   describe "#tracing_enabled?" do
     context "when sending not allowed" do
       before do

--- a/sentry-ruby/spec/sentry/dsn_spec.rb
+++ b/sentry-ruby/spec/sentry/dsn_spec.rb
@@ -31,4 +31,10 @@ RSpec.describe Sentry::DSN do
       expect(subject.server).to eq("http://sentry.localdomain:3000")
     end
   end
+
+  describe "#csp_report_uri" do
+    it "returns the correct uri" do
+      expect(subject.csp_report_uri).to eq("http://sentry.localdomain:3000/api/42/security/?sentry_key=12345")
+    end
+  end
 end

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -465,6 +465,19 @@ RSpec.describe Sentry do
     end
   end
 
+  describe ".csp_report_uri" do
+    it "returns nil if the SDK is not initialized" do
+      described_class.instance_variable_set(:@main_hub, nil)
+      expect(described_class.csp_report_uri).to eq(nil)
+    end
+
+    it "returns the csp_report_uri generated from the main Configuration" do
+      expect(Sentry.configuration).to receive(:csp_report_uri).and_call_original
+
+      expect(described_class.csp_report_uri).to eq("http://sentry.localdomain/api/42/security/?sentry_key=12345&sentry_environment=default")
+    end
+  end
+
   describe 'release detection' do
     let(:fake_root) { "/tmp/sentry/" }
 


### PR DESCRIPTION
Sentry requires a separated `Security Header Endpoint` for [Security Policy Reporting](https://docs.sentry.io/product/security-policy-reporting/). But the endpoint's major components like project id, public key or host are all identical with the SDK's DSN. Also, the additional environment or release information are also obtained by the SDK.

So this PR adds a helper `Sentry.csp_report_uri` to generate the `Security Header Endpoint` for users who report CSP events to the same project as DSN's (as suggested in #1499). It'll reduce the number of values they need to manage.

Take Rails' csp configuration for example:

**Without helper**

```ruby
Rails.application.config.content_security_policy do |policy|
  policy.report_uri ENV["SENTRY_CSP_URI"]
end
```

**With the helper**

```ruby
Rails.application.config.content_security_policy do |policy|
  policy.report_uri Sentry.csp_report_uri
end
```