### PR TITLE
fix-chatty-sentry

### DIFF
--- a/sentry-ruby/lib/sentry/utils/logging_helper.rb
+++ b/sentry-ruby/lib/sentry/utils/logging_helper.rb
@@ -10,11 +10,11 @@ module Sentry
     end
 
     def log_info(message)
-      logger.info(LOGGER_PROGNAME) { message }
+      # logger.info(LOGGER_PROGNAME) { message }
     end
 
     def log_debug(message)
-      logger.debug(LOGGER_PROGNAME) { message }
+      # logger.debug(LOGGER_PROGNAME) { message }
     end
 
     def log_warn(message)

--- a/sentry-ruby/lib/sentry/utils/logging_helper.rb
+++ b/sentry-ruby/lib/sentry/utils/logging_helper.rb
@@ -10,10 +10,12 @@ module Sentry
     end
 
     def log_info(message)
+      # issue ENR-759
       # logger.info(LOGGER_PROGNAME) { message }
     end
 
     def log_debug(message)
+      # issue ENR-759
       # logger.debug(LOGGER_PROGNAME) { message }
     end
 


### PR DESCRIPTION
Sentry uses Rails logging levels, and it became too noisy: sentry generates 21 gb of logs daily. To stop it here, we can mute info and debug levels on sentry with this monkeypatch, or invest some time to separate rails logging level from sentry logging level with configuration (result will be the same)