### PR TITLE
chore: Fix dark mode logos in READMEs

### DIFF
--- a/sentry-delayed_job/README.md
+++ b/sentry-delayed_job/README.md
@@ -1,8 +1,10 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
-    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
-  </a>
-  <br>
+    <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
+        <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+    </a>
+    <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+        <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
+    </a>
 </p>
 
 # sentry-delayed_job, the DelayedJob integration for Sentry's Ruby client

--- a/sentry-rails/README.md
+++ b/sentry-rails/README.md
@@ -1,8 +1,10 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
-    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
-  </a>
-  <br>
+    <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
+        <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+    </a>
+    <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+        <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
+    </a>
 </p>
 
 # sentry-rails, the Rails integration for Sentry's Ruby client

--- a/sentry-raven/README.md
+++ b/sentry-raven/README.md
@@ -1,8 +1,10 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
-    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
-  </a>
-  <br>
+    <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
+        <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+    </a>
+    <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+        <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
+    </a>
 </p>
 
 # Raven-Ruby, the Ruby Client for Sentry

--- a/sentry-resque/README.md
+++ b/sentry-resque/README.md
@@ -1,8 +1,10 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
-    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
-  </a>
-  <br>
+    <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
+        <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+    </a>
+    <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+        <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
+    </a>
 </p>
 
 # sentry-resque, the Resque integration for Sentry's Ruby client

--- a/sentry-ruby/README.md
+++ b/sentry-ruby/README.md
@@ -1,8 +1,10 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
-    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
-  </a>
-  <br />
+    <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
+        <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+    </a>
+    <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+        <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
+    </a>
 </p>
 
 _Bad software is everywhere, and we're tired of it. Sentry is on a mission to help developers write better software faster, so we can get back to enjoying technology. If you want to join us [<kbd>**Check out our open positions**</kbd>](https://sentry.io/careers/)_

--- a/sentry-sidekiq/README.md
+++ b/sentry-sidekiq/README.md
@@ -1,8 +1,10 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
-    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
-  </a>
-  <br>
+    <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
+        <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+    </a>
+    <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+        <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
+    </a>
 </p>
 
 # sentry-sidekiq, the Sidekiq integration for Sentry's Ruby client


### PR DESCRIPTION
Taking inspiration from https://github.com/getsentry/sentry-javascript/pull/4575