### PR TITLE
Don't require debug gem unless Ruby >= 2.6

### DIFF
--- a/sentry-rails/spec/spec_helper.rb
+++ b/sentry-rails/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "debug"
+require "debug" if RUBY_VERSION.to_f >= 2.6
 require "pry"
 
 require "sentry-ruby"

--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "bundler/setup"
+require "debug" if RUBY_VERSION.to_f >= 2.6
 require "pry"
 require "timecop"
 require 'simplecov'


### PR DESCRIPTION
The new debugger gem is only installed with Ruby >= 2.6 versions, so requiring `debug` before that will load the old and sometimes buggy debugger.