### PR TITLE
Log errors happened in BackgroundWorker#perform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Merge context with the same key instead of replacing the old value. [#1621](https://github.com/getsentry/sentry-ruby/pull/1621)
   - Fixes [#1619](https://github.com/getsentry/sentry-ruby/issues/1619)
 - Fix `HTTPTransport`'s `ssl` configuration [#1626](https://github.com/getsentry/sentry-ruby/pull/1626)
+- Log errors happened in `BackgroundWorker#perform` [#1624](https://github.com/getsentry/sentry-ruby/pull/1624)
+  - Fixes [#1618](https://github.com/getsentry/sentry-ruby/issues/1618)
 
 ### Refactoring
 

--- a/sentry-rails/lib/sentry/rails/background_worker.rb
+++ b/sentry-rails/lib/sentry/rails/background_worker.rb
@@ -1,11 +1,9 @@
 module Sentry
   class BackgroundWorker
-    def perform(&block)
-      @executor.post do
-        # make sure the background worker returns AR connection if it accidentally acquire one during serialization
-        ActiveRecord::Base.connection_pool.with_connection do
-          block.call
-        end
+    def _perform(&block)
+      # make sure the background worker returns AR connection if it accidentally acquire one during serialization
+      ActiveRecord::Base.connection_pool.with_connection do
+        block.call
       end
     end
   end

--- a/sentry-ruby/lib/sentry/background_worker.rb
+++ b/sentry-ruby/lib/sentry/background_worker.rb
@@ -12,6 +12,7 @@ module Sentry
       @max_queue = 30
       @number_of_threads = configuration.background_worker_threads
       @logger = configuration.logger
+      @debug = configuration.debug
 
       @executor =
         if configuration.async
@@ -34,7 +35,11 @@ module Sentry
 
     def perform(&block)
       @executor.post do
-        block.call
+        begin
+          block.call
+        rescue Exception => e
+          log_error("exception happened in background worker", e, debug: @debug)
+        end
       end
     end
   end

--- a/sentry-ruby/lib/sentry/background_worker.rb
+++ b/sentry-ruby/lib/sentry/background_worker.rb
@@ -33,14 +33,21 @@ module Sentry
         end
     end
 
+    # if you want to monkey-patch this method, please override `_perform` instead
     def perform(&block)
       @executor.post do
         begin
-          block.call
+          _perform(&block)
         rescue Exception => e
           log_error("exception happened in background worker", e, debug: @debug)
         end
       end
+    end
+
+    private
+
+    def _perform(&block)
+      block.call
     end
   end
 end


### PR DESCRIPTION
I assumed the block passed to `BackgroundWorker#perform` should already handle exceptions (e.g. `Client#send_event`). But #1618 showed it's not entirely true. So this PR adds exception logging to background worker and provide a safer approach to monkey patch its method.

Closes #1618