### PR TITLE
Fix issue with `connection.env` not being defined in test environments

### DIFF
--- a/sentry-rails/lib/sentry/rails/action_cable.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable.rb
@@ -69,7 +69,8 @@ module Sentry
           def sentry_capture(hook, &block)
             extra_context = { params: params }
 
-            ErrorHandler.capture(connection.env, transaction_name: "#{self.class.name}##{hook}", extra_context: extra_context, &block)
+            env = connection.respond_to?(:env) ? connection.env : {}
+            ErrorHandler.capture(env, transaction_name: "#{self.class.name}##{hook}", extra_context: extra_context, &block)
           end
         end
 
@@ -79,7 +80,8 @@ module Sentry
           def dispatch_action(action, data)
             extra_context = { params: params, data: data }
 
-            ErrorHandler.capture(connection.env, transaction_name: "#{self.class.name}##{action}", extra_context: extra_context) do
+            env = connection.respond_to?(:env) ? connection.env : {}
+            ErrorHandler.capture(env, transaction_name: "#{self.class.name}##{action}", extra_context: extra_context) do
               super
             end
           end


### PR DESCRIPTION
In test environments, the `env` method is not currently defined on the mocked `ActionCable::Channel::ConnectionStub` object. Leading to this error:

```
 2) StoredFileChannel subscribe with valid teacher successfully subscribes                                                                                                                                
     Failure/Error: subscribe(id: stored_file.id)                                                                                                                                                          
                                                                                                                                                                                                           
     NoMethodError:                                                                                                                                                                                        
       undefined method `env' for #<ActionCable::Channel::ConnectionStub:0x0000000006b36540 @transmissions=[], @subscriptions=#<ActionCable::Connection::Subscriptions:0x0000000006b363b0 @connection=#<Act
ionCable::Channel::ConnectionStub:0x0000000006b36540 ...>, @subscriptions={}>, @identifiers=[:socket_current_user], @logger=#<ActiveSupport::Logger:0x0000000006b35f00 @level=0, @progname=nil, @default_fo
rmatter=#<Logger::Formatter:0x0000000006b36108 @datetime_format=nil>, @formatter=#<ActiveSupport::Logger::SimpleFormatter:0x0000000006b35eb0 @datetime_format=nil>, @logdev=#<Logger::LogDevice:0x000000000
6b36040 @shift_period_suffix=nil, @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<StringIO:0x0000000006b362c0>, @binmode=false, @mon_data=#<Monitor:0x0000000006b35ff0>, @mon_data_owner_object_id=9
6300>>>                                                                                                                                                                                                    
     Shared Example Group: :successful_subscribe called from ./spec/channels/stored_file_channel_spec.rb:30                                                                                                
     # ./vendor/bundle/ruby/3.0.0/gems/sentry-rails-4.9.0/lib/sentry/rails/action_cable.rb:72:in `sentry_capture'                                                                                          
     # ./vendor/bundle/ruby/3.0.0/gems/sentry-rails-4.9.0/lib/sentry/rails/action_cable.rb:62:in `block (2 levels) in included'                                                                            
     # ./vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.4/lib/active_support/callbacks.rb:126:in `instance_exec'                                                                                        
     # ./vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.4/lib/active_support/callbacks.rb:126:in `block in run_callbacks'                                                                               
     # ./vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.4/lib/active_support/execution_wrapper.rb:88:in `wrap'                                                                                          
     # ./vendor/bundle/ruby/3.0.0/gems/actioncable-6.1.4.4/lib/action_cable/engine.rb:68:in `block (3 levels) in <class:Engine>'                                                                           
     # ./vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.4/lib/active_support/callbacks.rb:126:in `instance_exec'                                                                                        
     # ./vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.4/lib/active_support/callbacks.rb:126:in `block in run_callbacks'                                                                               
     # ./vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.4/lib/active_support/callbacks.rb:137:in `run_callbacks'                                                                                        
     # ./vendor/bundle/ruby/3.0.0/gems/actioncable-6.1.4.4/lib/action_cable/channel/base.rb:180:in `subscribe_to_channel'                                                                                  
     # ./vendor/bundle/ruby/3.0.0/gems/actioncable-6.1.4.4/lib/action_cable/channel/test_case.rb:228:in `subscribe'                                                                                        
     # ./spec/channels/stored_file_channel_spec.rb:8:in `block (3 levels) in <top (required)>'                                                                                                             
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:317:in `block (2 levels) in let'                                                                               
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:157:in `block (3 levels) in fetch_or_store'                                                                    
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:157:in `fetch'                                                                                                 
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:157:in `block (2 levels) in fetch_or_store'                                                                    
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-support-3.10.3/lib/rspec/support/reentrant_mutex.rb:23:in `synchronize'                                                                                       
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:156:in `block in fetch_or_store'                                                                               
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:155:in `fetch'                                                                                                 
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:155:in `fetch_or_store'                                                                                        
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/memoized_helpers.rb:317:in `block in let'                                                                                          
     # ./spec/channels/stored_file_channel_spec.rb:16:in `block (4 levels) in <top (required)>'                                                                                                            
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `instance_exec'                                                                                                  
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:262:in `block in run'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `block in with_around_and_singleton_context_hooks'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `block in with_around_example_hooks'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `block in run'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:350:in `call'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-rails-5.0.2/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in <module:MinitestLifecycleAdapter>'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:455:in `instance_exec'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:455:in `instance_exec'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:390:in `execute_with'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:350:in `call'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/hooks.rb:486:in `run'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:465:in `with_around_example_hooks'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:508:in `with_around_and_singleton_context_hooks'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example.rb:259:in `run'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:644:in `block in run_examples'
     # ./vendor/bundle/ruby/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/example_group.rb:640:in `map' 
```

This same exact issue was happening with AppSignal as well, which they highlighted in an issue here: https://github.com/appsignal/appsignal-ruby/issues/684

I took the fix from their PR to fix it: https://github.com/appsignal/appsignal-ruby/pull/705/files

Would love to try to write tests for this if they are needed, but I'm really unversed in this repo and would probably need some guidance. Thought I'd just make the PR and ask for advice here!