### PR TITLE
Support after-retry reporting to sentry-sidekiq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Support after-retry reporting to `sentry-sidekiq` [#1532](https://github.com/getsentry/sentry-ruby/pull/1532)
+
 ## 4.6.5
 
 - SDK should drop the event when any event processor returns nil [#1523](https://github.com/getsentry/sentry-ruby/pull/1523)

--- a/sentry-sidekiq/lib/sentry-sidekiq.rb
+++ b/sentry-sidekiq/lib/sentry-sidekiq.rb
@@ -2,6 +2,7 @@ require "sidekiq"
 require "sentry-ruby"
 require "sentry/integrable"
 require "sentry/sidekiq/version"
+require "sentry/sidekiq/configuration"
 require "sentry/sidekiq/error_handler"
 require "sentry/sidekiq/sentry_context_middleware"
 

--- a/sentry-sidekiq/lib/sentry/sidekiq/configuration.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/configuration.rb
@@ -1,0 +1,21 @@
+module Sentry
+  class Configuration
+    attr_reader :sidekiq
+
+    add_post_initialization_callback do
+      @sidekiq = Sentry::Sidekiq::Configuration.new
+    end
+  end
+
+  module Sidekiq
+    class Configuration
+      # Set this option to true if you want Sentry to only capture the last job
+      # retry if it fails.
+      attr_accessor :report_after_job_retries
+
+      def initialize
+        @report_after_job_retries = false
+      end
+    end
+  end
+end

--- a/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
@@ -11,6 +11,15 @@ module Sentry
         scope = Sentry.get_current_scope
         scope.set_transaction_name(context_filter.transaction_name) unless scope.transaction_name
 
+        retry_option = context.dig(:job, "retry")
+
+        if Sentry.configuration.sidekiq.report_after_job_retries && retry_option.is_a?(Integer)
+          retry_count = context.dig(:job, "retry_count")
+          if retry_count.nil? || retry_count < retry_option - 1
+            return
+          end
+        end
+
         Sentry::Sidekiq.capture_exception(
           ex,
           contexts: { sidekiq: context_filter.filtered },

--- a/sentry-sidekiq/spec/sentry/sidekiq/configuration_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/configuration_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe Sentry::Sidekiq::Configuration do
+  it "adds #delayed_job option to Sentry::Configuration" do
+    config = Sentry::Configuration.new
+
+    expect(config.sidekiq).to be_a(described_class)
+  end
+
+  describe "#report_after_job_retries" do
+    it "has correct default value" do
+      expect(subject.report_after_job_retries).to eq(false)
+    end
+  end
+end

--- a/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
     perform_basic_setup { |config| config.traces_sample_rate = 0 }
     Sentry.set_user(user)
 
-    process_job(processor, "SadWorker")
+    execute_worker(processor, SadWorker)
 
     expect(transport.events.count).to eq(1)
     event = transport.events.first
@@ -34,7 +34,7 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
     end
 
     it "sets user to the transaction" do
-      process_job(processor, "HappyWorker")
+      execute_worker(processor, HappyWorker)
 
       expect(transport.events.count).to eq(1)
       transaction = transport.events.first
@@ -43,7 +43,7 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
     end
 
     it "sets user to both the event and transaction" do
-      process_job(processor, "SadWorker")
+      execute_worker(processor, SadWorker)
 
       expect(transport.events.count).to eq(2)
       transaction = transport.events.first

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "pry"
+require "debug" if RUBY_VERSION.to_f >= 2.6
 
 # this enables sidekiq's server mode
 require "sidekiq/cli"
@@ -133,7 +134,7 @@ class ReportingWorker
 end
 
 def process_job(processor, klass)
-  msg = Sidekiq.dump_json(jid: "123123", class: klass)
+  msg = Sidekiq.dump_json(jid: "123123", class: klass, args: [])
   job = Sidekiq::BasicFetch::UnitOfWork.new('queue:default', msg)
   processor.instance_variable_set(:'@job', job)
 

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -133,6 +133,16 @@ class ReportingWorker
   end
 end
 
+class RetryWorker
+  include Sidekiq::Worker
+
+  sidekiq_options retry: 1
+
+  def perform
+    1/0
+  end
+end
+
 def execute_worker(processor, klass)
   klass_options = klass.sidekiq_options_hash || {}
   options = {}


### PR DESCRIPTION
This PR adds a new `config.sidekiq.report_after_job_retries` option (default: `false`).

When activated, `sentry-sidekiq` will wait for a job's retries to be exhausted before reporting the exception. Worker without the `retry` option will not be affected.

Closes #781