### PR TITLE
sentry-sidekiq pass extras from client to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   This feature should only introduce negligible performance overhead in most Ruby applications. But if you notice obvious performance regression, please file an issue and we'll investigate it.
 
 - Support `ActiveStorage` spans in tracing events [#1588](https://github.com/getsentry/sentry-ruby/pull/1588)
+- Support sentry extras in sidekiq jobs [#1599](https://github.com/getsentry/sentry-ruby/pull/1599](https://github.com/getsentry/sentry-ruby/pull/1599)
 
 ### Miscellaneous
 


### PR DESCRIPTION
## Description

We have the need to pass through a set of extras one of them is the `x-request-id` which generated the sidekiq job, so we find useful to be able to pass this through.
