### PR TITLE
Register Sentry's ErrorSubscriber for Rails 7.0+ apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - Support serializing ActiveRecord job arguments in global id form [#1688](https://github.com/getsentry/sentry-ruby/pull/1688)
+- Register Sentry's ErrorSubscriber for Rails 7.0+ apps [#1705](https://github.com/getsentry/sentry-ruby/pull/1705)
 
 ## 5.0.2
 

--- a/sentry-rails/lib/sentry/rails/error_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/error_subscriber.rb
@@ -1,0 +1,11 @@
+module Sentry
+  module Rails
+    # This is not a user-facing class. You should use it with Rails 7.0's error reporter feature and its interfaces.
+    # See https://github.com/rails/rails/blob/main/activesupport/lib/active_support/error_reporter.rb for more information.
+    class ErrorSubscriber
+      def report(error, handled:, severity:, context:)
+        Sentry::Rails.capture_exception(error, level: severity, contexts: { "rails.error" => context }, tags: { handled: handled })
+      end
+    end
+  end
+end

--- a/sentry-rails/lib/sentry/rails/error_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/error_subscriber.rb
@@ -4,6 +4,15 @@ module Sentry
     # See https://github.com/rails/rails/blob/main/activesupport/lib/active_support/error_reporter.rb for more information.
     class ErrorSubscriber
       def report(error, handled:, severity:, context:)
+        # a component may already have an integration to capture exceptions while its operation is also wrapped inside an `app.executor.wrap` (e.g. ActionCable)
+        # in such condition, the exception would be captured repeatedly. it usually happens in this order:
+        #
+        # 1. exception captured and reported by the component integration and re-raised
+        # 2. exception captured by the executor, which then reports it with executor.error_reporter
+        #
+        # and because there's no direct communication between the 2 callbacks, we need a way to identify if an exception has been captured before
+        # using a Sentry-specific intance variable should be the last impactful way
+        return if error.instance_variable_get(:@__sentry_captured)
         Sentry::Rails.capture_exception(error, level: severity, contexts: { "rails.error" => context }, tags: { handled: handled })
       end
     end

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -46,6 +46,8 @@ module Sentry
       setup_backtrace_cleanup_callback
       inject_breadcrumbs_logger
       activate_tracing
+
+      register_error_subscriber(app) if ::Rails.version.to_f >= 7.0
     end
 
     runner do
@@ -114,6 +116,11 @@ module Sentry
         Sentry::Rails::Tracing.subscribe_tracing_events
         Sentry::Rails::Tracing.patch_active_support_notifications
       end
+    end
+
+    def register_error_subscriber(app)
+      require "sentry/rails/error_subscriber"
+      app.executor.error_reporter.subscribe(Sentry::Rails::ErrorSubscriber.new)
     end
   end
 end

--- a/sentry-rails/spec/support/test_rails_app/app.rb
+++ b/sentry-rails/spec/support/test_rails_app/app.rb
@@ -166,6 +166,11 @@ def make_basic_app
   # the callbacks duplicate after each time we initialize the application and cause issues when they're executed
   ActiveSupport::Executor.reset_callbacks(:run)
   ActiveSupport::Executor.reset_callbacks(:complete)
+
+  # Rails uses this module to set a global context for its ErrorReporter feature.
+  # this needs to be cleared so previously set context won't pollute later reportings (see ErrorSubscriber).
+  ActiveSupport::ExecutionContext.clear if defined?(ActiveSupport::ExecutionContext)
+
   if defined?(ActionCable)
     ActionCable::Channel::Base.reset_callbacks(:subscribe)
     ActionCable::Channel::Base.reset_callbacks(:unsubscribe)

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -102,7 +102,10 @@ module Sentry
 
       return unless event
 
-      capture_event(event, **options, &block)
+      capture_event(event, **options, &block).tap do
+        # mark the exception as captured so we can use this information to avoid duplicated capturing
+        exception.instance_variable_set(:@__sentry_captured, true)
+      end
     end
 
     def capture_message(message, **options, &block)


### PR DESCRIPTION
This implements the integration proposed in #1630.

After Rails 7.0, you'll be able to use the standardized `Rails.error.record` or `Rails.error.handle` interfaces to report exceptions to Sentry. Please check [ActiveSupport::ErrorReporter](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/error_reporter.rb) for more information.

### Gotcha & Workaround

If an operation is wrapped inside `app.executor.wrap`, any exception raised will be captured by Rails' error reporter,
even if it has been reported by either the SDK integration or user. So in some cases (e.g. `ActionCable`'s channel actions), the same error could be reported twice.

I worked around this by marking if an exception has been captured by the SDK. And if it has, we don't capture it with the `ErrorSubscriber`.

(Dropping the original integration isn't an option because the contextual data may not be accessible from the error reporter)

Closes #1630