### PR TITLE
Gracefully shutdown background worker before the process exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@
 - Fix `HTTPTransport`'s `ssl` configuration [#1626](https://github.com/getsentry/sentry-ruby/pull/1626)
 - Log errors happened in `BackgroundWorker#perform` [#1624](https://github.com/getsentry/sentry-ruby/pull/1624)
   - Fixes [#1618](https://github.com/getsentry/sentry-ruby/issues/1618)
+- Gracefully shutdown background worker before the process exits [#1617](https://github.com/getsentry/sentry-ruby/pull/1617)
+  - Fixes [#1612](https://github.com/getsentry/sentry-ruby/issues/1612)
 
 ### Refactoring
 
 - Extract envelope construction logic from Transport [#1616](https://github.com/getsentry/sentry-ruby/pull/1616)
+- Add frozen string literal comment to sentry-ruby [#1623](https://github.com/getsentry/sentry-ruby/pull/1623)
 
 ## 4.8.0
 

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -108,6 +108,10 @@ module Sentry
       if config.capture_exception_frame_locals
         exception_locals_tp.enable
       end
+
+      at_exit do
+        @background_worker.shutdown
+      end
     end
 
     # Returns an uri for security policy reporting that's generated from the given DSN

--- a/sentry-ruby/lib/sentry/background_worker.rb
+++ b/sentry-ruby/lib/sentry/background_worker.rb
@@ -7,12 +7,15 @@ module Sentry
     include LoggingHelper
 
     attr_reader :max_queue, :number_of_threads, :logger
+    attr_accessor :shutdown_timeout
 
     def initialize(configuration)
       @max_queue = 30
+      @shutdown_timeout = 1
       @number_of_threads = configuration.background_worker_threads
       @logger = configuration.logger
       @debug = configuration.debug
+      @shutdown_callback = nil
 
       @executor =
         if configuration.async
@@ -24,12 +27,19 @@ module Sentry
         else
           log_debug("initialized a background worker with #{@number_of_threads} threads")
 
-          Concurrent::ThreadPoolExecutor.new(
+          executor = Concurrent::ThreadPoolExecutor.new(
             min_threads: 0,
             max_threads: @number_of_threads,
             max_queue: @max_queue,
             fallback_policy: :discard
           )
+
+          @shutdown_callback = proc do
+            executor.shutdown
+            executor.wait_for_termination(@shutdown_timeout)
+          end
+
+          executor
         end
     end
 
@@ -42,6 +52,10 @@ module Sentry
           log_error("exception happened in background worker", e, debug: @debug)
         end
       end
+    end
+
+    def shutdown
+      @shutdown_callback&.call
     end
 
     private

--- a/sentry-ruby/lib/sentry/rake.rb
+++ b/sentry-ruby/lib/sentry/rake.rb
@@ -5,7 +5,7 @@ module Sentry
   module Rake
     module Application
       def display_error_message(ex)
-        Sentry.capture_exception(ex, hint: { background: false }) do |scope|
+        Sentry.capture_exception(ex) do |scope|
           task_name = top_level_tasks.join(' ')
           scope.set_transaction_name(task_name)
           scope.set_tag("rake_task", task_name)
@@ -19,9 +19,7 @@ module Sentry
       def execute(args=nil)
         return super unless Sentry.initialized? && Sentry.get_current_hub
 
-        Sentry.get_current_hub.with_background_worker_disabled do
-          super
-        end
+        super
       end
     end
   end


### PR DESCRIPTION
Currently, when a process exits, SDK's background worker will discard all WIP sending tasks and cause lost of events. This is why we need to [disable background worker in rake integration](https://github.com/getsentry/sentry-ruby/blob/master/sentry-ruby/lib/sentry/rake.rb#L22-L24). And from the discussion in #1612, it seems to cause issues in the resque integration too.

Even though I want to avoid using the `at_exit` block, I don't think the responsibility of shutting down the background worker should fall on users. It should be handled by the SDK whenever possible. So in addition to providing a shutdown API in this PR, the SDK would also start the shutdown procedure when exiting the process.

Closes #1612