### PR TITLE
Change default environment to 'development'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- Change default environment to 'development' [#1565](https://github.com/getsentry/sentry-ruby/pull/1565)
+  - Fixes [#1559](https://github.com/getsentry/sentry-ruby/issues/1559)
+
+
 ## 4.7.1
 
 ### Bug Fixes

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -430,7 +430,7 @@ module Sentry
     end
 
     def environment_from_env
-      ENV['SENTRY_CURRENT_ENV'] || ENV['SENTRY_ENVIRONMENT'] || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'default'
+      ENV['SENTRY_CURRENT_ENV'] || ENV['SENTRY_ENVIRONMENT'] || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
     end
 
     def server_name_from_env

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -149,8 +149,8 @@ RSpec.describe Sentry::Configuration do
       ENV.delete('RACK_ENV')
     end
 
-    it 'defaults to "default"' do
-      expect(subject.environment).to eq('default')
+    it 'defaults to "development"' do
+      expect(subject.environment).to eq('development')
     end
 
     it 'uses `SENTRY_CURRENT_ENV` env variable' do

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -474,7 +474,7 @@ RSpec.describe Sentry do
     it "returns the csp_report_uri generated from the main Configuration" do
       expect(Sentry.configuration).to receive(:csp_report_uri).and_call_original
 
-      expect(described_class.csp_report_uri).to eq("http://sentry.localdomain/api/42/security/?sentry_key=12345&sentry_environment=default")
+      expect(described_class.csp_report_uri).to eq("http://sentry.localdomain/api/42/security/?sentry_key=12345&sentry_environment=development")
     end
   end
 


### PR DESCRIPTION
Most people use `development` instead of `default` as their default environment. This change should prevent other issues similar to #1559.

Closes #1559 