### PR TITLE
Don't do anything in Sentry unless enabled_in_current_env?

### DIFF
--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -8,7 +8,7 @@ module Sentry
       end
 
       def call(env)
-        return @app.call(env) unless Sentry.initialized?
+        return @app.call(env) unless Sentry.initialized? && Sentry.configuration.enabled_in_current_env?
 
         # make sure the current thread has a clean hub
         Sentry.clone_hub_to_current_thread


### PR DESCRIPTION
Otherwise Sentry can sometimes cause errors when trying to capture exceptions in tests, when `test` is not an enabled environment.

This has occurred for me when my system reaches its `ulimit` during many, many subsequent app requests in Capybara tests, which manifests as `RuntimeError: failed to get urandom`. Because Sentry captures the app exception, and then starts to build reporting around it, it also runs code that causes `RuntimeError: failed to get urandom`.

I then end up with a test failure report that only shows the trace of the Sentry exception, not the original app exception. Therefore I think this can be avoided by not doing anything in Sentry unless it's enabled for the current environment, because everything it does would end up being thrown away, if my thinking is correct?

For example:
```
Failure/Error: ret = Random.urandom(n)

RuntimeError:
  failed to get urandom
# /Users/me/path/to/gems/sentry-ruby-core-4.7.3/lib/sentry/event.rb:34:in `initialize'
# /Users/me/path/to/gems/sentry-ruby-core-4.7.3/lib/sentry/client.rb:54:in `new'
# /Users/me/path/to/gems/sentry-ruby-core-4.7.3/lib/sentry/client.rb:54:in `event_from_exception'
# /Users/me/path/to/gems/sentry-ruby-core-4.7.3/lib/sentry/hub.rb:99:in `capture_exception'
# /Users/me/path/to/gems/sentry-ruby-core-4.7.3/lib/sentry-ruby.rb:181:in `capture_exception'
# /Users/me/path/to/gems/sentry-ruby-core-4.7.3/lib/sentry/integrable.rb:15:in `capture_exception'
# /Users/me/path/to/gems/sentry-rails-4.7.3/lib/sentry/rails/capture_exceptions.rb:30:in `capture_exception'
# /Users/me/path/to/gems/sentry-ruby-core-4.7.3/lib/sentry/rack/capture_exceptions.rb:28:in `rescue in block in call'
# /Users/me/path/to/gems/sentry-ruby-core-4.7.3/lib/sentry/rack/capture_exceptions.rb:22:in `block in call'
# /Users/me/path/to/gems/sentry-ruby-core-4.7.3/lib/sentry/hub.rb:56:in `with_scope'
# /Users/me/path/to/gems/sentry-ruby-core-4.7.3/lib/sentry-ruby.rb:176:in `with_scope'
# /Users/me/path/to/gems/sentry-ruby-core-4.7.3/lib/sentry/rack/capture_exceptions.rb:14:in `call'
# /Users/me/path/to/gems/rack-2.2.3/lib/rack/sendfile.rb:110:in `call'
# /Users/me/path/to/gems/rack-cors-1.1.1/lib/rack/cors.rb:100:in `call'
# /Users/me/path/to/gems/railties-6.0.4.1/lib/rails/engine.rb:527:in `call'
# /Users/me/path/to/gems/rack-2.2.3/lib/rack/urlmap.rb:74:in `block in call'
# /Users/me/path/to/gems/rack-2.2.3/lib/rack/urlmap.rb:58:in `each'
# /Users/me/path/to/gems/rack-2.2.3/lib/rack/urlmap.rb:58:in `call'
# /Users/me/path/to/gems/capybara-3.32.2/lib/capybara/server/middleware.rb:58:in `call'
# /Users/me/path/to/gems/puma-5.5.1/lib/puma/configuration.rb:249:in `call'
# /Users/me/path/to/gems/puma-5.5.1/lib/puma/request.rb:77:in `block in handle_request'
# /Users/me/path/to/gems/puma-5.5.1/lib/puma/thread_pool.rb:340:in `with_force_shutdown'
# /Users/me/path/to/gems/puma-5.5.1/lib/puma/request.rb:76:in `handle_request'
# /Users/me/path/to/gems/puma-5.5.1/lib/puma/server.rb:447:in `process_client'
# /Users/me/path/to/gems/puma-5.5.1/lib/puma/thread_pool.rb:147:in `block in spawn_thread'
# ------------------
# --- Caused by: ---
# RuntimeError:
#   failed to get urandom
#   /Users/me/path/to/gems/rack-2.2.3/lib/rack/method_override.rb:24:in `call'
```

Thanks for your Pull Request 🎉 

**Please keep these instructions in mind so we can review it more efficiently:**

- Add the references of all the related issues/PRs in the description
- Whether it's a new feature or a bug fix, make sure they're covered by new test cases
- If this PR contains any refactoring work, please give it its own commit(s)
- Finally, please add an entry to the corresponding changelog


**Other Notes**
- We squash all commits before merging
- We generally review new PRs within a week
- If you have any question, you can ask for feedback in our [discord community](https://discord.gg/Ww9hbqr) first

## Description
Describe your changes:
