### PR TITLE
Make ignoring events test more reliable

### DIFF
--- a/sentry-rails/spec/sentry/rails/active_support_breadcrumbs_spec.rb
+++ b/sentry-rails/spec/sentry/rails/active_support_breadcrumbs_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe "Sentry::Breadcrumbs::ActiveSupportLogger", type: :request do
     Sentry.get_current_client.transport
   end
 
+  let(:breadcrumb_buffer) do
+    Sentry.get_current_scope.breadcrumbs
+  end
+
   let(:event) do
     transport.events.first.to_json_compatible
   end
@@ -86,6 +90,6 @@ RSpec.describe "Sentry::Breadcrumbs::ActiveSupportLogger", type: :request do
       ActiveSupport::Notifications.publish "foo", Object.new
     end.not_to raise_error
 
-    expect(transport.events).to be_empty
+    expect(breadcrumb_buffer.count).to be_zero
   end
 end


### PR DESCRIPTION
While testing this https://github.com/getsentry/sentry-ruby/pull/1531 I figured out that a test was not really reliable.

If you run:

```
    it "ignores events that doesn't have a started timestamp" do
      expect do
        ActiveSupport::Notifications.publish "foo", Time.now
      end.not_to raise_error

      expect(transport.events).to be_empty
    end
```

It will pass.
So I use `breadcrumb_buffer` to check if we record or not an event.

You can have additional information here https://github.com/getsentry/sentry-ruby/pull/1531#discussion_r688756659

Thanks.