### PR TITLE
Don't initialize Event objects when they won't be sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add workaround for ConnectionStub's missing interface [#1686](https://github.com/getsentry/sentry-ruby/pull/1686)
   - Fixes [#1685](https://github.com/getsentry/sentry-ruby/issues/1685)
+- Don't initialize Event objects when they won't be sent [#1687](https://github.com/getsentry/sentry-ruby/pull/1687)
+  - Fixes [#1683](https://github.com/getsentry/sentry-ruby/issues/1683)
 
 ## 4.9.0
 

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -76,8 +76,9 @@ module Sentry
     # @param hint [Hash] the hint data that'll be passed to `before_send` callback and the scope's event processors.
     # @return [Event, nil]
     def event_from_exception(exception, hint = {})
+      return unless @configuration.sending_allowed? && @configuration.exception_class_allowed?(exception)
+
       integration_meta = Sentry.integrations[hint[:integration]]
-      return unless @configuration.exception_class_allowed?(exception)
 
       Event.new(configuration: configuration, integration_meta: integration_meta).tap do |event|
         event.add_exception_interface(exception)
@@ -90,6 +91,8 @@ module Sentry
     # @param hint [Hash] the hint data that'll be passed to `before_send` callback and the scope's event processors.
     # @return [Event]
     def event_from_message(message, hint = {}, backtrace: nil)
+      return unless @configuration.sending_allowed?
+
       integration_meta = Sentry.integrations[hint[:integration]]
       event = Event.new(configuration: configuration, integration_meta: integration_meta, message: message)
       event.add_threads_interface(backtrace: backtrace || caller)

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -114,6 +114,9 @@ module Sentry
       options[:hint][:message] = message
       backtrace = options.delete(:backtrace)
       event = current_client.event_from_message(message, options[:hint], backtrace: backtrace)
+
+      return unless event
+
       capture_event(event, **options, &block)
     end
 

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -102,9 +102,13 @@ RSpec.describe Sentry do
     context "with sending_allowed? condition" do
       before do
         expect(Sentry.configuration).to receive(:sending_allowed?).and_return(false)
+        capture_subject
       end
 
       it "doesn't send the event nor assign last_event_id" do
+        # don't even initialize Event objects
+        expect(Sentry::Event).not_to receive(:new)
+
         described_class.send(capture_helper, capture_subject)
 
         expect(transport.events).to be_empty


### PR DESCRIPTION
Fixes #1683