### PR TITLE
Don't start Sentry::SendEventJob's transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   - Fixes [#1541](https://github.com/getsentry/sentry-ruby/issues/1541)
 - Don't apply Scope's transaction name if it's empty [#1546](https://github.com/getsentry/sentry-ruby/pull/1546)
   - Fixes [#1540](https://github.com/getsentry/sentry-ruby/issues/1540)
+- Don't start `Sentry::SendEventJob`'s transaction [#1547](https://github.com/getsentry/sentry-ruby/pull/1547)
+  - Fixes [#1539](https://github.com/getsentry/sentry-ruby/issues/1539)
 
 ## 4.6.5
 

--- a/sentry-rails/app/jobs/sentry/send_event_job.rb
+++ b/sentry-rails/app/jobs/sentry/send_event_job.rb
@@ -22,11 +22,6 @@ if defined?(ActiveJob)
       end
 
       def perform(event, hint = {})
-        # users don't need the tracing result of this job
-        if transaction = Sentry.get_current_scope.span
-          transaction.instance_variable_set(:@sampled, false)
-        end
-
         Sentry.send_event(event, hint)
       end
     end

--- a/sentry-rails/lib/sentry/rails/active_job.rb
+++ b/sentry-rails/lib/sentry/rails/active_job.rb
@@ -21,7 +21,12 @@ module Sentry
 
       def capture_and_reraise_with_sentry(job, scope, block)
         scope.set_transaction_name(job.class.name)
-        transaction = Sentry.start_transaction(name: scope.transaction_name, op: "active_job")
+        transaction =
+          if job.is_a?(::Sentry::SendEventJob)
+            nil
+          else
+            Sentry.start_transaction(name: scope.transaction_name, op: "active_job")
+          end
 
         scope.set_span(transaction) if transaction
 


### PR DESCRIPTION
Fixes #1539 