### PR TITLE
Move `Sentry::Rails::CaptureExceptions` before `ActionDispatch::ShowExceptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,18 +22,23 @@
 
 - Support `ActiveStorage` spans in tracing events [#1588](https://github.com/getsentry/sentry-ruby/pull/1588)
 
-### Miscellaneous
-
-- Start Testing Against Rails 7.0 [#1581](https://github.com/getsentry/sentry-ruby/pull/1581)
-- Tracing subscribers should be multi-event based [#1587](https://github.com/getsentry/sentry-ruby/pull/1587)
-- Refactor `Sentry::Configuration` [#1595](https://github.com/getsentry/sentry-ruby/pull/1595)
-
 ### Bug Fixes
 
 - Connect `Sidekiq`'s transaction with its parent when possible [#1590](https://github.com/getsentry/sentry-ruby/pull/1590)
   - Fixes [#1586](https://github.com/getsentry/sentry-ruby/issues/1586)
 - Use nil instead of false to disable callable settings [#1594](https://github.com/getsentry/sentry-ruby/pull/1594)
 - Avoid duplicated sampling on Transaction events [#1601](https://github.com/getsentry/sentry-ruby/pull/1601)
+
+### Refactoring
+
+- Move Sentry::Rails::CaptureExceptions before ActionDispatch::ShowExceptions [#1608](https://github.com/getsentry/sentry-ruby/pull/1608)
+- Refactor `Sentry::Configuration` [#1595](https://github.com/getsentry/sentry-ruby/pull/1595)
+- Tracing subscribers should be multi-event based [#1587](https://github.com/getsentry/sentry-ruby/pull/1587)
+
+### Miscellaneous
+
+- Start Testing Against Rails 7.0 [#1581](https://github.com/getsentry/sentry-ruby/pull/1581)
+
 
 ## 4.7.3
 

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -7,7 +7,7 @@ module Sentry
     # middlewares can't be injected after initialize
     initializer "sentry.use_rack_middleware" do |app|
       # placed after all the file-sending middlewares so we can avoid unnecessary transactions
-      app.config.middleware.insert_after ActionDispatch::Executor, Sentry::Rails::CaptureExceptions
+      app.config.middleware.insert_after ActionDispatch::ShowExceptions, Sentry::Rails::CaptureExceptions
       # need to place as close to DebugExceptions as possible to intercept most of the exceptions, including those raised by middlewares
       app.config.middleware.insert_after ActionDispatch::DebugExceptions, Sentry::Rails::RescuedExceptionInterceptor
     end

--- a/sentry-rails/lib/sentry/rails/rescued_exception_interceptor.rb
+++ b/sentry-rails/lib/sentry/rails/rescued_exception_interceptor.rb
@@ -11,22 +11,6 @@ module Sentry
         begin
           @app.call(env)
         rescue => e
-          request = ActionDispatch::Request.new(env)
-
-          # Rails' ShowExceptions#render_exception will mutate env for the exceptions app
-          # so we need to hold a copy of env to report the accurate data (like request's url)
-          if request.show_exceptions?
-            scope = Sentry.get_current_scope
-            copied_env = scope.rack_env.dup
-            copied_env["sentry.original_transaction"] = scope.transaction_name
-            scope.set_rack_env(copied_env)
-
-            if report_rescued_exceptions?
-              Sentry::Rails.capture_exception(e)
-              env["sentry.already_captured"] = true
-            end
-          end
-
           env["sentry.rescued_exception"] = e if report_rescued_exceptions?
           raise e
         end

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Sentry::Rails, type: :request do
 
     it "inserts middleware to a correct position" do
       app = Rails.application
-      index_of_executor = app.middleware.find_index { |m| m == ActionDispatch::Executor }
+      index_of_executor = app.middleware.find_index { |m| m == ActionDispatch::ShowExceptions }
       expect(app.middleware.find_index(Sentry::Rails::CaptureExceptions)).to eq(index_of_executor + 1)
       index_of_debug_exceptions = app.middleware.find_index { |m| m == ActionDispatch::DebugExceptions }
       expect(app.middleware.find_index(Sentry::Rails::RescuedExceptionInterceptor)).to eq(index_of_debug_exceptions + 1)


### PR DESCRIPTION
This can save us from reporting the exception manually in RescuedExceptionInterceptor, which was designed to prevent the exception being rescued by ShowExceptions.