### PR TITLE
Add tracing support to `ActionCable` integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
+### Features
+
 - Add Action Cable exception capturing (Rails 6+) [#1638](https://github.com/getsentry/sentry-ruby/pull/1638)
+- Add tracing support to `ActionCable` integration [#1640](https://github.com/getsentry/sentry-ruby/pull/1640)
 
 ### Bug Fixes
 

--- a/sentry-rails/lib/sentry/rails/action_cable.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable.rb
@@ -2,19 +2,39 @@ module Sentry
   module Rails
     module ActionCableExtensions
       class ErrorHandler
-        def self.capture(env, transaction_name:, extra_context: nil, &block)
-          Sentry.with_scope do |scope|
-            scope.set_rack_env(env)
-            scope.set_extras(action_cable: extra_context) if extra_context
-            scope.set_transaction_name(transaction_name)
+        class << self
+          def capture(env, transaction_name:, extra_context: nil, &block)
+            Sentry.with_scope do |scope|
+              scope.set_rack_env(env)
+              scope.set_extras(action_cable: extra_context) if extra_context
+              scope.set_transaction_name(transaction_name)
+              transaction = start_transaction(env, scope.transaction_name)
+              scope.set_span(transaction) if transaction
 
-            begin
-              block.call
-            rescue Exception => e # rubocop:disable Lint/RescueException
-              Sentry::Rails.capture_exception(e)
+              begin
+                block.call
+                finish_transaction(transaction, 200)
+              rescue Exception => e # rubocop:disable Lint/RescueException
+                Sentry::Rails.capture_exception(e)
+                finish_transaction(transaction, 500)
 
-              raise
+                raise
+              end
             end
+          end
+
+          def start_transaction(env, transaction_name)
+            sentry_trace = env["HTTP_SENTRY_TRACE"]
+            options = { name: transaction_name, op: "rails.action_cable".freeze }
+            transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, **options) if sentry_trace
+            Sentry.start_transaction(transaction: transaction, **options)
+          end
+
+          def finish_transaction(transaction, status_code)
+            return unless transaction
+
+            transaction.set_http_status(status_code)
+            transaction.finish
           end
         end
       end

--- a/sentry-rails/lib/sentry/rails/action_cable.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable.rb
@@ -6,7 +6,7 @@ module Sentry
           def capture(env, transaction_name:, extra_context: nil, &block)
             Sentry.with_scope do |scope|
               scope.set_rack_env(env)
-              scope.set_extras(action_cable: extra_context) if extra_context
+              scope.set_context("action_cable", extra_context) if extra_context
               scope.set_transaction_name(transaction_name)
               transaction = start_transaction(env, scope.transaction_name)
               scope.set_span(transaction) if transaction

--- a/sentry-rails/spec/sentry/rails/action_cable_spec.rb
+++ b/sentry-rails/spec/sentry/rails/action_cable_spec.rb
@@ -33,7 +33,6 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
     let(:transport) { Sentry.get_current_client.transport }
 
     after do
-      expect(Sentry.get_current_scope.extra).to eq({})
       transport.events = []
     end
 
@@ -48,14 +47,13 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
           expect(transport.events.count).to eq(1)
 
           event = transport.events.last.to_json_compatible
-
           expect(event).to include(
             "transaction" => "ChatChannel#subscribed",
-            "extra" => {
+            "contexts" => hash_including(
               "action_cable" => {
                 "params" => { "room_id" => 42 }
               }
-            }
+            )
           )
         end
       end
@@ -71,12 +69,12 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
 
           expect(event).to include(
             "transaction" => "AppearanceChannel#appear",
-            "extra" => {
+            "contexts" => hash_including(
               "action_cable" => {
                 "params" => { "room_id" => 42 },
                 "data" => { "action" => "appear", "foo" => "bar" }
               }
-            }
+            )
           )
         end
 
@@ -88,11 +86,11 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
 
           expect(event).to include(
             "transaction" => "AppearanceChannel#unsubscribed",
-            "extra" => {
+            "contexts" => hash_including(
               "action_cable" => {
                 "params" => { "room_id" => 42 }
               }
-            }
+            )
           )
         end
       end
@@ -114,29 +112,27 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
 
           expect(event).to include(
             "transaction" => "ChatChannel#subscribed",
-            "extra" => {
+            "contexts" => hash_including(
               "action_cable" => {
                 "params" => { "room_id" => 42 }
               }
-            }
+            )
           )
 
           transaction = transport.events.last.to_json_compatible
 
           expect(transaction).to include(
             "type" => "transaction",
+            "transaction" => "ChatChannel#subscribed",
             "contexts" => hash_including(
+              "action_cable" => {
+                "params" => { "room_id" => 42 }
+              },
               "trace" => hash_including(
                 "op" => "rails.action_cable",
                 "status" => "internal_error"
               )
-            ),
-            "transaction" => "ChatChannel#subscribed",
-            "extra" => {
-              "action_cable" => {
-                "params" => { "room_id" => 42 }
-              }
-            }
+            )
           )
         end
       end
@@ -156,26 +152,24 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
               "trace" => hash_including(
                 "op" => "rails.action_cable",
                 "status" => "ok"
-              )
-            ),
-            "transaction" => "AppearanceChannel#subscribed",
-            "extra" => {
+              ),
               "action_cable" => {
                 "params" => { "room_id" => 42 }
               }
-            }
+            ),
+            "transaction" => "AppearanceChannel#subscribed"
           )
 
           event = transport.events[1].to_json_compatible
 
           expect(event).to include(
             "transaction" => "AppearanceChannel#appear",
-            "extra" => {
+            "contexts" => hash_including(
               "action_cable" => {
                 "params" => { "room_id" => 42 },
                 "data" => { "action" => "appear", "foo" => "bar" }
               }
-            }
+            )
           )
 
           action_transaction = transport.events[2].to_json_compatible
@@ -186,15 +180,13 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
               "trace" => hash_including(
                 "op" => "rails.action_cable",
                 "status" => "internal_error"
-              )
-            ),
-            "transaction" => "AppearanceChannel#appear",
-            "extra" => {
+              ),
               "action_cable" => {
                 "params" => { "room_id" => 42 },
                 "data" => { "action" => "appear", "foo" => "bar" }
               }
-            }
+            ),
+            "transaction" => "AppearanceChannel#appear"
           )
         end
 
@@ -210,25 +202,23 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
               "trace" => hash_including(
                 "op" => "rails.action_cable",
                 "status" => "ok"
-              )
-            ),
-            "transaction" => "AppearanceChannel#subscribed",
-            "extra" => {
+              ),
               "action_cable" => {
                 "params" => { "room_id" => 42 }
               }
-            }
+            ),
+            "transaction" => "AppearanceChannel#subscribed"
           )
 
           event = transport.events[1].to_json_compatible
 
           expect(event).to include(
             "transaction" => "AppearanceChannel#unsubscribed",
-            "extra" => {
+            "contexts" => hash_including(
               "action_cable" => {
                 "params" => { "room_id" => 42 }
               }
-            }
+            )
           )
 
           transaction = transport.events[2].to_json_compatible
@@ -239,14 +229,12 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
               "trace" => hash_including(
                 "op" => "rails.action_cable",
                 "status" => "internal_error"
-              )
-            ),
-            "transaction" => "AppearanceChannel#unsubscribed",
-            "extra" => {
+              ),
               "action_cable" => {
                 "params" => { "room_id" => 42 }
               }
-            }
+            ),
+            "transaction" => "AppearanceChannel#unsubscribed"
           )
         end
       end

--- a/sentry-rails/spec/sentry/rails/action_cable_spec.rb
+++ b/sentry-rails/spec/sentry/rails/action_cable_spec.rb
@@ -47,14 +47,8 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
           expect(transport.events.count).to eq(1)
 
           event = transport.events.last.to_json_compatible
-          expect(event).to include(
-            "transaction" => "ChatChannel#subscribed",
-            "contexts" => hash_including(
-              "action_cable" => {
-                "params" => { "room_id" => 42 }
-              }
-            )
-          )
+          expect(event["transaction"]).to eq("ChatChannel#subscribed")
+          expect(event["contexts"]).to include("action_cable" => { "params" => { "room_id" => 42 } })
         end
       end
 
@@ -67,14 +61,12 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
 
           event = transport.events.last.to_json_compatible
 
-          expect(event).to include(
-            "transaction" => "AppearanceChannel#appear",
-            "contexts" => hash_including(
-              "action_cable" => {
-                "params" => { "room_id" => 42 },
-                "data" => { "action" => "appear", "foo" => "bar" }
-              }
-            )
+          expect(event["transaction"]).to eq("AppearanceChannel#appear")
+          expect(event["contexts"]).to include(
+            "action_cable" => {
+              "params" => { "room_id" => 42 },
+              "data" => { "action" => "appear", "foo" => "bar" }
+            }
           )
         end
 
@@ -84,13 +76,11 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
 
           event = transport.events.last.to_json_compatible
 
-          expect(event).to include(
-            "transaction" => "AppearanceChannel#unsubscribed",
-            "contexts" => hash_including(
-              "action_cable" => {
-                "params" => { "room_id" => 42 }
-              }
-            )
+          expect(event["transaction"]).to eq("AppearanceChannel#unsubscribed")
+          expect(event["contexts"]).to include(
+            "action_cable" => {
+              "params" => { "room_id" => 42 }
+            }
           )
         end
       end
@@ -110,28 +100,22 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
 
           event = transport.events.first.to_json_compatible
 
-          expect(event).to include(
-            "transaction" => "ChatChannel#subscribed",
-            "contexts" => hash_including(
-              "action_cable" => {
-                "params" => { "room_id" => 42 }
-              }
-            )
-          )
+          expect(event["transaction"]).to eq("ChatChannel#subscribed")
+          expect(event["contexts"]).to include("action_cable" => { "params" => { "room_id" => 42 } })
 
           transaction = transport.events.last.to_json_compatible
 
-          expect(transaction).to include(
-            "type" => "transaction",
-            "transaction" => "ChatChannel#subscribed",
-            "contexts" => hash_including(
-              "action_cable" => {
-                "params" => { "room_id" => 42 }
-              },
-              "trace" => hash_including(
-                "op" => "rails.action_cable",
-                "status" => "internal_error"
-              )
+          expect(transaction["type"]).to eq("transaction")
+          expect(transaction["transaction"]).to eq("ChatChannel#subscribed")
+          expect(transaction["contexts"]).to include(
+            "action_cable" => {
+              "params" => { "room_id" => 42 }
+            }
+          )
+          expect(transaction["contexts"]).to include(
+            "trace" => hash_including(
+              "op" => "rails.action_cable",
+              "status" => "internal_error"
             )
           )
         end
@@ -146,47 +130,45 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
 
           subscription_transaction = transport.events[0].to_json_compatible
 
-          expect(subscription_transaction).to include(
-            "type" => "transaction",
-            "contexts" => hash_including(
-              "trace" => hash_including(
-                "op" => "rails.action_cable",
-                "status" => "ok"
-              ),
-              "action_cable" => {
-                "params" => { "room_id" => 42 }
-              }
-            ),
-            "transaction" => "AppearanceChannel#subscribed"
+          expect(subscription_transaction["type"]).to eq("transaction")
+          expect(subscription_transaction["transaction"]).to eq("AppearanceChannel#subscribed")
+          expect(subscription_transaction["contexts"]).to include(
+            "action_cable" => {
+              "params" => { "room_id" => 42 }
+            }
+          )
+          expect(subscription_transaction["contexts"]).to include(
+            "trace" => hash_including(
+              "op" => "rails.action_cable",
+              "status" => "ok"
+            )
           )
 
           event = transport.events[1].to_json_compatible
 
-          expect(event).to include(
-            "transaction" => "AppearanceChannel#appear",
-            "contexts" => hash_including(
-              "action_cable" => {
-                "params" => { "room_id" => 42 },
-                "data" => { "action" => "appear", "foo" => "bar" }
-              }
-            )
+          expect(event["transaction"]).to eq("AppearanceChannel#appear")
+          expect(event["contexts"]).to include(
+            "action_cable" => {
+              "params" => { "room_id" => 42 },
+              "data" => { "action" => "appear", "foo" => "bar" }
+            }
           )
 
           action_transaction = transport.events[2].to_json_compatible
 
-          expect(action_transaction).to include(
-            "type" => "transaction",
-            "contexts" => hash_including(
-              "trace" => hash_including(
-                "op" => "rails.action_cable",
-                "status" => "internal_error"
-              ),
-              "action_cable" => {
-                "params" => { "room_id" => 42 },
-                "data" => { "action" => "appear", "foo" => "bar" }
-              }
-            ),
-            "transaction" => "AppearanceChannel#appear"
+          expect(action_transaction["type"]).to eq("transaction")
+          expect(action_transaction["transaction"]).to eq("AppearanceChannel#appear")
+          expect(action_transaction["contexts"]).to include(
+            "action_cable" => {
+              "params" => { "room_id" => 42 },
+              "data" => { "action" => "appear", "foo" => "bar" }
+            }
+          )
+          expect(action_transaction["contexts"]).to include(
+            "trace" => hash_including(
+              "op" => "rails.action_cable",
+              "status" => "internal_error"
+            )
           )
         end
 
@@ -196,45 +178,43 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
 
           subscription_transaction = transport.events[0].to_json_compatible
 
-          expect(subscription_transaction).to include(
-            "type" => "transaction",
-            "contexts" => hash_including(
-              "trace" => hash_including(
-                "op" => "rails.action_cable",
-                "status" => "ok"
-              ),
-              "action_cable" => {
-                "params" => { "room_id" => 42 }
-              }
-            ),
-            "transaction" => "AppearanceChannel#subscribed"
+          expect(subscription_transaction["type"]).to eq("transaction")
+          expect(subscription_transaction["transaction"]).to eq("AppearanceChannel#subscribed")
+          expect(subscription_transaction["contexts"]).to include(
+            "action_cable" => {
+              "params" => { "room_id" => 42 }
+            }
+          )
+          expect(subscription_transaction["contexts"]).to include(
+            "trace" => hash_including(
+              "op" => "rails.action_cable",
+              "status" => "ok"
+            )
           )
 
           event = transport.events[1].to_json_compatible
 
-          expect(event).to include(
-            "transaction" => "AppearanceChannel#unsubscribed",
-            "contexts" => hash_including(
-              "action_cable" => {
-                "params" => { "room_id" => 42 }
-              }
-            )
+          expect(event["transaction"]).to eq("AppearanceChannel#unsubscribed")
+          expect(event["contexts"]).to include(
+            "action_cable" => {
+              "params" => { "room_id" => 42 }
+            }
           )
 
           transaction = transport.events[2].to_json_compatible
 
-          expect(transaction).to include(
-            "type" => "transaction",
-            "contexts" => hash_including(
-              "trace" => hash_including(
-                "op" => "rails.action_cable",
-                "status" => "internal_error"
-              ),
-              "action_cable" => {
-                "params" => { "room_id" => 42 }
-              }
-            ),
-            "transaction" => "AppearanceChannel#unsubscribed"
+          expect(transaction["type"]).to eq("transaction")
+          expect(transaction["transaction"]).to eq("AppearanceChannel#unsubscribed")
+          expect(transaction["contexts"]).to include(
+            "action_cable" => {
+              "params" => { "room_id" => 42 }
+            }
+          )
+          expect(transaction["contexts"]).to include(
+            "trace" => hash_including(
+              "op" => "rails.action_cable",
+              "status" => "internal_error"
+            )
           )
         end
       end

--- a/sentry-rails/spec/sentry/rails/action_cable_spec.rb
+++ b/sentry-rails/spec/sentry/rails/action_cable_spec.rb
@@ -2,6 +2,8 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
   require "spec_helper"
   require "action_cable/engine"
 
+  ::ActionCable.server.config.cable = { "adapter" => "test" }
+
   # ensure we can access `connection.env` in tests like we can in production
   ActiveSupport.on_load :action_cable_channel_test_case do
     class ::ActionCable::Channel::ConnectionStub
@@ -30,9 +32,8 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
   RSpec.describe "Sentry::Rails::ActionCableExtensions", type: :channel do
     let(:transport) { Sentry.get_current_client.transport }
 
-    before(:all) do
+    before do
       make_basic_app
-      ::ActionCable.server.config.cable = { "adapter" => "test" }
     end
 
     after do


### PR DESCRIPTION
1. Add tracing support.
<img width="80%" alt="截圖 2021-12-12 20 21 06" src="https://user-images.githubusercontent.com/5079556/145728195-cb6c4855-4c26-4d23-9572-9e590ddc19e4.png">


2. Use `contexts` instead of `extras` for the additional data.
<img width="80%" alt="截圖 2021-12-12 20 19 58" src="https://user-images.githubusercontent.com/5079556/145728135-c174ec4f-42b8-4028-bce3-1684de5dc5b6.png">
