### PR TITLE
Explicitly passing Rack related configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,15 @@ When `config.send_default_pii` is set as `true`, `:http_logger` will include que
 
 - Rewrite documents with yard [#1635](https://github.com/getsentry/sentry-ruby/pull/1635)
 - Document Transaction and Span classes [#1653](https://github.com/getsentry/sentry-ruby/pull/1653)
+- Document Client and Scope classes [#1659](https://github.com/getsentry/sentry-ruby/pull/1659)
 
 ### Refactoring
 
 - Minor improvements on Net::HTTP patch [#1651](https://github.com/getsentry/sentry-ruby/pull/1651)
 - Deprecate unnecessarily exposed attributes [#1652](https://github.com/getsentry/sentry-ruby/pull/1652)
 - Refactor Net::HTTP patch [#1656](https://github.com/getsentry/sentry-ruby/pull/1656)
+- Deprecate Event#configuration [#1661](https://github.com/getsentry/sentry-ruby/pull/1661)
+- Explicitly passing Rack related configurations [#1662](https://github.com/getsentry/sentry-ruby/pull/1662)
 
 ## 4.8.1
 

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -22,7 +22,7 @@ module Sentry
 
     MAX_MESSAGE_SIZE_IN_BYTES = 1024 * 8
 
-    SKIP_INSPECTION_ATTRIBUTES = [:@modules, :@backtrace, :@stacktrace_builder, :@send_default_pii, :@trusted_proxies]
+    SKIP_INSPECTION_ATTRIBUTES = [:@modules, :@backtrace, :@stacktrace_builder, :@send_default_pii, :@trusted_proxies, :@rack_env_whitelist]
 
     include CustomInspection
 
@@ -55,6 +55,7 @@ module Sentry
       @send_default_pii = configuration.send_default_pii
       @trusted_proxies = configuration.trusted_proxies
       @stacktrace_builder = configuration.stacktrace_builder
+      @rack_env_whitelist = configuration.rack_env_whitelist
 
       @message = (message || "").byteslice(0..MAX_MESSAGE_SIZE_IN_BYTES)
 
@@ -132,7 +133,7 @@ module Sentry
     end
 
     def add_request_interface(env)
-      @request = Sentry::RequestInterface.build(env: env)
+      @request = Sentry::RequestInterface.build(env: env, send_default_pii: @send_default_pii, rack_env_whitelist: @rack_env_whitelist)
     end
 
     def add_threads_interface(backtrace: nil, **options)


### PR DESCRIPTION
Since `RequestInterface` is directly initialized from `Event`, it's entirely possible to pass everything it needs with method calls. 

This change will make `RequestInterface`'s dependencies clearer and shouldn't break any user program (interfaces shouldn't be initialized manually).