### PR TITLE
Re-position RescuedExceptionInterceptor middleware

### DIFF
--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -8,8 +8,8 @@ module Sentry
     initializer "sentry.use_rack_middleware" do |app|
       # placed after all the file-sending middlewares so we can avoid unnecessary transactions
       app.config.middleware.insert_after ActionDispatch::Executor, Sentry::Rails::CaptureExceptions
-      # need to be placed at last to smuggle app exceptions via env
-      app.config.middleware.use(Sentry::Rails::RescuedExceptionInterceptor)
+      # need to place as close to DebugExceptions as possible to intercept most of the exceptions, including those raised by middlewares
+      app.config.middleware.insert_after ActionDispatch::DebugExceptions, Sentry::Rails::RescuedExceptionInterceptor
     end
 
     # because the extension works by registering the around_perform callcack, it should always be ran

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Sentry::Rails, type: :request do
       app = Rails.application
       index_of_executor = app.middleware.find_index { |m| m == ActionDispatch::Executor }
       expect(app.middleware.find_index(Sentry::Rails::CaptureExceptions)).to eq(index_of_executor + 1)
-      expect(app.middleware.find_index(Sentry::Rails::RescuedExceptionInterceptor)).to eq(app.middleware.count - 1)
+      index_of_debug_exceptions = app.middleware.find_index { |m| m == ActionDispatch::DebugExceptions }
+      expect(app.middleware.find_index(Sentry::Rails::RescuedExceptionInterceptor)).to eq(index_of_debug_exceptions + 1)
     end
 
     it "inserts a callback to disable background_worker for the runner mode" do


### PR DESCRIPTION
Currently, exceptions raised by middlewares placed between RescuedExceptionInterceptor and DebugExceptions are rescued DebugExceptions without anyway to be reported to the CaptureExceptions middleware.

By placing RescuedExceptionInterceptor closer to DebugExceptions, it should avoid similar issues.

Closes #1563 