### PR TITLE
Fix sentry-rails' backtrace_cleanup_callback injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - Fixes [#1502](https://github.com/getsentry/sentry-ruby/issues/1502)
 - Declare `delayed_job` and `sidekiq` as integration gem's dependency [#1506](https://github.com/getsentry/sentry-ruby/pull/1506)
 - `DSN#server` shouldn't include path [#1505](https://github.com/getsentry/sentry-ruby/pull/1505)
+- Fix `sentry-rails`' `backtrace_cleanup_callback` injection [#1510](https://github.com/getsentry/sentry-ruby/pull/1510)
 
 ## 4.6.1
 

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -74,7 +74,7 @@ module Sentry
     def setup_backtrace_cleanup_callback
       backtrace_cleaner = Sentry::Rails::BacktraceCleaner.new
 
-      Sentry.configuration.backtrace_cleanup_callback = lambda do |backtrace|
+      Sentry.configuration.backtrace_cleanup_callback ||= lambda do |backtrace|
         backtrace_cleaner.clean(backtrace)
       end
     end

--- a/sentry-rails/spec/sentry/rails/controller_methods_spec.rb
+++ b/sentry-rails/spec/sentry/rails/controller_methods_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Sentry::Rails::ControllerMethods do
   end
 
   before do
-    perform_basic_setup
+    make_basic_app
   end
 
   let(:options) do

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -160,19 +160,15 @@ RSpec.describe Sentry::Rails, type: :request do
     end
 
     it "doesn't filters exception backtrace if backtrace_cleanup_callback is overridden" do
-      original_cleanup_callback = Sentry.configuration.backtrace_cleanup_callback
-
-      begin
-        Sentry.configuration.backtrace_cleanup_callback = nil
-
-        get "/view_exception"
-
-        traces = event.dig("exception", "values", 0, "stacktrace", "frames")
-        expect(traces.dig(-1, "filename")).to eq("inline template")
-        expect(traces.dig(-1, "function")).not_to be_nil
-      ensure
-        Sentry.configuration.backtrace_cleanup_callback = original_cleanup_callback
+      make_basic_app do |config|
+        config.backtrace_cleanup_callback = lambda { |backtrace| backtrace }
       end
+
+      get "/view_exception"
+
+      traces = event.dig("exception", "values", 0, "stacktrace", "frames")
+      expect(traces.dig(-1, "filename")).to eq("inline template")
+      expect(traces.dig(-1, "function")).not_to be_nil
     end
 
     context "with config.exceptions_app = self.routes" do

--- a/sentry-rails/spec/spec_helper.rb
+++ b/sentry-rails/spec/spec_helper.rb
@@ -94,13 +94,3 @@ def reload_send_event_job
   expect(defined?(Sentry::SendEventJob)).to eq(nil)
   load File.join(Dir.pwd, "app", "jobs", "sentry", "send_event_job.rb")
 end
-
-def perform_basic_setup
-  Sentry.init do |config|
-    config.dsn = DUMMY_DSN
-    config.logger = ::Logger.new(nil)
-    config.transport.transport_class = Sentry::DummyTransport
-    # for sending events synchronously
-    config.background_worker_threads = 0
-  end
-end


### PR DESCRIPTION
As spotted in https://github.com/getsentry/sentry-ruby/issues/1076#issuecomment-884754612, `sentry-rails` always overrides the `backtrace_cleanup_callback` provided by the user. It should respect the existing value instead.