### PR TITLE
Avoid using Resque::Worker#work in tests

### DIFF
--- a/sentry-resque/spec/spec_helper.rb
+++ b/sentry-resque/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "pry"
+require "debug" if RUBY_VERSION.to_f >= 2.6
 
 require "resque"
 


### PR DESCRIPTION
`Resque::Worker#work` calls `#startup`, which does tons of things for working on jobs:

https://github.com/resque/resque/blob/085f77e87927e3a04bc1c951ca8e36c62ceaef1a/lib/resque/worker.rb#L363-L368

But basically none of them are needed for processing a single job in
tests. So it's a waste of time for performing them.

Some of the methods may cause unstable state for tests, like `#start_heartbeat`.

https://github.com/resque/resque/blob/085f77e87927e3a04bc1c951ca8e36c62ceaef1a/lib/resque/worker.rb#L513-L527

The `#start_heartbeat` method would create a thread for heartbeating. And
it randomly causes build failures like

https://github.com/getsentry/sentry-ruby/runs/5201864477?check_suite_focus=true

I'm not sure if it's a direct or indirect cause of the problem as I'm
not able to reproduce it consistently. But I think by avoiding the `#startup` call 
can surely make the tests both faster and more stable.
