### PR TITLE
Add severity as sentry_logger's breadcrumb hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Add severity as `sentry_logger`'s breadcrumb hint [#1527](https://github.com/getsentry/sentry-ruby/pull/1527)
+
 ## 4.6.4
 
 - Extend Rake with a more elegant and reliable way [#1517](https://github.com/getsentry/sentry-ruby/pull/1517)

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -100,8 +100,8 @@ module Sentry
     end
 
     # Takes an instance of Sentry::Breadcrumb and stores it to the current active scope.
-    def add_breadcrumb(breadcrumb)
-      get_current_hub&.add_breadcrumb(breadcrumb)
+    def add_breadcrumb(breadcrumb, **options)
+      get_current_hub&.add_breadcrumb(breadcrumb, **options)
     end
 
     # Returns the current active hub.

--- a/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb
@@ -67,7 +67,7 @@ module Sentry
             type: severity >= 3 ? "error" : level
           )
 
-          Sentry.add_breadcrumb(crumb)
+          Sentry.add_breadcrumb(crumb, hint: { severity: severity })
         end
       end
 

--- a/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Sentry::Breadcrumbs::SentryLogger" do
     expect(breadcrumb.level).to eq("info")
     expect(breadcrumb.message).to eq("foo")
   end
-  
+
   it "records non-String message" do
     logger.info(200)
     expect(breadcrumbs.peek.message).to eq("200")
@@ -33,6 +33,19 @@ RSpec.describe "Sentry::Breadcrumbs::SentryLogger" do
     logger.info(Sentry::LOGGER_PROGNAME) { "foo" }
 
     expect(breadcrumbs.peek).to be_nil
+  end
+
+  it "passes severity as a hint" do
+    hint = nil
+    Sentry.configuration.before_breadcrumb = lambda do |breadcrumb, h|
+      hint = h
+      breadcrumb
+    end
+
+    logger.info("foo")
+
+    expect(breadcrumbs.peek.message).to eq("foo")
+    expect(hint[:severity]).to eq(1)
   end
 
   describe "category assignment" do


### PR DESCRIPTION
This will allow users to filter `sentry_logger`'s breadcrumbs with log level like:

```ruby
config.before_breadcrumb = lambda do |breadcrumb, hint|
  if severity = hint[:severity] && severity <= 1 # debug & info
    nil
  else
    breadcrumb
  end    
end
```