### PR TITLE
Avoid leaking tracing timestamp to breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Avoid leaking tracing timestamp to breadcrumbs [#1575](https://github.com/getsentry/sentry-ruby/pull/1575)
+
 ## 4.7.2
 
 - Change default environment to 'development' [#1565](https://github.com/getsentry/sentry-ruby/pull/1565)

--- a/sentry-rails/lib/sentry/rails.rb
+++ b/sentry-rails/lib/sentry/rails.rb
@@ -1,10 +1,10 @@
 require "rails"
 require "sentry-ruby"
 require "sentry/integrable"
+require "sentry/rails/tracing"
 require "sentry/rails/configuration"
 require "sentry/rails/engine"
 require "sentry/rails/railtie"
-require "sentry/rails/tracing"
 
 module Sentry
   module Rails

--- a/sentry-rails/lib/sentry/rails/instrument_payload_cleanup_helper.rb
+++ b/sentry-rails/lib/sentry/rails/instrument_payload_cleanup_helper.rb
@@ -1,7 +1,7 @@
 module Sentry
   module Rails
     module InstrumentPayloadCleanupHelper
-      IGNORED_DATA_TYPES = [:request, :response, :headers, :exception, :exception_object]
+      IGNORED_DATA_TYPES = [:request, :response, :headers, :exception, :exception_object, Tracing::START_TIMESTAMP_NAME]
 
       def cleanup_data(data)
         IGNORED_DATA_TYPES.each do |key|

--- a/sentry-rails/lib/sentry/rails/tracing.rb
+++ b/sentry-rails/lib/sentry/rails/tracing.rb
@@ -1,6 +1,8 @@
 module Sentry
   module Rails
     module Tracing
+      START_TIMESTAMP_NAME = :sentry_start_timestamp
+
       def self.register_subscribers(subscribers)
         @subscribers = subscribers
       end
@@ -37,7 +39,7 @@ module Sentry
           def instrument(name, payload = {}, &block)
             is_public_event = name[0] != "!"
 
-            payload[:start_timestamp] = Time.now.utc.to_f if is_public_event
+            payload[START_TIMESTAMP_NAME] = Time.now.utc.to_f if is_public_event
 
             super(name, payload, &block)
           end

--- a/sentry-rails/lib/sentry/rails/tracing/action_controller_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/action_controller_subscriber.rb
@@ -16,7 +16,7 @@ module Sentry
 
             record_on_current_span(
               op: event_name,
-              start_timestamp: payload[:start_timestamp],
+              start_timestamp: payload[START_TIMESTAMP_NAME],
               description: "#{controller}##{action}",
               duration: duration
             ) do |span|

--- a/sentry-rails/lib/sentry/rails/tracing/action_view_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/action_view_subscriber.rb
@@ -8,7 +8,7 @@ module Sentry
 
         def self.subscribe!
           subscribe_to_event(EVENT_NAME) do |event_name, duration, payload|
-            record_on_current_span(op: event_name, start_timestamp: payload[:start_timestamp], description: payload[:identifier], duration: duration)
+            record_on_current_span(op: event_name, start_timestamp: payload[START_TIMESTAMP_NAME], description: payload[:identifier], duration: duration)
           end
         end
       end

--- a/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
@@ -11,7 +11,7 @@ module Sentry
           subscribe_to_event(EVENT_NAME) do |event_name, duration, payload|
             next if EXCLUDED_EVENTS.include? payload[:name]
 
-            record_on_current_span(op: event_name, start_timestamp: payload[:start_timestamp], description: payload[:sql], duration: duration) do |span|
+            record_on_current_span(op: event_name, start_timestamp: payload[START_TIMESTAMP_NAME], description: payload[:sql], duration: duration) do |span|
               span.set_data(:connection_id, payload[:connection_id])
             end
           end

--- a/sentry-rails/spec/sentry/rails/breadcrumbs/active_support_breadcrumbs_spec.rb
+++ b/sentry-rails/spec/sentry/rails/breadcrumbs/active_support_breadcrumbs_spec.rb
@@ -92,4 +92,18 @@ RSpec.describe "Sentry::Breadcrumbs::ActiveSupportLogger", type: :request do
 
     expect(breadcrumb_buffer.count).to be_zero
   end
+
+  context "when used with tracing" do
+    it "doesn't add internal start timestamp payload to breadcrumbs data" do
+      p = Post.create!
+
+      get "/posts/#{p.id}"
+
+      expect(transport.events.count).to eq(1)
+
+      transaction = transport.events.last.to_hash
+      breadcrumbs = transaction[:breadcrumbs][:values]
+      expect(breadcrumbs.last[:data].has_key?(Sentry::Rails::Tracing::START_TIMESTAMP_NAME)).to eq(false)
+    end
+  end
 end

--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
       expect(described_class).to receive(:subscribe_tracing_events).and_call_original
 
       make_basic_app do |config|
-        config.breadcrumbs_logger = [:active_support_logger]
         config.traces_sample_rate = 1.0
       end
     end
@@ -87,18 +86,6 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
       expect(last_span[:op]).to eq("process_action.action_controller")
       expect(last_span[:description]).to eq("PostsController#show")
       expect(last_span[:parent_span_id]).to eq(parent_span_id)
-    end
-
-    it "doesn't add internal start timestamp payload to breadcrumbs data" do
-      p = Post.create!
-
-      get "/posts/#{p.id}"
-
-      expect(transport.events.count).to eq(1)
-
-      transaction = transport.events.last.to_hash
-      breadcrumbs = transaction[:breadcrumbs][:values]
-      expect(breadcrumbs.last[:data].has_key?(described_class::START_TIMESTAMP_NAME)).to eq(false)
     end
   end
 

--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
       expect(described_class).to receive(:subscribe_tracing_events).and_call_original
 
       make_basic_app do |config|
+        config.breadcrumbs_logger = [:active_support_logger]
         config.traces_sample_rate = 1.0
       end
     end
@@ -86,6 +87,18 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
       expect(last_span[:op]).to eq("process_action.action_controller")
       expect(last_span[:description]).to eq("PostsController#show")
       expect(last_span[:parent_span_id]).to eq(parent_span_id)
+    end
+
+    it "doesn't add internal start timestamp payload to breadcrumbs data" do
+      p = Post.create!
+
+      get "/posts/#{p.id}"
+
+      expect(transport.events.count).to eq(1)
+
+      transaction = transport.events.last.to_hash
+      breadcrumbs = transaction[:breadcrumbs][:values]
+      expect(breadcrumbs.last[:data].has_key?(described_class::START_TIMESTAMP_NAME)).to eq(false)
     end
   end
 

--- a/sentry-rails/spec/spec_helper.rb
+++ b/sentry-rails/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "bundler/setup"
+require "debug"
 require "pry"
 
 require "sentry-ruby"


### PR DESCRIPTION
Currently when using `sentry-rails`'s `active_support_logger` breadcrumb logger with tracing enabled, all the breadcrumbs will have an additional `start_timestamp` attribute. That attribute is added for helping tracing subscribers calculate each span's duration and is not designed to be leaked outside.

So this PR adds 2 changes:

- Because the attribute is added to all instrument events and is visible to all subscribers (including other libraries or users' subscribers), its name should have `sentry_` prefix to avoid misuse.
- `InstrumentPayloadCleanupHelper` should remove the `sentry_start_timestamp` key from breadcrumbs.