### PR TITLE
Log Redis command arguments if send_default_pii = true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Features
+
+- Log Redis command arguments when sending PII is enabled [#1726](https://github.com/getsentry/sentry-ruby/pull/1726)
+
 ### Bug Fixes
 
 - Allow overwriting of context values [#1724](https://github.com/getsentry/sentry-ruby/pull/1724)

--- a/sentry-ruby/lib/sentry/redis.rb
+++ b/sentry-ruby/lib/sentry/redis.rb
@@ -3,8 +3,8 @@
 module Sentry
   # @api private
   class Redis
-    OP_NAME ||= "db.redis.command"
-    LOGGER_NAME ||= :redis_logger
+    OP_NAME = "db.redis.command"
+    LOGGER_NAME = :redis_logger
 
     def initialize(commands, host, port, db)
       @commands, @host, @port, @db = commands, host, port, db
@@ -60,9 +60,11 @@ module Sentry
 
     def parsed_commands
       commands.map do |statement|
-        command, key, *_values = statement
+        command, key, *arguments = statement
 
-        { command: command.to_s.upcase, key: key }
+        { command: command.to_s.upcase, key: key }.tap do |command_set|
+          command_set[:arguments] = arguments.join(" ") if Sentry.configuration.send_default_pii
+        end
       end
     end
 

--- a/sentry-ruby/spec/sentry/breadcrumb/redis_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/redis_logger_spec.rb
@@ -11,14 +11,48 @@ RSpec.describe :redis_logger do
     end
   end
 
-  it "adds Redis command breadcrumb with command and key" do
-    result = redis.set("key", "value")
+  context "config.send_default_pii = false" do
+    before { Sentry.configuration.send_default_pii = false }
 
-    expect(result).to eq("OK")
-    expect(Sentry.get_current_scope.breadcrumbs.peek).to have_attributes(
-      category: "db.redis.command",
-      data: { commands: [{ command: "SET", key: "key" }], server: "127.0.0.1:6379/0" }
-    )
+    it "adds Redis command breadcrumb with command and key" do
+      result = redis.set("key", "value")
+
+      expect(result).to eq("OK")
+      expect(Sentry.get_current_scope.breadcrumbs.peek).to have_attributes(
+        category: "db.redis.command",
+        data: { commands: [{ command: "SET", key: "key" }], server: "127.0.0.1:6379/0" }
+      )
+    end
+  end
+
+  context "config.send_default_pii = true" do
+    before { Sentry.configuration.send_default_pii = true }
+
+    it "adds Redis command breadcrumb with command, key and arguments" do
+      result = redis.set("key", "value")
+
+      expect(result).to eq("OK")
+      expect(Sentry.get_current_scope.breadcrumbs.peek).to have_attributes(
+        category: "db.redis.command",
+        data: { commands: [{ command: "SET", key: "key", arguments: "value" }], server: "127.0.0.1:6379/0" }
+      )
+    end
+
+    it "logs complex Redis commands with multiple arguments" do
+      redis.hmset("hashkey", "key1", "value1", "key2", "value2")
+
+      expect(Sentry.get_current_scope.breadcrumbs.peek).to have_attributes(
+        data: include(commands: [{ command: "HMSET", key: "hashkey", arguments: "key1 value1 key2 value2" }])
+      )
+    end
+
+    it "logs Redis command with options" do
+      redis.zrangebyscore("sortedsetkey", "1", "2", with_scores: true, limit: [0, 10])
+
+      expect(Sentry.get_current_scope.breadcrumbs.peek).to have_attributes(
+        data: include(commands: [{ command: "ZRANGEBYSCORE", key: "sortedsetkey", arguments: "1 2 WITHSCORES LIMIT 0 10" }])
+      )
+    end
   end
 
   context "calling Redis command which doesn't require a key" do


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-ruby/issues/1718

## Description
When config.send_default_pii = true we will also log any Redis command arguments