### PR TITLE
SDK should drop the event when any event processor returns nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- SDK should drop the event when any event processor returns nil [#1523](https://github.com/getsentry/sentry-ruby/pull/1523)
+
 ## 4.6.4
 
 - Extend Rake with a more elegant and reliable way [#1517](https://github.com/getsentry/sentry-ruby/pull/1517)

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -26,7 +26,12 @@ module Sentry
     def capture_event(event, scope, hint = {})
       return unless configuration.sending_allowed?
 
-      scope.apply_to_event(event, hint)
+      event = scope.apply_to_event(event, hint)
+
+      if event.nil?
+        log_info("Discarded event because one of the event processors returned nil")
+        return
+      end
 
       if async_block = configuration.async
         dispatch_async_event(async_block, event, hint)

--- a/sentry-ruby/spec/sentry/client/event_sending_spec.rb
+++ b/sentry-ruby/spec/sentry/client/event_sending_spec.rb
@@ -225,6 +225,20 @@ RSpec.describe Sentry::Client do
         configuration.async = prior_async
       end
 
+      context "when scope.apply_to_event returns nil" do
+        before do
+          scope.add_event_processor do |event, hint|
+            nil
+          end
+        end
+
+        it "discards the event and logs a info" do
+          expect(subject.capture_event(event, scope)).to be_nil
+
+          expect(string_io.string).to match(/Discarded event because one of the event processors returned nil/)
+        end
+      end
+
       context "when scope.apply_to_event fails" do
         before do
           scope.add_event_processor do


### PR DESCRIPTION
This is something we should've supported but was missed.