### PR TITLE
Directly execute ActionCable's action if the SDK is not initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Bug Fixes
+
+- Directly execute ActionCable's action if the SDK is not initialized [#1692](https://github.com/getsentry/sentry-ruby/pull/1692)
+  - Fixes [#1691](https://github.com/getsentry/sentry-ruby/issues/1691)
+
 ## 4.9.1
 
 ### Bug Fixes

--- a/sentry-rails/lib/sentry/rails/action_cable.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable.rb
@@ -4,6 +4,7 @@ module Sentry
       class ErrorHandler
         class << self
           def capture(connection, transaction_name:, extra_context: nil, &block)
+            return block.call unless Sentry.initialized?
             # ActionCable's ConnectionStub (for testing) doesn't implement the exact same interfaces as Connection::Base.
             # One thing that's missing is `env`. So calling `connection.env` direclty will fail in test environments when `stub_connection` is used.
             # See https://github.com/getsentry/sentry-ruby/pull/1684 for more information.

--- a/sentry-rails/spec/sentry/rails/action_cable_spec.rb
+++ b/sentry-rails/spec/sentry/rails/action_cable_spec.rb
@@ -32,6 +32,19 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
     end
   end
 
+  RSpec.describe "without Sentry initialized" do
+    before do
+      allow(Sentry).to receive(:get_main_hub).and_return(nil)
+      make_basic_app
+      Sentry.clone_hub_to_current_thread # make sure the thread doesn't set a hub
+    end
+
+    describe ChatChannel, type: :channel do
+      it "doesn't swallow the app's operation" do
+        expect { subscribe }.to raise_error('foo')
+      end
+    end
+  end
 
   RSpec.describe "Sentry::Rails::ActionCableExtensions", type: :channel do
     let(:transport) { Sentry.get_current_client.transport }

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -174,7 +174,7 @@ module Sentry
     #
     # @return [Boolean]
     def initialized?
-      !!@main_hub
+      !!get_main_hub
     end
 
     # Returns an uri for security policy reporting that's generated from the given DSN


### PR DESCRIPTION
Fixes #1691 