### PR TITLE
Don't apply Scope's transaction name if it's empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Check sentry-rails before injecting ActiveJob skippable adapters [#1544](https://github.com/getsentry/sentry-ruby/pull/1544)
   - Fixes [#1541](https://github.com/getsentry/sentry-ruby/issues/1541)
+- Don't apply Scope's transaction name if it's empty [#1546](https://github.com/getsentry/sentry-ruby/pull/1546)
+  - Fixes [#1540](https://github.com/getsentry/sentry-ruby/issues/1540)
 
 ## 4.6.5
 

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -23,6 +23,7 @@ module Sentry
       event.user = user.merge(event.user)
       event.extra = extra.merge(event.extra)
       event.contexts = contexts.merge(event.contexts)
+      event.transaction = transaction_name if transaction_name
 
       if span
         event.contexts[:trace] = span.get_trace_context
@@ -30,7 +31,6 @@ module Sentry
 
       event.fingerprint = fingerprint
       event.level = level
-      event.transaction = transaction_names.last
       event.breadcrumbs = breadcrumbs
       event.rack_env = rack_env if rack_env
 

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -338,6 +338,15 @@ RSpec.describe Sentry::Transaction do
       expect(event[:spans]).to be_empty
     end
 
+    it "doesn't override the event's transaction attribute with the scope's" do
+      subject.finish
+
+      expect(events.count).to eq(1)
+      event = events.last.to_hash
+
+      expect(event[:transaction]).to eq("foo")
+    end
+
     describe "hub selection" do
       it "prioritizes the optional hub argument and uses it to submit the transaction" do
         expect(another_hub).to receive(:capture_event)


### PR DESCRIPTION
Fixes #1540.
