### PR TITLE
Fixup `Net::HTTP` breadcrumb url & span creation when `Net::HTTP.start` is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Use prepended method instead of `around_perform` for `ActiveJob` integration [#1631](https://github.com/getsentry/sentry-ruby/pull/1631)
   - Fixes [#956](https://github.com/getsentry/sentry-ruby/issues/956) and [#1629](https://github.com/getsentry/sentry-ruby/issues/1629)
 - Fix `Net::HTTP` breadcrump url when using `Net::HTTP.new` [#1637](https://github.com/getsentry/sentry-ruby/pull/1637)
+- Fix trace span creation when using `Net::HTTP.start` [#1637](https://github.com/getsentry/sentry-ruby/pull/1637)
 
 ## 4.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Use prepended method instead of `around_perform` for `ActiveJob` integration [#1631](https://github.com/getsentry/sentry-ruby/pull/1631)
   - Fixes [#956](https://github.com/getsentry/sentry-ruby/issues/956) and [#1629](https://github.com/getsentry/sentry-ruby/issues/1629)
+- Fix `Net::HTTP` breadcrump url when using `Net::HTTP.new` [#1637](https://github.com/getsentry/sentry-ruby/pull/1637)
 
 ## 4.8.1
 

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -115,7 +115,7 @@ module Sentry
       end
 
       def extract_request_info(req)
-        uri = req.uri
+        uri = req.uri || URI.parse("#{use_ssl? ? 'https' : 'http'}://#{address}#{req.path}")
         url = "#{uri.scheme}://#{uri.host}#{uri.path}" rescue uri.to_s
         { method: req.method, url: url }
       end

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -23,45 +23,25 @@ module Sentry
       # end
       # ```
       #
-      # So when the entire flow looks like this:
-      #
-      # 1. #request is called.
-      #   - But because the request hasn't started yet, it calls #start (which then calls #do_start)
-      #   - At this moment @sentry_span is still nil, so #set_sentry_trace_header returns early
-      # 2. #do_start then creates a new Span and assigns it to @sentry_span
-      # 3. #request is called for the second time.
-      #   - This time @sentry_span should present. So #set_sentry_trace_header will set the sentry-trace header on the request object
-      # 4. Once the request finished, it
-      #   - Records a breadcrumb if http_logger is set
-      #   - Finishes the Span inside @sentry_span and clears the instance variable
-      #
+      # So we're only instrumenting request when `Net::HTTP` is already started
       def request(req, body = nil, &block)
-        set_sentry_trace_header(req)
+        return super unless started?
+
+        sentry_span = start_sentry_span
+        set_sentry_trace_header(req, sentry_span)
 
         super.tap do |res|
           record_sentry_breadcrumb(req, res)
-          record_sentry_span(req, res)
-        end
-      end
-
-      def do_start
-        super.tap do
-          start_sentry_span
-        end
-      end
-
-      def do_finish
-        super.tap do
-          finish_sentry_span
+          record_sentry_span(req, res, sentry_span)
         end
       end
 
       private
 
-      def set_sentry_trace_header(req)
-        return unless @sentry_span
+      def set_sentry_trace_header(req, sentry_span)
+        return unless sentry_span
 
-        trace = Sentry.get_current_client.generate_sentry_trace(@sentry_span)
+        trace = Sentry.get_current_client.generate_sentry_trace(sentry_span)
         req[SENTRY_TRACE_HEADER_NAME] = trace if trace
       end
 
@@ -84,29 +64,28 @@ module Sentry
         end
       end
 
-      def record_sentry_span(req, res)
-        if Sentry.initialized? && @sentry_span
+      def record_sentry_span(req, res, sentry_span)
+        if Sentry.initialized? && sentry_span
           request_info = extract_request_info(req)
-          @sentry_span.set_description("#{request_info[:method]} #{request_info[:url]}")
-          @sentry_span.set_data(:status, res.code.to_i)
+          sentry_span.set_description("#{request_info[:method]} #{request_info[:url]}")
+          sentry_span.set_data(:status, res.code.to_i)
+          finish_sentry_span(sentry_span)
         end
       end
 
       def start_sentry_span
-        if Sentry.initialized? && transaction = Sentry.get_current_scope.get_transaction
-          return if from_sentry_sdk?
-          return if transaction.sampled == false
+        return unless Sentry.initialized? && transaction = Sentry.get_current_scope.get_transaction
+        return if from_sentry_sdk?
+        return if transaction.sampled == false
 
-          child_span = transaction.start_child(op: OP_NAME, start_timestamp: Sentry.utc_now.to_f)
-          @sentry_span = child_span
-        end
+        transaction.start_child(op: OP_NAME, start_timestamp: Sentry.utc_now.to_f)
       end
 
-      def finish_sentry_span
-        if Sentry.initialized? && @sentry_span
-          @sentry_span.set_timestamp(Sentry.utc_now.to_f)
-          @sentry_span = nil
-        end
+      def finish_sentry_span(sentry_span)
+        return unless Sentry.initialized? && sentry_span
+
+        sentry_span.set_timestamp(Sentry.utc_now.to_f)
+        sentry_span = nil
       end
 
       def from_sentry_sdk?

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -41,6 +41,15 @@ RSpec.describe Sentry::Net::HTTP do
       crumb = Sentry.get_current_scope.breadcrumbs.peek
       expect(crumb.category).to eq("net.http")
       expect(crumb.data).to eq({ status: 200, method: "GET", url: "http://example.com/path" })
+
+      http = Net::HTTP.new("example.com")
+      request = Net::HTTP::Get.new("/path")
+      response = http.request(request)
+
+      expect(response.code).to eq("200")
+      crumb = Sentry.get_current_scope.breadcrumbs.peek
+      expect(crumb.category).to eq("net.http")
+      expect(crumb.data).to eq({ status: 200, method: "GET", url: "http://example.com/path" })
     end
 
     it "doesn't record breadcrumb for the SDK's request" do


### PR DESCRIPTION
**Please keep these instructions in mind so we can review it more efficiently:**

Right now we're not recording URL and creating single span for all the requests.

## Description
Not sure if body addition is a welcome change and if 100 is a good length, but  it would be useful for us.