### PR TITLE
Fix markdown typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- Add `monotonic_active_support_logger` [#1531][https://github.com/getsentry/sentry-ruby/pull/1531]
+- Add `monotonic_active_support_logger` [#1531](https://github.com/getsentry/sentry-ruby/pull/1531)
 - Support after-retry reporting to `sentry-sidekiq` [#1532](https://github.com/getsentry/sentry-ruby/pull/1532)
 - Generate Security Header Endpoint with `Sentry.csp_report_uri` from dsn [#1507](https://github.com/getsentry/sentry-ruby/pull/1507)
 


### PR DESCRIPTION
Hi,

I just saw that I added a markdown typo in changelog. 😞 https://github.com/getsentry/sentry-ruby/pull/1531/commits/12d7c71e88d96c83fecd81f7dec3711ed3ac4ac5

Sorry for the noise.