### PR TITLE
Fix context merging #1722

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Bug Fixes
+
+- Allow overwriting of context values [#1724](https://github.com/getsentry/sentry-ruby/pull/1724)
+  - Fixes [#1722](https://github.com/getsentry/sentry-ruby/issues/1722)
+
 ## 5.1.0
 
 ### Features

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -173,7 +173,7 @@ module Sentry
     def set_contexts(contexts_hash)
       check_argument_type!(contexts_hash, Hash)
       @contexts.merge!(contexts_hash) do |key, old, new|
-        new.merge(old)
+        old.merge(new)
       end
     end
 

--- a/sentry-ruby/spec/sentry/scope/setters_spec.rb
+++ b/sentry-ruby/spec/sentry/scope/setters_spec.rb
@@ -109,6 +109,12 @@ RSpec.describe Sentry::Scope do
       subject.set_contexts({ character: { age: 25 }})
       expect(subject.contexts).to include({ character: { name: "John", age: 25 }})
     end
+
+    it "allows overwriting old values" do
+      subject.set_contexts({ character: { name: "John" }})
+      subject.set_contexts({ character: { name: "Jimmy" }})
+      expect(subject.contexts).to include({ character: { name: "Jimmy" }})
+    end
   end
 
   describe "#set_context" do
@@ -138,6 +144,12 @@ RSpec.describe Sentry::Scope do
       subject.set_context(:character, { name: "John" })
       subject.set_context(:character, { age: 25 })
       expect(subject.contexts).to include({ character: { name: "John", age: 25 }})
+    end
+
+    it "allows overwriting old values" do
+      subject.set_context(:character, { name: "John" })
+      subject.set_context(:character, { name: "Jimmy" })
+      expect(subject.contexts).to include({ character: { name: "Jimmy" }})
     end
   end
 


### PR DESCRIPTION
When using the same key in a context hash, the new value should
overwrite the old value. Before, the value having been set first would
always win.

fixes #1722