### PR TITLE
[ENHANCE] Support Sidekiq Tags in Sentry

### DIFF
--- a/sentry-sidekiq/lib/sentry/sidekiq/sentry_context_middleware.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/sentry_context_middleware.rb
@@ -14,6 +14,7 @@ module Sentry
           scope.set_user(user)
         end
         scope.set_tags(queue: queue, jid: job["jid"])
+        scope.set_tags(build_tags(job["tags"]))
         scope.set_contexts(sidekiq: job.merge("queue" => queue))
         scope.set_transaction_name(context_filter.transaction_name)
         transaction = start_transaction(scope.transaction_name, job["sentry_trace"])
@@ -30,6 +31,10 @@ module Sentry
         # don't need to use ensure here
         # if the job failed, we need to keep the scope for error handler. and the scope will be cleared there
         scope.clear
+      end
+
+      def build_tags(tags)
+        Array(tags).each_with_object({}) { |name, tags_hash| tags_hash[:"sidekiq.#{name}"] = true }
       end
 
       def start_transaction(transaction_name, sentry_trace)

--- a/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
       expect(event.user).to eq(user)
     end
 
+    it "sets sidekiq tags to the event" do
+      execute_worker(processor, TagsWorker)
+      event = transport.events.last
+      expect(event.tags.keys).to include(:"sidekiq.marvel", :"sidekiq.dc")
+    end
+
     context "with sentry_trace" do
       let(:parent_transaction) { Sentry.start_transaction(op: "sidekiq") }
 

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -153,6 +153,14 @@ class ZeroRetryWorker
   end
 end
 
+class TagsWorker
+  include Sidekiq::Worker
+
+  sidekiq_options tags: ["marvel", "dc"]
+
+  def perform; end
+end
+
 def execute_worker(processor, klass, **options)
   klass_options = klass.sidekiq_options_hash || {}
 


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-ruby/issues/1488

## Description
Add Sidekiq Tags to Sentry

## Notes
Just Few things TBC
- Since Sidekiq supports array of tags but Sentry supports different way of setup with key/value, not sure if given boolean value is a common practice here
- default naming pattern I use`sidekiq.#{name}` here, the reason for prefixing with `sidekiq` is that tag naming sometimes can be too generic, might conflict with custom setup from users. But can also be other naming, welcome for any feedback
