### PR TITLE
Add workaround for ConnectionStub's missing interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.9.1
+
+### Bug Fixes
+
+- Add workaround for ConnectionStub's missing interface [#1686](https://github.com/getsentry/sentry-ruby/pull/1686)
+  - Fixes [#1685](https://github.com/getsentry/sentry-ruby/issues/1685)
+
 ## 4.9.0
 
 ### Features

--- a/sentry-rails/spec/sentry/rails/action_cable_spec.rb
+++ b/sentry-rails/spec/sentry/rails/action_cable_spec.rb
@@ -4,15 +4,6 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
 
   ::ActionCable.server.config.cable = { "adapter" => "test" }
 
-  # ensure we can access `connection.env` in tests like we can in production
-  ActiveSupport.on_load :action_cable_channel_test_case do
-    class ::ActionCable::Channel::ConnectionStub
-      def env
-        @_env ||= ::ActionCable::Connection::TestRequest.create.env
-      end
-    end
-  end
-
   class ChatChannel < ::ActionCable::Channel::Base
     def subscribed
       raise "foo"

--- a/sentry-rails/spec/sentry/rails/action_cable_spec.rb
+++ b/sentry-rails/spec/sentry/rails/action_cable_spec.rb
@@ -29,11 +29,64 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
     end
   end
 
+  class FailToOpenConnection < ActionCable::Connection::Base
+    def connect
+      raise "foo"
+    end
+  end
+
+  class FailToCloseConnection < ActionCable::Connection::Base
+    def disconnect
+      raise "bar"
+    end
+  end
+
+
   RSpec.describe "Sentry::Rails::ActionCableExtensions", type: :channel do
     let(:transport) { Sentry.get_current_client.transport }
 
     after do
       transport.events = []
+    end
+
+    describe "Connection" do
+      before do
+        make_basic_app
+      end
+
+      let(:connection) do
+        env = Rack::MockRequest.env_for "/test", "HTTP_CONNECTION" => "upgrade", "HTTP_UPGRADE" => "websocket",
+          "HTTP_HOST" => "localhost", "HTTP_ORIGIN" => "http://rubyonrails.com"
+        described_class.new(spy, env)
+      end
+
+      before do
+        connection.process
+      end
+
+      describe FailToOpenConnection do
+        it "captures errors happen when establishing connection" do
+          expect { connection.send(:handle_open) }.to raise_error(RuntimeError, "foo")
+
+          expect(transport.events.count).to eq(1)
+
+          event = transport.events.last.to_json_compatible
+          expect(event["transaction"]).to eq("FailToOpenConnection#connect")
+        end
+      end
+
+      describe FailToCloseConnection do
+        it "captures errors happen when establishing connection" do
+          connection.send(:handle_open)
+
+          expect { connection.send(:handle_close) }.to raise_error(RuntimeError, "bar")
+
+          expect(transport.events.count).to eq(1)
+
+          event = transport.events.last.to_json_compatible
+          expect(event["transaction"]).to eq("FailToCloseConnection#disconnect")
+        end
+      end
     end
 
     context "without tracing" do


### PR DESCRIPTION
ActionCable's `ConnectionStub` (for testing) doesn't implement the exact same interfaces as `Connection::Base`.
One thing that's missing is `env`. So calling `connection.env` direclty will fail in test environments when `stub_connection` is used.
See #1684 for more information.

Closes #1685.