### PR TITLE
Isolate ActiveJob error handling methods

### DIFF
--- a/sentry-rails/lib/sentry/rails/active_job.rb
+++ b/sentry-rails/lib/sentry/rails/active_job.rb
@@ -2,79 +2,89 @@ module Sentry
   module Rails
     module ActiveJobExtensions
       def perform_now
-        if !Sentry.initialized? || already_supported_by_sentry_integration?
-          super
-        else
-          Sentry.with_scope do |scope|
-            capture_and_reraise_with_sentry(scope) do
-              super
+        Adapter.new(self).perform { super }
+      end
+
+      class Adapter
+        attr_reader :job
+
+        def initialize(job)
+          @job = job
+        end
+
+        def perform
+          if !Sentry.initialized? || already_supported_by_sentry_integration?
+            yield
+          else
+            Sentry.with_scope do |scope|
+              capture_and_reraise_with_sentry(scope) { yield }
             end
           end
         end
-      end
 
-      def capture_and_reraise_with_sentry(scope, &block)
-        scope.set_transaction_name(self.class.name)
-        transaction =
-          if is_a?(::Sentry::SendEventJob)
-            nil
-          else
-            Sentry.start_transaction(name: scope.transaction_name, op: "active_job")
-          end
+        def capture_and_reraise_with_sentry(scope, &block)
+          scope.set_transaction_name(job.class.name)
+          transaction =
+            if job.is_a?(::Sentry::SendEventJob)
+              nil
+            else
+              Sentry.start_transaction(name: scope.transaction_name, op: "active_job")
+            end
 
-        scope.set_span(transaction) if transaction
+          scope.set_span(transaction) if transaction
 
-        return_value = block.call
+          return_value = block.call
 
-        finish_sentry_transaction(transaction, 200)
+          finish_sentry_transaction(transaction, 200)
 
-        return_value
-      rescue Exception => e # rubocop:disable Lint/RescueException
-        finish_sentry_transaction(transaction, 500)
+          return_value
+        rescue Exception => e # rubocop:disable Lint/RescueException
+          finish_sentry_transaction(transaction, 500)
 
-        Sentry::Rails.capture_exception(
-          e,
-          extra: sentry_context,
-          tags: {
-            job_id: job_id,
-            provider_job_id: provider_job_id
+          Sentry::Rails.capture_exception(
+            e,
+            extra: sentry_context,
+            tags: {
+              job_id: job.job_id,
+              provider_job_id: job.provider_job_id
+            }
+          )
+          raise e
+        end
+
+        def finish_sentry_transaction(transaction, status)
+          return unless transaction
+
+          transaction.set_http_status(status)
+          transaction.finish
+        end
+
+        def already_supported_by_sentry_integration?
+          Sentry.configuration.rails.skippable_job_adapters.include?(job.class.queue_adapter.class.to_s)
+        end
+
+        def sentry_context
+          {
+            active_job: job.class.name,
+            arguments: sentry_serialize_arguments(job.arguments),
+            scheduled_at: job.scheduled_at,
+            job_id: job.job_id,
+            provider_job_id: job.provider_job_id,
+            locale: job.locale
           }
-        )
-        raise e
-      end
+        end
 
-      def finish_sentry_transaction(transaction, status)
-        return unless transaction
-
-        transaction.set_http_status(status)
-        transaction.finish
-      end
-
-      def already_supported_by_sentry_integration?
-        Sentry.configuration.rails.skippable_job_adapters.include?(self.class.queue_adapter.class.to_s)
-      end
-
-      def sentry_context
-        {
-          active_job: self.class.name,
-          arguments: sentry_serialize_arguments(arguments),
-          scheduled_at: scheduled_at,
-          job_id: job_id,
-          provider_job_id: provider_job_id,
-          locale: locale
-        }
-      end
-
-      def sentry_serialize_arguments(argument)
-        case argument
-        when Hash
-          argument.transform_values { |v| sentry_serialize_arguments(v) }
-        when Array, Enumerable
-          argument.map { |v| sentry_serialize_arguments(v) }
-        when ->(v) { v.respond_to?(:to_global_id) }
-          argument.to_global_id.to_s rescue argument
-        else
-          argument
+        def sentry_serialize_arguments(argument)
+          case argument
+          when Hash
+            argument.transform_values { |v| sentry_serialize_arguments(v) }
+          when Array, Enumerable
+            argument.map { |v| sentry_serialize_arguments(v) }
+          when ->(v) { v.respond_to?(:to_global_id) }
+            argument.to_global_id.to_s rescue argument
+          else
+            argument
+          end
         end
       end
     end


### PR DESCRIPTION
Thanks for your Pull Request 🎉 

**Please keep these instructions in mind so we can review it more efficiently:**

- Add the references of all the related issues/PRs in the description
- Whether it's a new feature or a bug fix, make sure they're covered by new test cases
- If this PR contains any refactoring work, please give it its own commit(s)
- Finally, please add an entry to the corresponding changelog


**Other Notes**
- We squash all commits before merging
- We generally review new PRs within a week
- If you have any question, you can ask for feedback in our [discord community](https://discord.gg/Ww9hbqr) first

## Description
Describe your changes:


This pull request refactors the `ActiveJobExtensions` module to prevent its methods from being leaked into the `ActiveJob` object. The reason behind this change is that I'm trying to run `sentry-raven` and `sentry-rails` side by side while doing the upgrade and both gems define these methods.

