### PR TITLE
Add query string & body to `Net::HTTP` breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
+### Features
+
 - Add Action Cable exception capturing (Rails 6+) [#1638](https://github.com/getsentry/sentry-ruby/pull/1638)
+- Add query string to `Net::HTTP` breadcrumb [#1637](https://github.com/getsentry/sentry-ruby/pull/1637)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 - Add Action Cable exception capturing (Rails 6+) [#1638](https://github.com/getsentry/sentry-ruby/pull/1638)
-- Add query string to `Net::HTTP` breadcrumb [#1637](https://github.com/getsentry/sentry-ruby/pull/1637)
+- Add request body & query string to `Net::HTTP` breadcrumb [#1637](https://github.com/getsentry/sentry-ruby/pull/1637)
 
 ### Bug Fixes
 

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -50,14 +50,15 @@ module Sentry
         return if from_sentry_sdk?
 
         request_info = extract_request_info(req)
+        request_info[:body] = req.body if Sentry.configuration.send_default_pii
+
         crumb = Sentry::Breadcrumb.new(
           level: :info,
           category: OP_NAME,
           type: :info,
           data: {
-            method: request_info[:method],
-            url: request_info[:url],
-            status: res.code.to_i
+            status: res.code.to_i,
+            **request_info
           }
         )
         Sentry.add_breadcrumb(crumb)

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -93,8 +93,12 @@ module Sentry
 
       def extract_request_info(req)
         uri = req.uri || URI.parse("#{use_ssl? ? 'https' : 'http'}://#{address}#{req.path}")
-        url = "#{uri.scheme}://#{uri.host}#{uri.path}" rescue uri.to_s
+        url = "#{uri.scheme}://#{uri.host}#{uri.path}"
+        url = "#{url}?#{uri.query}" if uri.query && Sentry.configuration.send_default_pii
+
         { method: req.method, url: url }
+      rescue
+        { method: req.method, url: url.to_s }
       end
     end
   end


### PR DESCRIPTION
## Description
They are useful, let's add them.
This is on top of https://github.com/getsentry/sentry-ruby/pull/1637 because they're touching the same code and probably #1637 would be merged faster.
