### PR TITLE
Deprecate unnecessarily exposed attributes

### DIFF
--- a/sentry-ruby/lib/sentry/background_worker.rb
+++ b/sentry-ruby/lib/sentry/background_worker.rb
@@ -8,7 +8,9 @@ module Sentry
   class BackgroundWorker
     include LoggingHelper
 
-    attr_reader :max_queue, :number_of_threads, :logger
+    attr_reader :max_queue, :number_of_threads
+    # @deprecated Use Sentry.logger to retrieve the current logger instead.
+    attr_reader :logger
     attr_accessor :shutdown_timeout
 
     def initialize(configuration)

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -6,7 +6,10 @@ module Sentry
   class Client
     include LoggingHelper
 
-    attr_reader :transport, :configuration, :logger
+    attr_reader :transport, :configuration
+
+    # @deprecated Use Sentry.logger to retrieve the current logger instead.
+    attr_reader :logger
 
     def initialize(configuration)
       @configuration = configuration

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -14,12 +14,15 @@ module Sentry
 
     include LoggingHelper
 
-    attr_reader :name, :parent_sampled, :hub
+    attr_reader :name, :parent_sampled
 
-    # @deprecated Use Sentry.configuration to retrieve the current configuration instead.
+    # @deprecated Use Sentry.get_current_hub instead.
+    attr_reader :hub
+
+    # @deprecated Use Sentry.configuration instead.
     attr_reader :configuration
 
-    # @deprecated Use Sentry.logger to retrieve the current logger instead.
+    # @deprecated Use Sentry.logger instead.
     attr_reader :logger
 
     def initialize(name: nil, parent_sampled: nil, hub:, **options)

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -14,7 +14,10 @@ module Sentry
 
     include LoggingHelper
 
-    attr_reader :name, :parent_sampled, :hub, :configuration
+    attr_reader :name, :parent_sampled, :hub
+
+    # @deprecated Use Sentry.configuration to retrieve the current configuration instead.
+    attr_reader :configuration
 
     # @deprecated Use Sentry.logger to retrieve the current logger instead.
     attr_reader :logger
@@ -26,8 +29,11 @@ module Sentry
       @parent_sampled = parent_sampled
       @transaction = self
       @hub = hub
-      @configuration = hub.configuration
-      @logger = configuration.logger
+      @configuration = hub.configuration # to be removed
+      @tracing_enabled = hub.configuration.tracing_enabled?
+      @traces_sampler = hub.configuration.traces_sampler
+      @traces_sample_rate = hub.configuration.traces_sample_rate
+      @logger = hub.configuration.logger
       init_span_recorder
     end
 
@@ -69,22 +75,20 @@ module Sentry
     end
 
     def set_initial_sample_decision(sampling_context:)
-      unless configuration.tracing_enabled?
+      unless @tracing_enabled
         @sampled = false
         return
       end
 
       return unless @sampled.nil?
 
-      traces_sampler = configuration.traces_sampler
-
       sample_rate =
-        if traces_sampler.is_a?(Proc)
-          traces_sampler.call(sampling_context)
+        if @traces_sampler.is_a?(Proc)
+          @traces_sampler.call(sampling_context)
         elsif !sampling_context[:parent_sampled].nil?
           sampling_context[:parent_sampled]
         else
-          configuration.traces_sample_rate
+          @traces_sample_rate
         end
 
       transaction_description = generate_transaction_description

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -14,7 +14,10 @@ module Sentry
 
     include LoggingHelper
 
-    attr_reader :name, :parent_sampled, :hub, :configuration, :logger
+    attr_reader :name, :parent_sampled, :hub, :configuration
+
+    # @deprecated Use Sentry.logger to retrieve the current logger instead.
+    attr_reader :logger
 
     def initialize(name: nil, parent_sampled: nil, hub:, **options)
       super(**options)

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -23,7 +23,10 @@ module Sentry
 
     include LoggingHelper
 
-    attr_reader :logger, :rate_limits, :discarded_events, :last_client_report_sent
+    attr_reader :rate_limits, :discarded_events, :last_client_report_sent
+
+    # @deprecated Use Sentry.logger to retrieve the current logger instead.
+    attr_reader :logger
 
     def initialize(configuration)
       @logger = configuration.logger

--- a/sentry-ruby/lib/sentry/utils/logging_helper.rb
+++ b/sentry-ruby/lib/sentry/utils/logging_helper.rb
@@ -6,21 +6,21 @@ module Sentry
       message = "#{message}: #{exception.message}"
       message += "\n#{exception.backtrace.join("\n")}" if debug
 
-      logger.error(LOGGER_PROGNAME) do
+      @logger.error(LOGGER_PROGNAME) do
         message
       end
     end
 
     def log_info(message)
-      logger.info(LOGGER_PROGNAME) { message }
+      @logger.info(LOGGER_PROGNAME) { message }
     end
 
     def log_debug(message)
-      logger.debug(LOGGER_PROGNAME) { message }
+      @logger.debug(LOGGER_PROGNAME) { message }
     end
 
     def log_warn(message)
-      logger.warn(LOGGER_PROGNAME) { message }
+      @logger.warn(LOGGER_PROGNAME) { message }
     end
   end
 end

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -263,18 +263,18 @@ RSpec.describe Sentry::Transaction do
         it "uses the genereted rate for sampling (positive)" do
           expect(Sentry.configuration.logger).to receive(:debug).exactly(3).and_call_original
 
-          subject = described_class.new(hub: Sentry.get_current_hub)
           Sentry.configuration.traces_sampler = -> (_) { true }
+          subject = described_class.new(hub: Sentry.get_current_hub)
           subject.set_initial_sample_decision(sampling_context: {})
           expect(subject.sampled).to eq(true)
 
-          subject = described_class.new(hub: Sentry.get_current_hub)
           Sentry.configuration.traces_sampler = -> (_) { 1.0 }
+          subject = described_class.new(hub: Sentry.get_current_hub)
           subject.set_initial_sample_decision(sampling_context: {})
           expect(subject.sampled).to eq(true)
 
-          subject = described_class.new(hub: Sentry.get_current_hub)
           Sentry.configuration.traces_sampler = -> (_) { 1 }
+          subject = described_class.new(hub: Sentry.get_current_hub)
           subject.set_initial_sample_decision(sampling_context: {})
           expect(subject.sampled).to eq(true)
 
@@ -286,13 +286,13 @@ RSpec.describe Sentry::Transaction do
         it "uses the genereted rate for sampling (negative)" do
           expect(Sentry.configuration.logger).to receive(:debug).exactly(2).and_call_original
 
-          subject = described_class.new(hub: Sentry.get_current_hub)
           Sentry.configuration.traces_sampler = -> (_) { false }
+          subject = described_class.new(hub: Sentry.get_current_hub)
           subject.set_initial_sample_decision(sampling_context: {})
           expect(subject.sampled).to eq(false)
 
-          subject = described_class.new(hub: Sentry.get_current_hub)
           Sentry.configuration.traces_sampler = -> (_) { 0.0 }
+          subject = described_class.new(hub: Sentry.get_current_hub)
           subject.set_initial_sample_decision(sampling_context: {})
           expect(subject.sampled).to eq(false)
 
@@ -374,7 +374,7 @@ RSpec.describe Sentry::Transaction do
 
       it "records lost event" do
         subject.finish
-        expect(subject.hub.current_client.transport).to have_recorded_lost_event(:sample_rate, 'transaction')
+        expect(Sentry.get_current_client.transport).to have_recorded_lost_event(:sample_rate, 'transaction')
       end
     end
 

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -377,12 +377,12 @@ RSpec.describe Sentry do
         end
 
         it "provides proper sampling context to the traces_sampler" do
-          transaction = Sentry::Transaction.new(op: "foo", hub: Sentry.get_current_hub)
-
           context = nil
           Sentry.configuration.traces_sampler = lambda do |sampling_context|
             context = sampling_context
           end
+
+          transaction = Sentry::Transaction.new(op: "foo", hub: Sentry.get_current_hub)
 
           described_class.start_transaction(transaction: transaction)
 
@@ -391,12 +391,12 @@ RSpec.describe Sentry do
         end
 
         it "passes parent_sampled to the sampling_context" do
-          transaction = Sentry::Transaction.new(parent_sampled: true, hub: Sentry.get_current_hub)
-
           context = nil
           Sentry.configuration.traces_sampler = lambda do |sampling_context|
             context = sampling_context
           end
+
+          transaction = Sentry::Transaction.new(parent_sampled: true, hub: Sentry.get_current_hub)
 
           described_class.start_transaction(transaction: transaction)
 


### PR DESCRIPTION
Although they probably aren't used by anyone, directly removing them can still break some users' apps. So I decide to remove them later in version 5.0.0.