### PR TITLE
Fix HTTPTransport's ssl configuration

### DIFF
--- a/sentry-ruby/lib/sentry/transport/http_transport.rb
+++ b/sentry-ruby/lib/sentry/transport/http_transport.rb
@@ -139,10 +139,10 @@ module Sentry
     end
 
     def ssl_configuration
-      (@transport_configuration.ssl || {}).merge(
-        :verify => @transport_configuration.ssl_verification,
-        :ca_file => @transport_configuration.ssl_ca_file
-      )
+      {
+        verify: @transport_configuration.ssl_verification,
+        ca_file: @transport_configuration.ssl_ca_file
+      }.merge(@transport_configuration.ssl || {})
     end
   end
 end

--- a/sentry-ruby/spec/contexts/with_request_mock.rb
+++ b/sentry-ruby/spec/contexts/with_request_mock.rb
@@ -12,8 +12,8 @@ RSpec.shared_context "with request mock" do
   end
 
   def stub_request(fake_response, &block)
-    allow_any_instance_of(Net::HTTP).to receive(:transport_request) do |_, request|
-      block.call(request) if block
+    allow_any_instance_of(Net::HTTP).to receive(:transport_request) do |http_obj, request|
+      block.call(request, http_obj) if block
     end.and_return(fake_response)
   end
 

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Sentry::HTTPTransport do
   end
 
   describe "customizations" do
+    let(:fake_response) { build_fake_response("200") }
+
     it 'sets a custom User-Agent' do
       expect(subject.conn.headers[:user_agent]).to eq("sentry-ruby/#{Sentry::VERSION}")
     end
@@ -40,6 +42,18 @@ RSpec.describe Sentry::HTTPTransport do
       subject
 
       expect(builder).to have_received(:request).with(:instrumentation)
+    end
+
+    it "accepts custom proxy" do
+      configuration.transport.proxy = { uri:  URI("https://example.com"), user: "stan", password: "foobar" }
+
+      stub_request(fake_response) do |_, http_obj|
+        expect(http_obj.proxy_address).to eq("example.com")
+        expect(http_obj.proxy_user).to eq("stan")
+        expect(http_obj.proxy_pass).to eq("foobar")
+      end
+
+      subject.send_data(data)
     end
   end
 

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -55,6 +55,50 @@ RSpec.describe Sentry::HTTPTransport do
 
       subject.send_data(data)
     end
+
+    describe "ssl configurations" do
+      it "has the corrent default" do
+        stub_request(fake_response) do |_, http_obj|
+          expect(http_obj.verify_mode).to eq(1)
+          expect(http_obj.ca_file).to eq(nil)
+        end
+
+        subject.send_data(data)
+      end
+
+      it "accepts custom ssl_verification configuration" do
+        configuration.transport.ssl_verification = false
+
+        stub_request(fake_response) do |_, http_obj|
+          expect(http_obj.verify_mode).to eq(0)
+          expect(http_obj.ca_file).to eq(nil)
+        end
+
+        subject.send_data(data)
+      end
+
+      it "accepts custom ssl_ca_file configuration" do
+        configuration.transport.ssl_ca_file = "/tmp/foo"
+
+        stub_request(fake_response) do |_, http_obj|
+          expect(http_obj.verify_mode).to eq(1)
+          expect(http_obj.ca_file).to eq("/tmp/foo")
+        end
+
+        subject.send_data(data)
+      end
+
+      it "accepts custom ssl configuration" do
+        configuration.transport.ssl  = { verify: false, ca_file: "/tmp/foo" }
+
+        stub_request(fake_response) do |_, http_obj|
+          expect(http_obj.verify_mode).to eq(0)
+          expect(http_obj.ca_file).to eq("/tmp/foo")
+        end
+
+        subject.send_data(data)
+      end
+    end
   end
 
   describe "request payload" do


### PR DESCRIPTION
Transport's configuration allows users to configure ssl options with a Ruby hash:

```rb
configuration.transport.ssl = { key: value }
```

or with specific options:

```rb
configuration.transport.ssl_verification = false
configuration.transport.ssl_ca_file = file
```

But there's a bug that will always override the `ssl` (Hash) option's `verify` and `ca_file` values with specific options' values (usually `nil` in this case).

This bug seems to exist for years (from `sentry-raven` era), which makes me wonder if anyone really uses the `ssl` option 🤔 

The PR fixes the issue and adds tests for all transport configuration options.