### PR TITLE
`Hub#capture_message` should check its argument's type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## Unreleased
+## 4.7.3
 
 - Avoid leaking tracing timestamp to breadcrumbs [#1575](https://github.com/getsentry/sentry-ruby/pull/1575)
 - Avoid injecting tracing timestamp to all ActiveSupport instrument events [#1576](https://github.com/getsentry/sentry-ruby/pull/1576)
+  - Fixes [#1573](https://github.com/getsentry/sentry-ruby/issues/1574)
+- `Hub#capture_message` should check its argument's type [#1577](https://github.com/getsentry/sentry-ruby/pull/1577)
   - Fixes [#1574](https://github.com/getsentry/sentry-ruby/issues/1574)
 
 ## 4.7.2

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -90,9 +90,9 @@ module Sentry
     end
 
     def capture_exception(exception, **options, &block)
-      return unless current_client
-
       check_argument_type!(exception, ::Exception)
+
+      return unless current_client
 
       options[:hint] ||= {}
       options[:hint][:exception] = exception
@@ -104,6 +104,8 @@ module Sentry
     end
 
     def capture_message(message, **options, &block)
+      check_argument_type!(message, ::String)
+
       return unless current_client
 
       options[:hint] ||= {}
@@ -114,9 +116,9 @@ module Sentry
     end
 
     def capture_event(event, **options, &block)
-      return unless current_client
-
       check_argument_type!(event, Sentry::Event)
+
+      return unless current_client
 
       hint = options.delete(:hint) || {}
       scope = current_scope.dup

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -149,6 +149,12 @@ RSpec.describe Sentry::Hub do
       expect(event_hash.dig(:threads, :values, 0, :stacktrace, :frames, 0, :function)).to eq("foo")
     end
 
+    it "raises error when passing a non-string object" do
+      expect do
+        subject.capture_message(1)
+      end.to raise_error(ArgumentError, 'expect the argument to be a String, got Integer (1)')
+    end
+
     it "assigns default backtrace with caller" do
       event = subject.capture_message(message)
       event_hash = event.to_hash


### PR DESCRIPTION
Fixes #1574 