### PR TITLE
Use prepended method instead of around_perform for ActiveJob integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Bug Fixes
+
+- Use prepended method instead of `around_perform` for `ActiveJob` integration [#1631](https://github.com/getsentry/sentry-ruby/pull/1631)
+  - Fixes [#956](https://github.com/getsentry/sentry-ruby/issues/956) and [#1629](https://github.com/getsentry/sentry-ruby/issues/1629)
+
 ## 4.8.1
 
 ### Bug Fixes

--- a/sentry-rails/app/jobs/sentry/send_event_job.rb
+++ b/sentry-rails/app/jobs/sentry/send_event_job.rb
@@ -16,8 +16,8 @@ if defined?(ActiveJob)
         discard_on ActiveJob::DeserializationError
       else
         # mimic what discard_on does for Rails 5.0
-        rescue_from ActiveJob::DeserializationError do
-          logger.error "Discarded #{self.class} due to a #{exception}. The original exception was #{error.cause.inspect}."
+        rescue_from ActiveJob::DeserializationError do |exception|
+          logger.error "Discarded #{self.class} due to a #{exception}. The original exception was #{exception.cause.inspect}."
         end
       end
 

--- a/sentry-rails/lib/sentry/rails/active_job.rb
+++ b/sentry-rails/lib/sentry/rails/active_job.rb
@@ -2,25 +2,21 @@ module Sentry
   module Rails
     module ActiveJobExtensions
       def perform_now
-        if Sentry.initialized?
-          if already_supported_by_specific_integration?(self)
-            super
-          else
-            Sentry.with_scope do |scope|
-              capture_and_reraise_with_sentry(self, scope) do
-                super
-              end
+        if !Sentry.initialized? || already_supported_by_sentry_integration?
+          super
+        else
+          Sentry.with_scope do |scope|
+            capture_and_reraise_with_sentry(scope) do
+              super
             end
           end
-        else
-          super
         end
       end
 
-      def capture_and_reraise_with_sentry(job, scope, &block)
-        scope.set_transaction_name(job.class.name)
+      def capture_and_reraise_with_sentry(scope, &block)
+        scope.set_transaction_name(self.class.name)
         transaction =
-          if job.is_a?(::Sentry::SendEventJob)
+          if is_a?(::Sentry::SendEventJob)
             nil
           else
             Sentry.start_transaction(name: scope.transaction_name, op: "active_job")
@@ -30,40 +26,40 @@ module Sentry
 
         block.call
 
-        finish_transaction(transaction, 200)
+        finish_sentry_transaction(transaction, 200)
       rescue Exception => e # rubocop:disable Lint/RescueException
-        finish_transaction(transaction, 500)
+        finish_sentry_transaction(transaction, 500)
 
         Sentry::Rails.capture_exception(
           e,
-          extra: sentry_context(job),
+          extra: sentry_context,
           tags: {
-            job_id: job.job_id,
-            provider_job_id: job.provider_job_id
+            job_id: job_id,
+            provider_job_id:provider_job_id
           }
         )
         raise e
       end
 
-      def finish_transaction(transaction, status)
+      def finish_sentry_transaction(transaction, status)
         return unless transaction
 
         transaction.set_http_status(status)
         transaction.finish
       end
 
-      def already_supported_by_specific_integration?(job)
-        Sentry.configuration.rails.skippable_job_adapters.include?(job.class.queue_adapter.class.to_s)
+      def already_supported_by_sentry_integration?
+        Sentry.configuration.rails.skippable_job_adapters.include?(self.class.queue_adapter.class.to_s)
       end
 
-      def sentry_context(job)
+      def sentry_context
         {
-          active_job: job.class.name,
-          arguments: job.arguments,
-          scheduled_at: job.scheduled_at,
-          job_id: job.job_id,
-          provider_job_id: job.provider_job_id,
-          locale: job.locale
+          active_job: self.class.name,
+          arguments: arguments,
+          scheduled_at: scheduled_at,
+          job_id: job_id,
+          provider_job_id: provider_job_id,
+          locale: locale
         }
       end
     end


### PR DESCRIPTION
Since the sdk registers its around_perform as the "first" callback, it needs to call all error handlers manually (which naturally should happen later) to see if it should report the exception.

Usually, this approach works well because if an exception will be handled later, handling it ealier doesn't make much of a difference.

However, as described in #956, if there's another exception happened inside one of the error handlers, it'll re-enter the error handler again in here: https://github.com/rails/rails/blob/38cb5610b1/activejob/lib/active_job/execution.rb#l50-l51

Of course, it may be possible to handle such case by adding more rescue block inside the `capture_and_reraise_with_sentry` method. But it'll force the entire exception handling flow to be performed inside the first `around_perform` block. And that's something we should avoid.

This also fixes a `rescue_from` callback issue in `Sentry::SendEventJob`.

Closes #956 and #1629 