### PR TITLE
Correctly pass arguments to a rake task

### DIFF
--- a/sentry-ruby/lib/sentry/rake.rb
+++ b/sentry-ruby/lib/sentry/rake.rb
@@ -20,10 +20,10 @@ module Rake
     alias orig_execute execute
 
     def execute(args=nil)
-      return orig_execute unless Sentry.initialized? && Sentry.get_current_hub
+      return orig_execute(args) unless Sentry.initialized? && Sentry.get_current_hub
 
       Sentry.get_current_hub.with_background_worker_disabled do
-        orig_execute
+        orig_execute(args)
       end
     end
   end

--- a/sentry-ruby/spec/sentry/rake_spec.rb
+++ b/sentry-ruby/spec/sentry/rake_spec.rb
@@ -24,4 +24,16 @@ RSpec.describe "rake auto-reporting" do
 
     expect(message).not_to match(/Sentry/)
   end
+
+  it "run rake task with original arguments" do
+    message = ""
+
+    # if we change the directory in the current process, it'll affect other tests that relies on system call too
+    # e.g. release detection tests
+    Thread.new do
+      message = `cd spec/support && bundle exec rake pass_arguments[arguments]`
+    end.join
+
+    expect(message).to match("arguments")
+  end
 end

--- a/sentry-ruby/spec/support/Rakefile.rb
+++ b/sentry-ruby/spec/support/Rakefile.rb
@@ -14,3 +14,7 @@ task :raise_exception_without_rake_integration do
   Sentry.configuration.skip_rake_integration = true
   1/0
 end
+
+task :pass_arguments, ['name']  do |_task, args|
+  puts args[:name]
+end


### PR DESCRIPTION
## Description

Due to effect of #1509, arguments of Rake task are lost now. This patch pass arguments to Rake as before.

I'm sorry to miss this!