### PR TITLE
Refactor RequestInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ When `config.send_default_pii` is set as `true`, `:http_logger` will include que
 - Refactor Net::HTTP patch [#1656](https://github.com/getsentry/sentry-ruby/pull/1656)
 - Deprecate Event#configuration [#1661](https://github.com/getsentry/sentry-ruby/pull/1661)
 - Explicitly passing Rack related configurations [#1662](https://github.com/getsentry/sentry-ruby/pull/1662)
+- Refactor RequestInterface [#1673](https://github.com/getsentry/sentry-ruby/pull/1673)
 
 ## 4.8.3
 

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -104,8 +104,6 @@ module Sentry
 
     def rack_env=(env)
       unless request || env.empty?
-        env = env.dup
-
         add_request_interface(env)
 
         if @send_default_pii

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -131,7 +131,7 @@ module Sentry
     end
 
     def add_request_interface(env)
-      @request = Sentry::RequestInterface.build(env: env, send_default_pii: @send_default_pii, rack_env_whitelist: @rack_env_whitelist)
+      @request = Sentry::RequestInterface.new(env: env, send_default_pii: @send_default_pii, rack_env_whitelist: @rack_env_whitelist)
     end
 
     def add_threads_interface(backtrace: nil, **options)

--- a/sentry-ruby/lib/sentry/interfaces/request.rb
+++ b/sentry-ruby/lib/sentry/interfaces/request.rb
@@ -17,7 +17,7 @@ module Sentry
 
     attr_accessor :url, :method, :data, :query_string, :cookies, :headers, :env
 
-    def self.build(env:, send_default_pii:, rack_env_whitelist:)
+    def initialize(env:, send_default_pii:, rack_env_whitelist:)
       env = env.dup
 
       unless send_default_pii
@@ -28,11 +28,6 @@ module Sentry
       end
 
       request = ::Rack::Request.new(env)
-      self.new(request: request, send_default_pii: send_default_pii, rack_env_whitelist: rack_env_whitelist)
-    end
-
-    def initialize(request:, send_default_pii:, rack_env_whitelist:)
-      env = request.env
 
       if send_default_pii
         self.data = read_data_from(request)

--- a/sentry-ruby/lib/sentry/interfaces/request.rb
+++ b/sentry-ruby/lib/sentry/interfaces/request.rb
@@ -18,6 +18,8 @@ module Sentry
     attr_accessor :url, :method, :data, :query_string, :cookies, :headers, :env
 
     def self.build(env:, send_default_pii:, rack_env_whitelist:)
+      env = env.dup
+
       unless send_default_pii
         # need to completely wipe out ip addresses
         RequestInterface::IP_HEADERS.each do |header|

--- a/sentry-ruby/lib/sentry/interfaces/request.rb
+++ b/sentry-ruby/lib/sentry/interfaces/request.rb
@@ -18,12 +18,6 @@ module Sentry
     attr_accessor :url, :method, :data, :query_string, :cookies, :headers, :env
 
     def self.build(env:, send_default_pii:, rack_env_whitelist:)
-      env = clean_env(env, send_default_pii)
-      request = ::Rack::Request.new(env)
-      self.new(request: request, send_default_pii: send_default_pii, rack_env_whitelist: rack_env_whitelist)
-    end
-
-    def self.clean_env(env, send_default_pii)
       unless send_default_pii
         # need to completely wipe out ip addresses
         RequestInterface::IP_HEADERS.each do |header|
@@ -31,7 +25,8 @@ module Sentry
         end
       end
 
-      env
+      request = ::Rack::Request.new(env)
+      self.new(request: request, send_default_pii: send_default_pii, rack_env_whitelist: rack_env_whitelist)
     end
 
     def initialize(request:, send_default_pii:, rack_env_whitelist:)

--- a/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Sentry::RequestInterface do
   let(:rack_env_whitelist) { Sentry::Configuration::RACK_ENV_WHITELIST_DEFAULT }
 
   subject do
-    described_class.build(env: env, send_default_pii: send_default_pii, rack_env_whitelist: rack_env_whitelist)
+    described_class.new(env: env, send_default_pii: send_default_pii, rack_env_whitelist: rack_env_whitelist)
   end
 
   describe "rack_env_whitelist" do
@@ -125,7 +125,7 @@ RSpec.describe Sentry::RequestInterface do
 
       env.merge!("HTTP_FOO" => "BAR", "rails_object" => obj)
 
-      expect { described_class.build(env: env, send_default_pii: send_default_pii, rack_env_whitelist: rack_env_whitelist) }.to_not raise_error
+      expect { described_class.new(env: env, send_default_pii: send_default_pii, rack_env_whitelist: rack_env_whitelist) }.to_not raise_error
     end
   end
 


### PR DESCRIPTION
This PR removes the 2 class methods that I think are redundant: `.build` and `.clean_env`, as they can just happen in `RequestInterface#initialize`.

I also don't think this is a breaking change as `Event#rack_env=` should be the API for users to attaching request data to an event.