### PR TITLE
Merge back 4.8.2 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,11 @@ When `config.send_default_pii` is set as `true`, `:http_logger` will include que
 
 ### Bug Fixes
 
-- Use prepended method instead of `around_perform` for `ActiveJob` integration [#1631](https://github.com/getsentry/sentry-ruby/pull/1631)
-  - Fixes [#956](https://github.com/getsentry/sentry-ruby/issues/956) and [#1629](https://github.com/getsentry/sentry-ruby/issues/1629)
-- Remove unnecessary ActiveJob inclusion [#1655](https://github.com/getsentry/sentry-ruby/pull/1655)
 - Fix `Net::HTTP` breadcrump url when using `Net::HTTP.new` [#1637](https://github.com/getsentry/sentry-ruby/pull/1637)
 - Fix trace span creation when using `Net::HTTP.start` [#1637](https://github.com/getsentry/sentry-ruby/pull/1637)
-- Lock faraday to version 1.x [#1664](https://github.com/getsentry/sentry-ruby/pull/1664)
-  - This is a temporary effort to avoid dependency issue with `faraday 2.0` and `faraday` will be removed from dependencies very soon. 
-    See [this comment](https://github.com/getsentry/sentry-ruby/issues/1663) for more information about our plan to remove it.
 
 ### Documentation
 
-- Rewrite documents with yard [#1635](https://github.com/getsentry/sentry-ruby/pull/1635)
 - Document Transaction and Span classes [#1653](https://github.com/getsentry/sentry-ruby/pull/1653)
 - Document Client and Scope classes [#1659](https://github.com/getsentry/sentry-ruby/pull/1659)
 
@@ -33,6 +26,21 @@ When `config.send_default_pii` is set as `true`, `:http_logger` will include que
 - Refactor Net::HTTP patch [#1656](https://github.com/getsentry/sentry-ruby/pull/1656)
 - Deprecate Event#configuration [#1661](https://github.com/getsentry/sentry-ruby/pull/1661)
 - Explicitly passing Rack related configurations [#1662](https://github.com/getsentry/sentry-ruby/pull/1662)
+
+## 4.8.2
+
+### Documentation
+
+- Rewrite documents with yard [#1635](https://github.com/getsentry/sentry-ruby/pull/1635)
+
+### Bug Fixes
+
+- Use prepended method instead of `around_perform` for `ActiveJob` integration [#1631](https://github.com/getsentry/sentry-ruby/pull/1631)
+  - Fixes [#956](https://github.com/getsentry/sentry-ruby/issues/956) and [#1629](https://github.com/getsentry/sentry-ruby/issues/1629)
+- Remove unnecessary ActiveJob inclusion [#1655](https://github.com/getsentry/sentry-ruby/pull/1655)
+- Lock faraday to version 1.x [#1664](https://github.com/getsentry/sentry-ruby/pull/1664)
+  - This is a temporary effort to avoid dependency issue with `faraday 2.0` and `faraday` will be removed from dependencies very soon. 
+    See [this comment](https://github.com/getsentry/sentry-ruby/issues/1663) for more information about our plan to remove it.
 
 ## 4.8.1
 

--- a/sentry-delayed_job/lib/sentry/delayed_job/version.rb
+++ b/sentry-delayed_job/lib/sentry/delayed_job/version.rb
@@ -1,5 +1,5 @@
 module Sentry
   module DelayedJob
-    VERSION = "4.8.1"
+    VERSION = "4.8.2"
   end
 end

--- a/sentry-delayed_job/sentry-delayed_job.gemspec
+++ b/sentry-delayed_job/sentry-delayed_job.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sentry-ruby-core", "~> 4.8.1"
+  spec.add_dependency "sentry-ruby-core", "~> 4.8.2"
   spec.add_dependency "delayed_job", ">= 4.0"
 end

--- a/sentry-rails/lib/sentry/rails/version.rb
+++ b/sentry-rails/lib/sentry/rails/version.rb
@@ -1,5 +1,5 @@
 module Sentry
   module Rails
-    VERSION = "4.8.1"
+    VERSION = "4.8.2"
   end
 end

--- a/sentry-rails/sentry-rails.gemspec
+++ b/sentry-rails/sentry-rails.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "railties", ">= 5.0"
-  spec.add_dependency "sentry-ruby-core", "~> 4.8.1"
+  spec.add_dependency "sentry-ruby-core", "~> 4.8.2"
 end

--- a/sentry-resque/lib/sentry/resque/version.rb
+++ b/sentry-resque/lib/sentry/resque/version.rb
@@ -1,5 +1,5 @@
 module Sentry
   module Resque
-    VERSION = "4.8.1"
+    VERSION = "4.8.2"
   end
 end

--- a/sentry-resque/sentry-resque.gemspec
+++ b/sentry-resque/sentry-resque.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sentry-ruby-core", "~> 4.8.1"
+  spec.add_dependency "sentry-ruby-core", "~> 4.8.2"
   spec.add_dependency "resque", ">= 1.24"
 end

--- a/sentry-ruby/lib/sentry/version.rb
+++ b/sentry-ruby/lib/sentry/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sentry
-  VERSION = "4.8.1"
+  VERSION = "4.8.2"
 end

--- a/sentry-sidekiq/lib/sentry/sidekiq/version.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/version.rb
@@ -1,5 +1,5 @@
 module Sentry
   module Sidekiq
-    VERSION = "4.8.1"
+    VERSION = "4.8.2"
   end
 end

--- a/sentry-sidekiq/sentry-sidekiq.gemspec
+++ b/sentry-sidekiq/sentry-sidekiq.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sentry-ruby-core", "~> 4.8.1"
+  spec.add_dependency "sentry-ruby-core", "~> 4.8.2"
   spec.add_dependency "sidekiq", ">= 3.0"
 end


### PR DESCRIPTION
I'm not sure if this is the right way to port `4-8` branch (currently `4.8.2`) specific changes back to master, which are:

- Versions
- Changelog Entries

I thought about rebasing master on `4-8`, which will yield a more natural git history. But it requires force pushing the master branch, which sounds like a big no-no to me. 

And the other way is this: merging `4-8` back to master with this intermediate branch to resolve conflicts. It don't require any force-push but the commit history **might** look ugly (old commits marked as recently committed..etc.). This is the first time I do branch-based release so I'm not really sure what'd happen next.

Any idea? @sl0thentr0py 