### PR TITLE
Be able to add event's tags to exception object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Add Action Cable exception capturing (Rails 6+) [#1638](https://github.com/getsentry/sentry-ruby/pull/1638)
+- Be able to define exception tags from the exception itself. [#1650](https://github.com/getsentry/sentry-ruby/pull/1650)
 
 ### Bug Fixes
 

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -139,6 +139,10 @@ module Sentry
         @extra.merge!(exception.sentry_context)
       end
 
+      if exception.respond_to?(:sentry_tags)
+        @tags.merge!(exception.sentry_tags)
+      end
+
       @exception = Sentry::ExceptionInterface.build(exception: exception, stacktrace_builder: configuration.stacktrace_builder)
     end
 

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -6,6 +6,13 @@ class ExceptionWithContext < StandardError
       foo: "bar"
     }
   end
+
+  def sentry_tags
+    {
+      a: 'b',
+      c: 'd'
+    }
+  end
 end
 
 RSpec.describe Sentry::Client do
@@ -353,6 +360,17 @@ RSpec.describe Sentry::Client do
 
         it "merges the context into event's extra" do
           expect(hash[:extra][:foo]).to eq('bar')
+        end
+      end
+
+      context 'when the exception responds to sentry_tags' do
+        let(:hash) do
+          event = subject.event_from_exception(ExceptionWithContext.new)
+          event.to_hash
+        end
+
+        it "merges the tags into event's tags" do
+          expect(hash[:tags]).to eq( a: 'b', c: 'd')
         end
       end
     end


### PR DESCRIPTION
Like for `sentry_context` we want to be able to define a method in our exception to provide additional tags to the Sentry event.