### PR TITLE
Only report one test coverage per workflow

### DIFF
--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -12,15 +12,19 @@ jobs:
     defaults:
       run:
         working-directory: sentry-delayed_job
-    name: Test on ruby ${{ matrix.ruby_version }}
+    name: Ruby ${{ matrix.ruby_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', jruby]
-        os: [ubuntu-latest]
         include:
-          - ruby_version: '3.0'
-            env: RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
+          - { os: ubuntu-latest, ruby_version: 2.4 }
+          - { os: ubuntu-latest, ruby_version: 2.5 }
+          - { os: ubuntu-latest, ruby_version: 2.6 }
+          - { os: ubuntu-latest, ruby_version: 2.7 }
+          - { os: ubuntu-latest, ruby_version: '3.0' }
+          - { os: ubuntu-latest, ruby_version: jruby }
+          - { os: ubuntu-latest, ruby_version: '3.0', options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
+          - { os: ubuntu-latest, ruby_version: '3.0', options: { codecov: 1 } }
     steps:
     - uses: actions/checkout@v1
     - name: Install sqlite
@@ -37,6 +41,9 @@ jobs:
         ruby-version: ${{ matrix.ruby_version }}
 
     - name: Run specs
+      env:
+        RUBYOPT: ${{ matrix.options.rubyopt }}
+        CODECOV: ${{ matrix.options.codecov }}
       run: |
         bundle install --jobs 4 --retry 3
         bundle exec rake

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -12,7 +12,7 @@ jobs:
     defaults:
       run:
         working-directory: sentry-rails
-    name: Test on ruby ${{ matrix.ruby_version }} and rails ${{ matrix.rails_version }}
+    name: Ruby ${{ matrix.ruby_version }} & Rails ${{ matrix.rails_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -20,9 +20,8 @@ jobs:
         ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', jruby]
         os: [ubuntu-latest]
         include:
-          - ruby_version: '3.0'
-            rails_version: 6.1.0
-            env: RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
+          - { os: ubuntu-latest, ruby_version: '3.0', rails_version: 6.1.0, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
+          - { os: ubuntu-latest, ruby_version: '2.7', rails_version: 6.1.0, options: { codecov: 1 } }
         exclude:
           - ruby_version: 2.4
             rails_version: 6.0.0
@@ -58,6 +57,8 @@ jobs:
     - name: Build with Rails ${{ matrix.rails_version }}
       env:
         RAILS_VERSION: ${{ matrix.rails_version }}
+        RUBYOPT: ${{ matrix.options.rubyopt }}
+        CODECOV: ${{ matrix.options.codecov }}
       run: |
         bundle install --jobs 4 --retry 3
         bundle exec rake

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -12,15 +12,19 @@ jobs:
     defaults:
       run:
         working-directory: sentry-resque
-    name: Test on ruby ${{ matrix.ruby_version }}
+    name: Ruby ${{ matrix.ruby_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', jruby]
-        os: [ubuntu-latest]
         include:
-          - ruby_version: '3.0'
-            env: RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
+          - { os: ubuntu-latest, ruby_version: 2.4 }
+          - { os: ubuntu-latest, ruby_version: 2.5 }
+          - { os: ubuntu-latest, ruby_version: 2.6 }
+          - { os: ubuntu-latest, ruby_version: 2.7 }
+          - { os: ubuntu-latest, ruby_version: '3.0' }
+          - { os: ubuntu-latest, ruby_version: jruby }
+          - { os: ubuntu-latest, ruby_version: '3.0', options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
+          - { os: ubuntu-latest, ruby_version: '3.0', options: { codecov: 1 } }
     steps:
     - uses: actions/checkout@v1
     - name: Set up Ruby ${{ matrix.ruby_version }}
@@ -35,6 +39,9 @@ jobs:
         redis-version: 5
 
     - name: Run specs
+      env:
+        RUBYOPT: ${{ matrix.options.rubyopt }}
+        CODECOV: ${{ matrix.options.codecov }}
       run: |
         bundle install --jobs 4 --retry 3
         bundle exec rake

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -12,7 +12,7 @@ jobs:
     defaults:
       run:
         working-directory: sentry-ruby
-    name: Test on ruby ${{ matrix.ruby_version }} with options - ${{ toJson(matrix.options) }}
+    name: Ruby ${{ matrix.ruby_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -25,6 +25,7 @@ jobs:
           - { os: ubuntu-latest, ruby_version: jruby }
           - { os: ubuntu-latest, ruby_version: '3.0', options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
           - { os: ubuntu-latest, ruby_version: '3.0', options: { without_rack: 1 } }
+          - { os: ubuntu-latest, ruby_version: '3.0', options: { codecov: 1 } }
     steps:
     - uses: actions/checkout@v1
 
@@ -38,6 +39,7 @@ jobs:
       env:
         RUBYOPT: ${{ matrix.options.rubyopt }}
         WITHOUT_RACK: ${{ matrix.options.without_rack }}
+        CODECOV: ${{ matrix.options.codecov }}
       run: |
         bundle install --jobs 4 --retry 3
         bundle exec rake

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -12,7 +12,7 @@ jobs:
     defaults:
       run:
         working-directory: sentry-sidekiq
-    name: Test on ruby ${{ matrix.ruby_version }} and sidekiq ${{ matrix.sidekiq_version }}
+    name: Ruby ${{ matrix.ruby_version }} & Sidekiq ${{ matrix.sidekiq_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -20,8 +20,8 @@ jobs:
         ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', jruby]
         os: [ubuntu-latest]
         include:
-          - ruby_version: '3.0'
-            env: RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
+          - { os: ubuntu-latest, ruby_version: '3.0', sidekiq_version: 6.0, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
+          - { os: ubuntu-latest, ruby_version: '2.7', sidekiq_version: 6.0, options: { codecov: 1 } }
         exclude:
           - ruby_version: 2.4
             sidekiq_version: 6.0
@@ -42,6 +42,8 @@ jobs:
     - name: Run specs with Sidekiq ${{ matrix.sidekiq_version }}
       env:
         SIDEKIQ_VERSION: ${{ matrix.sidekiq_version }}
+        RUBYOPT: ${{ matrix.options.rubyopt }}
+        CODECOV: ${{ matrix.options.codecov }}
       run: |
         bundle install --jobs 4 --retry 3
         make test

--- a/sentry-delayed_job/spec/spec_helper.rb
+++ b/sentry-delayed_job/spec/spec_helper.rb
@@ -15,7 +15,7 @@ SimpleCov.start do
   coverage_dir File.join(__FILE__, "../../coverage")
 end
 
-if ENV["CI"]
+if ENV["CI"] && ENV["CODECOV"] == "1"
   require 'codecov'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end

--- a/sentry-rails/spec/spec_helper.rb
+++ b/sentry-rails/spec/spec_helper.rb
@@ -12,7 +12,7 @@ SimpleCov.start do
   coverage_dir File.join(__FILE__, "../../coverage")
 end
 
-if ENV["CI"]
+if ENV["CI"] && ENV["CODECOV"] == "1"
   require 'codecov'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end

--- a/sentry-raven/spec/spec_helper.rb
+++ b/sentry-raven/spec/spec_helper.rb
@@ -7,7 +7,7 @@ SimpleCov.start do
   coverage_dir File.join(__FILE__, "../../coverage")
 end
 
-if ENV["CI"]
+if ENV["CI"] && ENV["CODECOV"] == "1"
   require 'codecov'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end

--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -10,7 +10,7 @@ SimpleCov.start do
   coverage_dir File.join(__FILE__, "../../coverage")
 end
 
-if ENV["CI"]
+if ENV["CI"] && ENV["CODECOV"] == "1"
   require 'codecov'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -16,7 +16,7 @@ SimpleCov.start do
   coverage_dir File.join(__FILE__, "../../coverage")
 end
 
-if ENV["CI"]
+if ENV["CI"] && ENV["CODECOV"] == "1"
   require 'codecov'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end


### PR DESCRIPTION
Currently every CI job sends a coverage report to codecov, which generates about 40 reports per CI run. This makes CI's status highly depend on codecov's because if it can't accept a report request (due to server issue...etc.), it fails the CI job.