### PR TITLE
Disable background worker when executing rake tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Declare `delayed_job` and `sidekiq` as integration gem's dependency [#1506](https://github.com/getsentry/sentry-ruby/pull/1506)
 - `DSN#server` shouldn't include path [#1505](https://github.com/getsentry/sentry-ruby/pull/1505)
 - Fix `sentry-rails`' `backtrace_cleanup_callback` injection [#1510](https://github.com/getsentry/sentry-ruby/pull/1510)
+- Disable background worker when executing rake tasks [#1509](https://github.com/getsentry/sentry-ruby/pull/1509)
+  - Fixes [#1508](https://github.com/getsentry/sentry-ruby/issues/1508)
 
 ## 4.6.1
 

--- a/sentry-ruby/examples/rake/Rakefile.rb
+++ b/sentry-ruby/examples/rake/Rakefile.rb
@@ -7,3 +7,7 @@ end
 task :raise_exception do
   1/0
 end
+
+task :send_message do
+  Sentry.capture_message("message from rake")
+end

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -144,6 +144,17 @@ module Sentry
       current_scope.add_breadcrumb(breadcrumb)
     end
 
+    # this doesn't do anything to the already initialized background worker
+    # but it temporarily disables dispatching events to it
+    def with_background_worker_disabled(&block)
+      original_background_worker_threads = configuration.background_worker_threads
+      configuration.background_worker_threads = 0
+
+      block.call
+    ensure
+      configuration.background_worker_threads = original_background_worker_threads
+    end
+
     private
 
     def current_layer


### PR DESCRIPTION
This fixes #1508 

(I know disabling background worker by setting `background_worker_threads = 0` looks hacky, but I don't want to introduce another config option for background toggling atm.)