### PR TITLE
Rewrite documents with yard

### DIFF
--- a/sentry-ruby/.yardopts
+++ b/sentry-ruby/.yardopts
@@ -1,0 +1,2 @@
+--exclude lib/sentry/utils/
+--exclude lib/sentry/core_ext

--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -22,3 +22,5 @@ gem "benchmark-ips"
 gem "benchmark_driver"
 gem "benchmark-ipsa"
 gem "benchmark-memory"
+
+gem "yard", "~> 0.9.27"

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -39,6 +39,7 @@ module Sentry
   THREAD_LOCAL = :sentry_hub
 
   class << self
+    # @!visibility private
     def exception_locals_tp
       @exception_locals_tp ||= TracePoint.new(:raise) do |tp|
         exception = tp.raised_exception
@@ -55,46 +56,60 @@ module Sentry
       end
     end
 
+    # @!attribute [rw] background_worker
+    #   @return [BackgroundWorker]
     attr_accessor :background_worker
 
     ##### Patch Registration #####
-    #
+
+    # @!visibility private
     def register_patch(&block)
       registered_patches << block
     end
 
+    # @!visibility private
     def apply_patches(config)
       registered_patches.each do |patch|
         patch.call(config)
       end
     end
 
+    # @!visibility private
     def registered_patches
       @registered_patches ||= []
     end
 
     ##### Integrations #####
-    #
+
     # Returns a hash that contains all the integrations that have been registered to the main SDK.
+    #
+    # @return [Hash{String=>Hash}]
     def integrations
       @integrations ||= {}
     end
 
     # Registers the SDK integration with its name and version.
+    #
+    # @param name [String] name of the integration
+    # @param version [String] version of the integration
     def register_integration(name, version)
       meta = { name: "sentry.ruby.#{name}", version: version }.freeze
       integrations[name.to_s] = meta
     end
 
     ##### Method Delegation #####
-    #
+
     extend Forwardable
 
     def_delegators :get_current_client, :configuration, :send_event
     def_delegators :get_current_scope, :set_tags, :set_extras, :set_user, :set_context
 
     ##### Main APIs #####
+
+    # Initializes the SDK with given configuration.
     #
+    # @yieldparam config [Configuration]
+    # @return [void]
     def init(&block)
       config = Configuration.new
       yield(config) if block_given?
@@ -116,24 +131,36 @@ module Sentry
       end
     end
 
+    # Returns true if the SDK is initialized.
+    #
+    # @return [Boolean]
+    def initialized?
+      !!@main_hub
+    end
+
     # Returns an uri for security policy reporting that's generated from the given DSN
     # (To learn more about security policy reporting: https://docs.sentry.io/product/security-policy-reporting/)
     #
     # It returns nil if
+    # - The SDK is not initialized yet.
+    # - The DSN is not provided or is invalid.
     #
-    # 1. The SDK is not initialized yet.
-    # 2. The DSN is not provided or is invalid.
+    # @return [String, nil]
     def csp_report_uri
       return unless initialized?
       configuration.csp_report_uri
     end
 
     # Returns the main thread's active hub.
+    #
+    # @return [Hub]
     def get_main_hub
       @main_hub
     end
 
     # Takes an instance of Sentry::Breadcrumb and stores it to the current active scope.
+    #
+    # @return [Breadcrumb, nil]
     def add_breadcrumb(breadcrumb, **options)
       get_current_hub&.add_breadcrumb(breadcrumb, **options)
     end
@@ -141,6 +168,8 @@ module Sentry
     # Returns the current active hub.
     # If the current thread doesn't have an active hub, it will clone the main thread's active hub,
     # stores it in the current thread, and then returns it.
+    #
+    # @return [Hub]
     def get_current_hub
       # we need to assign a hub to the current thread if it doesn't have one yet
       #
@@ -151,85 +180,105 @@ module Sentry
     end
 
     # Returns the current active client.
+    # @return [Client, nil]
     def get_current_client
       get_current_hub&.current_client
     end
 
     # Returns the current active scope.
+    #
+    # @return [Scope, nil]
     def get_current_scope
       get_current_hub&.current_scope
     end
 
     # Clones the main thread's active hub and stores it to the current thread.
+    #
+    # @return [void]
     def clone_hub_to_current_thread
       Thread.current.thread_variable_set(THREAD_LOCAL, get_main_hub.clone)
     end
 
     # Takes a block and yields the current active scope.
     #
-    # ```ruby
-    # Sentry.configure_scope do |scope|
-    #   scope.set_tags(foo: "bar")
-    # end
+    # @example
+    #   Sentry.configure_scope do |scope|
+    #     scope.set_tags(foo: "bar")
+    #   end
     #
-    # Sentry.capture_message("test message") # this event will have tags { foo: "bar" }
-    # ```
+    #   Sentry.capture_message("test message") # this event will have tags { foo: "bar" }
     #
+    # @yieldparam scope [Scope]
+    # @return [void]
     def configure_scope(&block)
       get_current_hub&.configure_scope(&block)
     end
 
     # Takes a block and yields a temporary scope.
     # The temporary scope will inherit all the attributes from the current active scope and replace it to be the active
-    # scope inside the block. For example:
+    # scope inside the block.
     #
-    # ```ruby
-    # Sentry.configure_scope do |scope|
-    #   scope.set_tags(foo: "bar")
-    # end
+    # @example
+    #   Sentry.configure_scope do |scope|
+    #     scope.set_tags(foo: "bar")
+    #   end
     #
-    # Sentry.capture_message("test message") # this event will have tags { foo: "bar" }
+    #   Sentry.capture_message("test message") # this event will have tags { foo: "bar" }
     #
-    # Sentry.with_scope do |temp_scope|
-    #   temp_scope.set_tags(foo: "baz")
-    #   Sentry.capture_message("test message 2") # this event will have tags { foo: "baz" }
-    # end
+    #   Sentry.with_scope do |temp_scope|
+    #     temp_scope.set_tags(foo: "baz")
+    #     Sentry.capture_message("test message 2") # this event will have tags { foo: "baz" }
+    #   end
     #
-    # Sentry.capture_message("test message 3") # this event will have tags { foo: "bar" }
-    # ```
+    #   Sentry.capture_message("test message 3") # this event will have tags { foo: "bar" }
     #
+    # @yieldparam scope [Scope]
+    # @return [void]
     def with_scope(&block)
       get_current_hub&.with_scope(&block)
     end
 
     # Takes an exception and reports it to Sentry via the currently active hub.
+    #
+    # @yieldparam scope [Scope]
+    # @return [Event, nil]
     def capture_exception(exception, **options, &block)
       get_current_hub&.capture_exception(exception, **options, &block)
     end
 
     # Takes a message string and reports it to Sentry via the currently active hub.
+    #
+    # @yieldparam scope [Scope]
+    # @return [Event, nil]
     def capture_message(message, **options, &block)
       get_current_hub&.capture_message(message, **options, &block)
     end
 
     # Takes an instance of Sentry::Event and dispatches it to the currently active hub.
+    #
+    # @return [Event, nil]
     def capture_event(event)
       get_current_hub&.capture_event(event)
     end
 
     # Takes or initializes a new Sentry::Transaction and makes a sampling decision for it.
+    #
+    # @return [Transaction, nil]
     def start_transaction(**options)
       get_current_hub&.start_transaction(**options)
     end
 
     # Returns the id of the lastly reported Sentry::Event.
+    #
+    # @return [String, nil]
     def last_event_id
       get_current_hub&.last_event_id
     end
 
 
     ##### Helpers #####
-    #
+
+    # @!visibility private
     def sys_command(command)
       result = `#{command} 2>&1` rescue nil
       return if result.nil? || result.empty? || ($CHILD_STATUS && $CHILD_STATUS.exitstatus != 0)
@@ -237,18 +286,17 @@ module Sentry
       result.strip
     end
 
-    def initialized?
-      !!@main_hub
-    end
-
+    # @!visibility private
     def logger
       configuration.logger
     end
 
+    # @!visibility private
     def sdk_meta
       META
     end
 
+    # @!visibility private
     def utc_now
       Time.now.utc
     end

--- a/sentry-ruby/lib/sentry/backtrace.rb
+++ b/sentry-ruby/lib/sentry/backtrace.rb
@@ -4,6 +4,7 @@
 
 module Sentry
   # Front end to parsing the backtrace for each notice
+  # @api private
   class Backtrace
     # Handles backtrace parsing line by line
     class Line

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -17,10 +17,15 @@ module Sentry
     # Directories to be recognized as part of your app. e.g. if you
     # have an `engines` dir at the root of your project, you may want
     # to set this to something like /(app|config|engines|lib)/
+    #
+    # @return [Regexp, nil]
     attr_accessor :app_dirs_pattern
 
     # Provide an object that responds to `call` to send events asynchronously.
     # E.g.: lambda { |event| Thread.new { Sentry.send_event(event) } }
+    #
+    # @deprecated It will be removed in the next major release. Please read https://github.com/getsentry/sentry-ruby/issues/1522 for more information
+    # @return [Proc, nil]
     attr_reader :async
 
     # to send events in a non-blocking way, sentry-ruby has its own background worker
@@ -30,74 +35,94 @@ module Sentry
     #
     # if you want to send events synchronously, set the value to 0
     # E.g.: config.background_worker_threads = 0
+    # @return [Integer]
     attr_accessor :background_worker_threads
 
     # a proc/lambda that takes an array of stack traces
     # it'll be used to silence (reduce) backtrace of the exception
     #
-    # for example:
+    # @example
+    #   config.backtrace_cleanup_callback = lambda do |backtrace|
+    #     Rails.backtrace_cleaner.clean(backtrace)
+    #   end
     #
-    # ```ruby
-    # Sentry.configuration.backtrace_cleanup_callback = lambda do |backtrace|
-    #   Rails.backtrace_cleaner.clean(backtrace)
-    # end
-    # ```
-    #
+    # @return [Proc]
     attr_accessor :backtrace_cleanup_callback
 
     # Optional Proc, called before adding the breadcrumb to the current scope
-    # E.g.: lambda { |breadcrumb, hint| breadcrumb }
-    # E.g.: lambda { |breadcrumb, hint| nil }
-    # E.g.: lambda { |breadcrumb, hint|
-    #   breadcrumb.message = 'a'
-    #   breadcrumb
-    # }
+    # @example
+    #   config.before = lambda do |breadcrumb, hint|
+    #     breadcrumb.message = 'a'
+    #     breadcrumb
+    #   end
+    # @return [Proc]
     attr_reader :before_breadcrumb
 
-    # Optional Proc, called before sending an event to the server/
-    # E.g.: lambda { |event, hint| event }
-    # E.g.: lambda { |event, hint| nil }
-    # E.g.: lambda { |event, hint|
-    #   event[:message] = 'a'
-    #   event
-    # }
+    # Optional Proc, called before sending an event to the server
+    # @example
+    #   config.before_send = lambda do |event, hint|
+    #     # skip ZeroDivisionError exceptions
+    #     # note: hint[:exception] would be a String if you use async callback
+    #     if hint[:exception].is_a?(ZeroDivisionError)
+    #       nil
+    #     else
+    #       event
+    #     end
+    #   end
+    # @return [Proc]
     attr_reader :before_send
 
     # An array of breadcrumbs loggers to be used. Available options are:
     # - :sentry_logger
+    # - :http_logger
+    #
+    # And if you also use sentry-rails:
     # - :active_support_logger
+    # - :monotonic_active_support_logger
+    #
+    # @return [Array<Symbol>]
     attr_reader :breadcrumbs_logger
 
     # Whether to capture local variables from the raised exception's frame. Default is false.
+    # @return [Boolean]
     attr_accessor :capture_exception_frame_locals
 
     # Max number of breadcrumbs a breadcrumb buffer can hold
+    # @return [Integer]
     attr_accessor :max_breadcrumbs
 
     # Number of lines of code context to capture, or nil for none
+    # @return [Integer, nil]
     attr_accessor :context_lines
 
     # RACK_ENV by default.
+    # @return [String]
     attr_reader :environment
 
     # Whether the SDK should run in the debugging mode. Default is false.
     # If set to true, SDK errors will be logged with backtrace
+    # @return [Boolean]
     attr_accessor :debug
 
     # the dsn value, whether it's set via `config.dsn=` or `ENV["SENTRY_DSN"]`
+    # @return [String]
     attr_reader :dsn
 
     # Whitelist of enabled_environments that will send notifications to Sentry. Array of Strings.
+    # @return [Array<String>]
     attr_accessor :enabled_environments
 
     # Logger 'progname's to exclude from breadcrumbs
+    # @return [Array<String>]
     attr_accessor :exclude_loggers
 
     # Array of exception classes that should never be sent. See IGNORE_DEFAULT.
     # You should probably append to this rather than overwrite it.
+    # @return [Array<String>]
     attr_accessor :excluded_exceptions
 
     # Boolean to check nested exceptions when deciding if to exclude. Defaults to true
+    # @return [Boolean]
     attr_accessor :inspect_exception_causes_for_exclusion
     alias inspect_exception_causes_for_exclusion? inspect_exception_causes_for_exclusion
 
@@ -108,65 +133,80 @@ module Sentry
 
     # Logger used by Sentry. In Rails, this is the Rails logger, otherwise
     # Sentry provides its own Sentry::Logger.
+    # @return [Logger]
     attr_accessor :logger
 
     # Project directory root for in_app detection. Could be Rails root, etc.
     # Set automatically for Rails.
+    # @return [String]
     attr_accessor :project_root
 
     # Insert sentry-trace to outgoing requests' headers
+    # @return [Boolean]
     attr_accessor :propagate_traces
 
     # Array of rack env parameters to be included in the event sent to sentry.
+    # @return [Array<String>]
     attr_accessor :rack_env_whitelist
 
     # Release tag to be passed with every event sent to Sentry.
     # We automatically try to set this to a git SHA or Capistrano release.
+    # @return [String]
     attr_accessor :release
 
     # The sampling factor to apply to events. A value of 0.0 will not send
     # any events, and a value of 1.0 will send 100% of events.
+    # @return [Float]
     attr_accessor :sample_rate
 
     # Include module versions in reports - boolean.
+    # @return [Boolean]
     attr_accessor :send_modules
 
     # When send_default_pii's value is false (default), sensitive information like
     # - user ip
     # - user cookie
     # - request body
+    # - query string
     # will not be sent to Sentry.
+    # @return [Boolean]
     attr_accessor :send_default_pii
 
     # Allow to skip Sentry emails within rake tasks
+    # @return [Boolean]
     attr_accessor :skip_rake_integration
 
     # IP ranges for trusted proxies that will be skipped when calculating IP address.
     attr_accessor :trusted_proxies
 
+    # @return [String]
     attr_accessor :server_name
 
     # Return a Transport::Configuration object for transport-related configurations.
+    # @return [Transport]
     attr_reader :transport
 
     # Take a float between 0.0 and 1.0 as the sample rate for tracing events (transactions).
+    # @return [Float]
     attr_accessor :traces_sample_rate
 
     # Take a Proc that controls the sample rate for every tracing event, e.g.
-    # ```
-    # lambda do |tracing_context|
-    #   # tracing_context[:transaction_context] contains the information about the transaction
-    #   # tracing_context[:parent_sampled] contains the transaction's parent's sample decision
-    #   true # return value can be a boolean or a float between 0.0 and 1.0
-    # end
-    # ```
+    # @example
+    #   config.traces_sampler =  lambda do |tracing_context|
+    #     # tracing_context[:transaction_context] contains the information about the transaction
+    #     # tracing_context[:parent_sampled] contains the transaction's parent's sample decision
+    #     true # return value can be a boolean or a float between 0.0 and 1.0
+    #   end
+    # @return [Proc]
     attr_accessor :traces_sampler
 
     # Send diagnostic client reports about dropped events, true by default
     # tries to attach to an existing envelope max once every 30s
+    # @return [Boolean]
     attr_accessor :send_client_reports
 
     # these are not config options
+    # @!visibility private
     attr_reader :errors, :gem_specs
 
     # Most of these errors generate 4XX responses. In general, Sentry clients
@@ -287,11 +327,6 @@ module Sentry
       Random.rand < sample_rate
     end
 
-    def error_messages
-      @errors = [@errors[0]] + @errors[1..-1].map(&:downcase) # fix case of all but first
-      @errors.join(", ")
-    end
-
     def exception_class_allowed?(exc)
       if exc.is_a?(Sentry::Error)
         # Try to prevent error reporting loops
@@ -313,6 +348,17 @@ module Sentry
       !!((@traces_sample_rate && @traces_sample_rate >= 0.0 && @traces_sample_rate <= 1.0) || @traces_sampler) && sending_allowed?
     end
 
+    # @return [String, nil]
+    def csp_report_uri
+      if dsn && dsn.valid?
+        uri = dsn.csp_report_uri
+        uri += "&sentry_release=#{CGI.escape(release)}" if release && !release.empty?
+        uri += "&sentry_environment=#{CGI.escape(environment)}" if environment && !environment.empty?
+        uri
+      end
+    end
+
+    # @api private
     def stacktrace_builder
       @stacktrace_builder ||= StacktraceBuilder.new(
         project_root: @project_root.to_s,
@@ -323,6 +369,7 @@ module Sentry
       )
     end
 
+    # @api private
     def detect_release
       return unless sending_allowed?
 
@@ -335,13 +382,10 @@ module Sentry
       log_error("Error detecting release", e, debug: debug)
     end
 
-    def csp_report_uri
-      if dsn && dsn.valid?
-        uri = dsn.csp_report_uri
-        uri += "&sentry_release=#{CGI.escape(release)}" if release && !release.empty?
-        uri += "&sentry_environment=#{CGI.escape(environment)}" if environment && !environment.empty?
-        uri
-      end
+    # @api private
+    def error_messages
+      @errors = [@errors[0]] + @errors[1..-1].map(&:downcase) # fix case of all but first
+      @errors.join(", ")
     end
 
     private

--- a/sentry-ruby/lib/sentry/envelope.rb
+++ b/sentry-ruby/lib/sentry/envelope.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Sentry
+  # @api private
   class Envelope
     def initialize(headers)
       @headers = headers

--- a/sentry-ruby/lib/sentry/linecache.rb
+++ b/sentry-ruby/lib/sentry/linecache.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Sentry
+  # @api private
   class LineCache
     def initialize
       @cache = {}

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -3,6 +3,7 @@
 require "net/http"
 
 module Sentry
+  # @api private
   module Net
     module HTTP
       OP_NAME = "net.http"

--- a/sentry-ruby/lib/sentry/rake.rb
+++ b/sentry-ruby/lib/sentry/rake.rb
@@ -6,6 +6,7 @@ require "rake/task"
 module Sentry
   module Rake
     module Application
+      # @api private
       def display_error_message(ex)
         Sentry.capture_exception(ex) do |scope|
           task_name = top_level_tasks.join(' ')
@@ -18,6 +19,7 @@ module Sentry
     end
 
     module Task
+      # @api private
       def execute(args=nil)
         return super unless Sentry.initialized? && Sentry.get_current_hub
 
@@ -27,5 +29,13 @@ module Sentry
   end
 end
 
-Rake::Application.prepend(Sentry::Rake::Application)
-Rake::Task.prepend(Sentry::Rake::Task)
+# @api private
+module Rake
+  class Application
+    prepend(Sentry::Rake::Application)
+  end
+
+  class Task
+    prepend(Sentry::Rake::Task)
+  end
+end

--- a/sentry-ruby/lib/sentry/release_detector.rb
+++ b/sentry-ruby/lib/sentry/release_detector.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Sentry
+  # @api private
   class ReleaseDetector
     class << self
       def detect_release(project_root:, running_on_heroku:)


### PR DESCRIPTION
Given that `yard` is still the major format for Ruby documentation, using it to document SDK will make it more accessible for our users. More importantly, it provides a format for type information, which will be essential when we later add documentation for `Sentry::Event` and different event interfaces.