### PR TITLE
Merge context with the same key instead of replacing the old value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 4.8.1
 
+### Bug Fixes
+
+- Merge context with the same key instead of replacing the old value. [#1621](https://github.com/getsentry/sentry-ruby/pull/1621)
+  - Fixes [#1619](https://github.com/getsentry/sentry-ruby/issues/1619)
+
 ### Refactoring
 
 - Extract envelope construction logic from Transport [#1616](https://github.com/getsentry/sentry-ruby/pull/1616)

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -112,7 +112,7 @@ module Sentry
     end
 
     def set_extra(key, value)
-      @extra.merge!(key => value)
+      set_extras(key => value)
     end
 
     def set_tags(tags_hash)
@@ -121,7 +121,7 @@ module Sentry
     end
 
     def set_tag(key, value)
-      @tags.merge!(key => value)
+      set_tags(key => value)
     end
 
     def set_contexts(contexts_hash)
@@ -131,7 +131,7 @@ module Sentry
 
     def set_context(key, value)
       check_argument_type!(value, Hash)
-      @contexts.merge!(key => value)
+      set_contexts(key => value)
     end
 
     def set_level(level)

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -126,7 +126,9 @@ module Sentry
 
     def set_contexts(contexts_hash)
       check_argument_type!(contexts_hash, Hash)
-      @contexts.merge!(contexts_hash)
+      @contexts.merge!(contexts_hash) do |key, old, new|
+        new.merge(old)
+      end
     end
 
     def set_context(key, value)

--- a/sentry-ruby/spec/sentry/scope/setters_spec.rb
+++ b/sentry-ruby/spec/sentry/scope/setters_spec.rb
@@ -103,6 +103,12 @@ RSpec.describe Sentry::Scope do
       expect(subject.contexts).to include({ character: { name: "John", age: 25 }})
       expect(subject.contexts).to include({ another_character: { name: "Jane", age: 20 }})
     end
+
+    it "merges context with the same key" do
+      subject.set_contexts({ character: { name: "John" }})
+      subject.set_contexts({ character: { age: 25 }})
+      expect(subject.contexts).to include({ character: { name: "John", age: 25 }})
+    end
   end
 
   describe "#set_context" do
@@ -126,6 +132,12 @@ RSpec.describe Sentry::Scope do
           another_character: { name: "Jane", age: 20 }
         }
       )
+    end
+
+    it "merges context with the same key" do
+      subject.set_context(:character, { name: "John" })
+      subject.set_context(:character, { age: 25 })
+      expect(subject.contexts).to include({ character: { name: "John", age: 25 }})
     end
   end
 


### PR DESCRIPTION
Before:

```rb
Sentry.set_context(:character, { name: "John" })
Sentry.set_context(:character, { age: 25 })
p Sentry.get_current_scope.contexts[:character] #=> {:age=>25}
```

After:

```rb
Sentry.set_context(:character, { name: "John" })
Sentry.set_context(:character, { age: 25 })
p Sentry.get_current_scope.contexts[:character] #=> {:age=>25, :name=>"John"}
```

Closes #1619 