### PR TITLE
Remove verbose data from #inspect result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   This feature should only introduce negligible performance overhead in most Ruby applications. But if you notice obvious performance regression, please file an issue and we'll investigate it.
 
 - Support `ActiveStorage` spans in tracing events [#1588](https://github.com/getsentry/sentry-ruby/pull/1588)
+- Support `Sidekiq` Tags in Sentry [#1596](https://github.com/getsentry/sentry-ruby/pull/1596)
 
 ### Bug Fixes
 
@@ -28,6 +29,7 @@
   - Fixes [#1586](https://github.com/getsentry/sentry-ruby/issues/1586)
 - Use nil instead of false to disable callable settings [#1594](https://github.com/getsentry/sentry-ruby/pull/1594)
 - Avoid duplicated sampling on Transaction events [#1601](https://github.com/getsentry/sentry-ruby/pull/1601)
+- Remove verbose data from `#inspect` result [#1602](https://github.com/getsentry/sentry-ruby/pull/1602)
 
 ### Refactoring
 

--- a/sentry-ruby/bin/console
+++ b/sentry-ruby/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "sentry/ruby"
+require "sentry-ruby"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -9,6 +9,10 @@ require "sentry/ruby"
 # (If you use this, don't forget to add pry to your Gemfile!)
 # require "pry"
 # Pry.start
+
+# Sentry.init do |config|
+#   config.dsn = 'https://2fb45f003d054a7ea47feb45898f7649@o447951.ingest.sentry.io/5434472'
+# end
 
 require "irb"
 IRB.start(__FILE__)

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -1,6 +1,7 @@
 require "concurrent/utility/processor_counter"
 
 require "sentry/utils/exception_cause_chain"
+require 'sentry/utils/custom_inspection'
 require "sentry/dsn"
 require "sentry/release_detector"
 require "sentry/transport/configuration"
@@ -9,6 +10,7 @@ require "sentry/interfaces/stacktrace_builder"
 
 module Sentry
   class Configuration
+    include CustomInspection
     include LoggingHelper
     # Directories to be recognized as part of your app. e.g. if you
     # have an `engines` dir at the root of your project, you may want
@@ -181,6 +183,7 @@ module Sentry
 
     LOG_PREFIX = "** [Sentry] ".freeze
     MODULE_SEPARATOR = "::".freeze
+    SKIP_INSPECTION_ATTRIBUTES = [:@linecache, :@stacktrace_builder]
 
     # Post initialization callbacks are called at the end of initialization process
     # allowing extending the configuration of sentry-ruby by multiple extensions

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -6,6 +6,7 @@ require 'sentry/interface'
 require 'sentry/backtrace'
 require 'sentry/utils/real_ip'
 require 'sentry/utils/request_id'
+require 'sentry/utils/custom_inspection'
 
 module Sentry
   class Event
@@ -20,6 +21,10 @@ module Sentry
     WRITER_ATTRIBUTES = SERIALIZEABLE_ATTRIBUTES - %i(type timestamp level)
 
     MAX_MESSAGE_SIZE_IN_BYTES = 1024 * 8
+
+    SKIP_INSPECTION_ATTRIBUTES = [:@configuration, :@modules, :@backtrace]
+
+    include CustomInspection
 
     attr_writer(*WRITER_ATTRIBUTES)
     attr_reader(*SERIALIZEABLE_ATTRIBUTES)

--- a/sentry-ruby/lib/sentry/interfaces/single_exception.rb
+++ b/sentry-ruby/lib/sentry/interfaces/single_exception.rb
@@ -1,5 +1,10 @@
+require "sentry/utils/exception_cause_chain"
+
 module Sentry
   class SingleExceptionInterface < Interface
+    include CustomInspection
+
+    SKIP_INSPECTION_ATTRIBUTES = [:@stacktrace]
     PROBLEMATIC_LOCAL_VALUE_REPLACEMENT = "[ignored due to error]".freeze
     OMISSION_MARK = "...".freeze
     MAX_LOCAL_BYTES = 1024

--- a/sentry-ruby/lib/sentry/interfaces/stacktrace.rb
+++ b/sentry-ruby/lib/sentry/interfaces/stacktrace.rb
@@ -10,6 +10,10 @@ module Sentry
       { frames: @frames.map(&:to_hash) }
     end
 
+    def inspect
+      @frames.map(&:to_s)
+    end
+
     private
 
     # Not actually an interface, but I want to use the same style
@@ -26,6 +30,10 @@ module Sentry
         @in_app = line.in_app
         @module = line.module_name if line.module_name
         @filename = compute_filename
+      end
+
+      def to_s
+        "#{@filename}:#{@lineno}"
       end
 
       def compute_filename

--- a/sentry-ruby/lib/sentry/utils/custom_inspection.rb
+++ b/sentry-ruby/lib/sentry/utils/custom_inspection.rb
@@ -1,0 +1,12 @@
+module Sentry
+  module CustomInspection
+    def inspect
+      attr_strings = (instance_variables - self.class::SKIP_INSPECTION_ATTRIBUTES).each_with_object([]) do |attr, result|
+        value = instance_variable_get(attr)
+        result << "#{attr}=#{value.inspect}" if value
+      end
+
+      "#<#{self.class.name} #{attr_strings.join(", ")}>"
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -33,6 +33,38 @@ RSpec.describe Sentry::Event do
     end
   end
 
+  describe "#inspect" do
+    let(:client) do
+      Sentry::Client.new(configuration)
+    end
+
+    subject do
+      e = begin
+            1/0
+          rescue => e
+            e
+          end
+
+      client.event_from_exception(e)
+    end
+
+    it "still contains relevant info" do
+      expect(subject.inspect).to match(/@event_id="#{subject.event_id}"/)
+    end
+
+    it "ignores @configuration" do
+      expect(subject.inspect).not_to match(/@configuration/)
+    end
+
+    it "ignores @modules" do
+      expect(subject.inspect).not_to match(/@modules/)
+    end
+
+    it "ignores @backtrace" do
+      expect(subject.inspect).not_to match(/@backtrace/)
+    end
+  end
+
   context 'rack context specified', rack: true do
     require 'stringio'
 


### PR DESCRIPTION
This PR removes some lengthy data from `Event`, `Configuration`, and `SingleExceptionInterface`'s `#inspect` method. (`SingleExceptionInterface` is usually included in `Event`'s inspect result, so it's important to keep it simple too).

Removing those data will make inspecting those objects easier and help debug or report the SDK issues.

### Example

```rb
event = Sentry.capture_message("foo")
event.inspect.length
```

**Before**

`52024` (too long so skip pasting)

**After**

`2905`

<details>

```
#<Sentry::Event @event_id="9a85bad59bb64044a2e99679c3adc618", @timestamp="2021-11-05T18:37:15Z", @platform=:ruby, @sdk={"name"=>"sentry.ruby", "version"=>"4.7.3"}, 
@user={}, @extra={}, @contexts={:os=>{:name=>"Darwin", :version=>"Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:27 PDT 2021; root:xnu-7195.141.2~5/RELEASE_ARM64_T8101", :build=>"20.6.0", :kernel_version=>"Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:27 PDT 2021; root:xnu-7195.141.2~5/RELEASE_ARM64_T8101"}, :runtime=>{:name=>"ruby", :version=>"ruby 2.7.4p191 (2021-07-07 revision a21a3b7d23) [x86_64-darwin20]"}}, @tags={}, @fingerprint=[], @server_name="Stans-MBPR-2.local", @environment="development", @release="fix-#1600\n", @message="foo", @level=:error, @threads=#<Sentry::ThreadsInterface:0x00007fb9245de0a0 @id=5340, @name=nil, @current=true, @crashed=false, @stacktrace=[
"bin/rails:9", "bootsnap (1.9.0) lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31", "bootsnap (1.9.0) lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22", "bootsnap (1.9.0) lib/bootsnap/load_path_cache/loaded_features_index.rb:92", 
"bootsnap (1.9.0) lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23", "bootsnap (1.9.0) lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23", 
"railties (6.1.4.1) lib/rails/commands.rb:18", "railties (6.1.4.1) lib/rails/command.rb:48", "railties (6.1.4.1) lib/rails/command/base.rb:69", 
"thor (1.1.0) lib/thor.rb:392", "thor (1.1.0) lib/thor/invocation.rb:127", "thor (1.1.0) lib/thor/command.rb:27", "railties (6.1.4.1) lib/rails/commands/console/console_command.rb:102", "railties (6.1.4.1) lib/rails/commands/console/console_command.rb:19", 
"railties (6.1.4.1) lib/rails/commands/console/console_command.rb:70", "irb (1.3.7) lib/irb.rb:409", "irb (1.3.7) lib/irb.rb:480", "irb (1.3.7) lib/irb.rb:480", "irb (1.3.7) lib/irb.rb:481", "irb (1.3.7) lib/irb.rb:547", "irb (1.3.7) lib/irb/ruby-lex.rb:247", "irb (1.3.7) lib/irb/ruby-lex.rb:247", 
"irb (1.3.7) lib/irb/ruby-lex.rb:248", "irb (1.3.7) lib/irb/ruby-lex.rb:248", "irb (1.3.7) lib/irb/ruby-lex.rb:266", "irb (1.3.7) lib/irb.rb:548", "irb (1.3.7) lib/irb.rb:758", "irb (1.3.7) lib/irb.rb:567", "irb (1.3.7) lib/irb/context.rb:450", "irb (1.3.7) lib/irb/workspace.rb:116", "irb (1.3.7) lib/irb/workspace.rb:116", "(irb):2", "sentry-ruby.rb:206", "sentry/hub.rb:114"]>, 
@breadcrumbs=#<Sentry::BreadcrumbBuffer:0x00007fb9245ddee8 @buffer=[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil]>>
```

</details>




Closes #1600