### PR TITLE
Goodbye faraday 👋 

### DIFF
--- a/sentry-ruby/lib/sentry/transport/configuration.rb
+++ b/sentry-ruby/lib/sentry/transport/configuration.rb
@@ -3,8 +3,7 @@
 module Sentry
   class Transport
     class Configuration
-      attr_accessor :timeout, :open_timeout, :proxy, :ssl, :ssl_ca_file, :ssl_verification, :http_adapter, :faraday_builder,
-        :encoding
+      attr_accessor :timeout, :open_timeout, :proxy, :ssl, :ssl_ca_file, :ssl_verification, :encoding
       attr_reader :transport_class
 
       def initialize

--- a/sentry-ruby/lib/sentry/transport/http_transport.rb
+++ b/sentry-ruby/lib/sentry/transport/http_transport.rb
@@ -13,11 +13,10 @@ module Sentry
     RETRY_AFTER_HEADER = "retry-after"
     RATE_LIMIT_HEADER = "x-sentry-rate-limits"
 
-    attr_reader :conn, :adapter
+    attr_reader :conn
 
     def initialize(*args)
       super
-      @adapter = @transport_configuration.http_adapter || Faraday.default_adapter
       @conn = set_conn
       @endpoint = @dsn.envelope_endpoint
     end
@@ -125,11 +124,10 @@ module Sentry
       log_debug("Sentry HTTP Transport connecting to #{server}")
 
       Faraday.new(server, :ssl => ssl_configuration, :proxy => @transport_configuration.proxy) do |builder|
-        @transport_configuration.faraday_builder&.call(builder)
         builder.response :raise_error
         builder.options.merge! faraday_opts
         builder.headers[:user_agent] = "sentry-ruby/#{Sentry::VERSION}"
-        builder.adapter(*adapter)
+        builder.adapter(Faraday.default_adapter)
       end
     end
 

--- a/sentry-ruby/lib/sentry/transport/http_transport.rb
+++ b/sentry-ruby/lib/sentry/transport/http_transport.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'faraday'
-require 'zlib'
+require "net/http"
+require "zlib"
 
 module Sentry
   class HTTPTransport < Transport
@@ -12,6 +12,7 @@ module Sentry
     DEFAULT_DELAY = 60
     RETRY_AFTER_HEADER = "retry-after"
     RATE_LIMIT_HEADER = "x-sentry-rate-limits"
+    USER_AGENT = "sentry-ruby/#{Sentry::VERSION}"
 
     attr_reader :conn
 
@@ -29,29 +30,37 @@ module Sentry
         encoding = GZIP_ENCODING
       end
 
-      response = conn.post @endpoint do |req|
-        req.headers['Content-Type'] = CONTENT_TYPE
-        req.headers['Content-Encoding'] = encoding
-        req.headers['X-Sentry-Auth'] = generate_auth_header
-        req.body = data
+      headers = {
+        'Content-Type' => CONTENT_TYPE,
+        'Content-Encoding' => encoding,
+        'X-Sentry-Auth' => generate_auth_header,
+        'User-Agent' => USER_AGENT
+      }
+
+      response = conn.start do |http|
+        request = ::Net::HTTP::Post.new(@endpoint, headers)
+        request.body = data
+        http.request(request)
       end
 
-      if has_rate_limited_header?(response.headers)
-        handle_rate_limited_response(response.headers)
-      end
-    rescue Faraday::Error => e
-      error_info = e.message
-
-      if e.response
-        if e.response[:status] == 429
-          handle_rate_limited_response(e.response[:headers])
-        else
-          error_info += "\nbody: #{e.response[:body]}"
-          error_info += " Error in headers is: #{e.response[:headers]['x-sentry-error']}" if e.response[:headers]['x-sentry-error']
+      if response.code.match?(/\A2\d{2}/)
+        if has_rate_limited_header?(response)
+          handle_rate_limited_response(response)
         end
-      end
+      else
+        error_info = "the server responded with status #{response.code}"
 
-      raise Sentry::ExternalError, error_info
+        if response.code == "429"
+          handle_rate_limited_response(response)
+        else
+          error_info += "\nbody: #{response.body}"
+          error_info += " Error in headers is: #{response['x-sentry-error']}" if response['x-sentry-error']
+        end
+
+        raise Sentry::ExternalError, error_info
+      end
+    rescue SocketError => e
+      raise Sentry::ExternalError.new(e.message)
     end
 
     private
@@ -119,30 +128,40 @@ module Sentry
     end
 
     def set_conn
-      server = @dsn.server
+      server = URI(@dsn.server)
 
       log_debug("Sentry HTTP Transport connecting to #{server}")
 
-      Faraday.new(server, :ssl => ssl_configuration, :proxy => @transport_configuration.proxy) do |builder|
-        builder.response :raise_error
-        builder.options.merge! faraday_opts
-        builder.headers[:user_agent] = "sentry-ruby/#{Sentry::VERSION}"
-        builder.adapter(Faraday.default_adapter)
-      end
-    end
+      use_ssl = server.scheme == "https"
+      port = use_ssl ? 443 : 80
 
-    # TODO: deprecate and replace where possible w/Faraday Builder
-    def faraday_opts
-      [:timeout, :open_timeout].each_with_object({}) do |opt, memo|
-        memo[opt] = @transport_configuration.public_send(opt) if @transport_configuration.public_send(opt)
+      connection =
+        if proxy = @transport_configuration.proxy
+          ::Net::HTTP.new(server.hostname, port, proxy[:uri].hostname, proxy[:uri].port, proxy[:user], proxy[:password])
+        else
+          ::Net::HTTP.new(server.hostname, port, nil)
+        end
+
+      connection.use_ssl = use_ssl
+      connection.read_timeout = @transport_configuration.timeout
+      connection.write_timeout = @transport_configuration.timeout if connection.respond_to?(:write_timeout)
+      connection.open_timeout = @transport_configuration.open_timeout
+
+      ssl_configuration.each do |key, value|
+        connection.send("#{key}=", value)
       end
+
+      connection
     end
 
     def ssl_configuration
-      {
+      configuration = {
         verify: @transport_configuration.ssl_verification,
         ca_file: @transport_configuration.ssl_ca_file
       }.merge(@transport_configuration.ssl || {})
+
+      configuration[:verify_mode] = configuration.delete(:verify) ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+      configuration
     end
   end
 end

--- a/sentry-ruby/sentry-ruby-core.gemspec
+++ b/sentry-ruby/sentry-ruby-core.gemspec
@@ -22,6 +22,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday"
   spec.add_dependency "concurrent-ruby"
 end

--- a/sentry-ruby/sentry-ruby.gemspec
+++ b/sentry-ruby/sentry-ruby.gemspec
@@ -18,6 +18,5 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"
 
   spec.add_dependency "sentry-ruby-core", Sentry::VERSION
-  spec.add_dependency "faraday", "~> 1.0"
   spec.add_dependency "concurrent-ruby", '~> 1.0', '>= 1.0.2'
 end

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -38,16 +38,6 @@ RSpec.describe Sentry::HTTPTransport do
       subject.send_data(data)
     end
 
-    it 'allows to customise faraday' do
-      builder = spy('faraday_builder')
-      expect(Faraday).to receive(:new).and_yield(builder)
-      configuration.transport.faraday_builder = proc { |b| b.request :instrumentation }
-
-      subject
-
-      expect(builder).to have_received(:request).with(:instrumentation)
-    end
-
     it "accepts custom proxy" do
       configuration.transport.proxy = { uri:  URI("https://example.com"), user: "stan", password: "foobar" }
 


### PR DESCRIPTION
1. Removed `faraday_builder` and `http_adapter` transport configs.
2. Rewrote `HTTPTransport` with pure `Net::HTTP` implementation. ([faraday-net_http](https://github.com/lostisland/faraday-net_http) provided pretty good guidance)
3. Removed `faraday` from dependencies.

## Todo

- ~~Test against different versions of `Net::HTTP` to see if the implementation can work from Ruby 2.4~3.1~~
- Update migration guide and documentation.

Closes #1663