### PR TITLE
Extend Rake with a more elegant and reliable way

### DIFF
--- a/sentry-ruby/lib/sentry/rake.rb
+++ b/sentry-ruby/lib/sentry/rake.rb
@@ -4,7 +4,7 @@ require "rake/task"
 module Sentry
   module Rake
     module Application
-      def display_error_message(*)
+      def display_error_message(ex)
         Sentry.capture_exception(ex, hint: { background: false }) do |scope|
           task_name = top_level_tasks.join(' ')
           scope.set_transaction_name(task_name)
@@ -16,7 +16,7 @@ module Sentry
     end
 
     module Task
-      def execute(*)
+      def execute(args=nil)
         return super unless Sentry.initialized? && Sentry.get_current_hub
 
         Sentry.get_current_hub.with_background_worker_disabled do

--- a/sentry-ruby/lib/sentry/rake.rb
+++ b/sentry-ruby/lib/sentry/rake.rb
@@ -1,30 +1,31 @@
 require "rake"
 require "rake/task"
 
-module Rake
-  class Application
+module Sentry
+  module Rake
+    module Application
+      def display_error_message(*)
+        Sentry.capture_exception(ex, hint: { background: false }) do |scope|
+          task_name = top_level_tasks.join(' ')
+          scope.set_transaction_name(task_name)
+          scope.set_tag("rake_task", task_name)
+        end if Sentry.initialized? && !Sentry.configuration.skip_rake_integration
 
-    alias orig_display_error_messsage display_error_message
-    def display_error_message(ex)
-      Sentry.capture_exception(ex, hint: { background: false }) do |scope|
-        task_name = top_level_tasks.join(' ')
-        scope.set_transaction_name(task_name)
-        scope.set_tag("rake_task", task_name)
-      end if Sentry.initialized? && !Sentry.configuration.skip_rake_integration
-
-      orig_display_error_messsage(ex)
+        super
+      end
     end
-  end
 
-  class Task
-    alias orig_execute execute
+    module Task
+      def execute(*)
+        return super unless Sentry.initialized? && Sentry.get_current_hub
 
-    def execute(args=nil)
-      return orig_execute(args) unless Sentry.initialized? && Sentry.get_current_hub
-
-      Sentry.get_current_hub.with_background_worker_disabled do
-        orig_execute(args)
+        Sentry.get_current_hub.with_background_worker_disabled do
+          super
+        end
       end
     end
   end
 end
+
+Rake::Application.prepend(Sentry::Rake::Application)
+Rake::Task.prepend(Sentry::Rake::Task)


### PR DESCRIPTION
Extend Rake with a more elegant and reliable way

Closes https://github.com/getsentry/sentry-ruby/issues/1520

## Description

Per https://github.com/getsentry/sentry-ruby/commit/4dc603b4f45eb2f34ed2b283fa3084360b067f32#r54079829

Overwriting methods with aliasing is is rather a bad practice and, since it may cause conflicts, circular dependencies and infinite loops. `Module#prepend` is more elegant and reliable.



