### PR TITLE
Capture transaction tags

### DIFF
--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -108,6 +108,7 @@ module Sentry
         event.contexts.merge!(trace: transaction.get_trace_context)
         event.timestamp = transaction.timestamp
         event.start_timestamp = transaction.start_timestamp
+        event.tags = transaction.tags
 
         finished_spans = transaction.span_recorder.spans.select { |span| span.timestamp && span != transaction }
         event.spans = finished_spans.map(&:to_hash)

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -347,6 +347,17 @@ RSpec.describe Sentry::Transaction do
       expect(event[:transaction]).to eq("foo")
     end
 
+    it "doesn't override the event's tags attribute with the scope's" do
+      subject.set_tag(:foo, 'bar')
+
+      subject.finish
+
+      expect(events.count).to eq(1)
+      event = events.last.to_hash
+
+      expect(event[:tags]).to eq({foo: 'bar'})
+    end
+
     describe "hub selection" do
       it "prioritizes the optional hub argument and uses it to submit the transaction" do
         expect(another_hub).to receive(:capture_event)


### PR DESCRIPTION
## Description

With the following code:

```ruby
transaction = Sentry.start_transaction(name: 'example transaction', description: "example transaction")
transaction.set_tag('host', 'www.example.org')
transaction.finish
```

I was expecting Sentry to create a clickable tag within the Tag Details section here:

<img width="600" alt="Screenshot 2022-01-26 at 22 08 13" src="https://user-images.githubusercontent.com/666397/151255265-dd221211-0cef-404f-9801-1a87ddf52bc1.png">

However - this doesn't currently work because the transaction's tags aren't shared here: https://github.com/getsentry/sentry-ruby/blob/16a13052b562b6a6a3b1f9747e69141a6eaed9f3/sentry-ruby/lib/sentry/client.rb#L105

With this change applied the tags from the transaction are captured and it creates a clickable tag within Event Details -> Tag Details

<img width="369" alt="Screenshot 2022-01-26 at 22 13 34" src="https://user-images.githubusercontent.com/666397/151255885-c9aa06b9-92b2-4d56-9ebb-54d4bf4d1b01.png">

I wondered if there might be a specific reason transaction tags aren't currently captured or might it be possible to introduce this change.

Please let me know your thoughts - thanks very much!

