### PR TITLE
Don't reuse Net::HTTP objects in `HTTPTransport`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.1
+
+- Don't reuse Net::HTTP objects in `HTTPTransport` [#1696](https://github.com/getsentry/sentry-ruby/pull/1696)
+
 ## 5.0.0
 
 ### Breaking Change - Goodbye `faraday` 👋 

--- a/sentry-ruby/lib/sentry/transport/http_transport.rb
+++ b/sentry-ruby/lib/sentry/transport/http_transport.rb
@@ -14,12 +14,11 @@ module Sentry
     RATE_LIMIT_HEADER = "x-sentry-rate-limits"
     USER_AGENT = "sentry-ruby/#{Sentry::VERSION}"
 
-    attr_reader :conn
-
     def initialize(*args)
       super
-      @conn = set_conn
       @endpoint = @dsn.envelope_endpoint
+
+      log_debug("Sentry HTTP Transport will connect to #{@dsn.server}")
     end
 
     def send_data(data)
@@ -127,10 +126,8 @@ module Sentry
       @transport_configuration.encoding == GZIP_ENCODING && data.bytesize >= GZIP_THRESHOLD
     end
 
-    def set_conn
+    def conn
       server = URI(@dsn.server)
-
-      log_debug("Sentry HTTP Transport connecting to #{server}")
 
       use_ssl = server.scheme == "https"
       port = use_ssl ? 443 : 80


### PR DESCRIPTION
When investigating #1695, I found that `Net::HTTP` object is not supposed to be used as `Faraday::Connection` that can be held and shared. Because it'll cause error `HTTP session already opened` when multiple threads try to send events with the same object.

I also assume #1695 is caused by a race condition between threads that attempt to update the same `OpenSSL::SSL::SSLSocket` instance's session [around here](https://github.com/ruby/net-http/blob/v0.2.0/lib/net/http.rb#L1030-L1039)