### PR TITLE
Log event payload in debug mode

### DIFF
--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -133,6 +133,11 @@ module Sentry
 
       event = current_client.capture_event(event, scope, hint)
 
+
+      if event && configuration.debug
+        configuration.log_debug(event.to_json_compatible)
+      end
+
       @last_event_id = event&.event_id
       event
     end

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -223,6 +223,24 @@ RSpec.describe Sentry::Hub do
       end.to raise_error(ArgumentError, 'expect the argument to be a Sentry::Event, got String ("String")')
     end
 
+    it "doesn't log event payload" do
+      subject.capture_event(event)
+
+      expect(string_io.string).not_to include(event.to_json_compatible.to_s)
+    end
+
+    context "in debug mode" do
+      before do
+        configuration.debug = true
+      end
+
+      it "logs event payload" do
+        subject.capture_event(event)
+
+        expect(string_io.string).to include(event.to_json_compatible.to_s)
+      end
+    end
+
     it_behaves_like "capture_helper" do
       let(:capture_helper) { :capture_event }
       let(:capture_subject) { event }


### PR DESCRIPTION
For issues like https://github.com/getsentry/sentry-ruby/issues/1603, it'll be a lot easier to debug if the debug mode can output all the reported events and let clients copy and paste their event payload.