### PR TITLE
Avoid duplicated capturing on the same exception object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Allow overwriting of context values [#1724](https://github.com/getsentry/sentry-ruby/pull/1724)
   - Fixes [#1722](https://github.com/getsentry/sentry-ruby/issues/1722)
+- Avoid duplicated capturing on the same exception object [#1738](https://github.com/getsentry/sentry-ruby/pull/1738)
+  - Fixes [#1731](https://github.com/getsentry/sentry-ruby/issues/1731)
 
 
 ### Refactoring

--- a/sentry-rails/lib/sentry/rails/error_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/error_subscriber.rb
@@ -4,15 +4,6 @@ module Sentry
     # See https://github.com/rails/rails/blob/main/activesupport/lib/active_support/error_reporter.rb for more information.
     class ErrorSubscriber
       def report(error, handled:, severity:, context:)
-        # a component may already have an integration to capture exceptions while its operation is also wrapped inside an `app.executor.wrap` (e.g. ActionCable)
-        # in such condition, the exception would be captured repeatedly. it usually happens in this order:
-        #
-        # 1. exception captured and reported by the component integration and re-raised
-        # 2. exception captured by the executor, which then reports it with executor.error_reporter
-        #
-        # and because there's no direct communication between the 2 callbacks, we need a way to identify if an exception has been captured before
-        # using a Sentry-specific intance variable should be the last impactful way
-        return if error.instance_variable_get(:@__sentry_captured)
         Sentry::Rails.capture_exception(error, level: severity, contexts: { "rails.error" => context }, tags: { handled: handled })
       end
     end

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -31,6 +31,8 @@ end
 module Sentry
   META = { "name" => "sentry.ruby", "version" => Sentry::VERSION }.freeze
 
+  CAPTURED_SIGNATURE = :@__sentry_captured
+
   LOGGER_PROGNAME = "sentry".freeze
 
   SENTRY_TRACE_HEADER_NAME = "sentry-trace".freeze
@@ -350,6 +352,13 @@ module Sentry
       get_current_hub.last_event_id
     end
 
+    # Checks if the exception object has been captured by the SDK.
+    #
+    # @return [Boolean]
+    def exception_captured?(exc)
+      return false unless initialized?
+      !!exc.instance_variable_get(CAPTURED_SIGNATURE)
+    end
 
     ##### Helpers #####
 

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -94,6 +94,8 @@ module Sentry
     def capture_exception(exception, **options, &block)
       check_argument_type!(exception, ::Exception)
 
+      return if Sentry.exception_captured?(exception)
+
       return unless current_client
 
       options[:hint] ||= {}
@@ -104,7 +106,7 @@ module Sentry
 
       capture_event(event, **options, &block).tap do
         # mark the exception as captured so we can use this information to avoid duplicated capturing
-        exception.instance_variable_set(:@__sentry_captured, true)
+        exception.instance_variable_set(Sentry::CAPTURED_SIGNATURE, true)
       end
     end
 

--- a/sentry-ruby/spec/initialization_check_spec.rb
+++ b/sentry-ruby/spec/initialization_check_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "with uninitialized SDK" do
   it { expect(Sentry.set_extras(foo: "bar")).to eq(nil) }
   it { expect(Sentry.set_context(foo:  { bar: "baz" })).to eq(nil) }
   it { expect(Sentry.last_event_id).to eq(nil) }
+  it { expect(Sentry.exception_captured?(Exception.new)).to eq(false) }
   it do
     expect { Sentry.configure_scope { raise "foo" } }.not_to raise_error(RuntimeError)
   end

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -50,8 +50,6 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
       end
       stack = described_class.new(app)
 
-      stack.call(env)
-
       expect do
         stack.call(env)
       end.to change { transport.events.count }.by(1)
@@ -198,7 +196,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
       it "doesn't pollute other request's scope" do
         request_1 = lambda do |e|
           Sentry.configure_scope { |s| s.set_tags({tag_1: "foo"}) }
-          e['rack.exception'] = exception
+          e['rack.exception'] = Exception.new
           [200, {}, ["ok"]]
         end
         app_1 = described_class.new(request_1)
@@ -210,7 +208,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
 
         request_2 = proc do |e|
           Sentry.configure_scope { |s| s.set_tags({tag_2: "bar"}) }
-          e['rack.exception'] = exception
+          e['rack.exception'] = Exception.new
           [200, {}, ["ok"]]
         end
         app_2 = described_class.new(request_2)

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -88,17 +88,6 @@ RSpec.describe Sentry do
   end
 
   shared_examples "capture_helper" do
-    context "without any Sentry setup" do
-      before do
-        allow(Sentry).to receive(:get_main_hub)
-        allow(Sentry).to receive(:get_current_hub)
-      end
-
-      it "doesn't cause any issue" do
-        described_class.send(capture_helper, capture_subject)
-      end
-    end
-
     context "with sending_allowed? condition" do
       before do
         expect(Sentry.configuration).to receive(:sending_allowed?).and_return(false)
@@ -520,11 +509,6 @@ RSpec.describe Sentry do
   end
 
   describe ".csp_report_uri" do
-    it "returns nil if the SDK is not initialized" do
-      described_class.instance_variable_set(:@main_hub, nil)
-      expect(described_class.csp_report_uri).to eq(nil)
-    end
-
     it "returns the csp_report_uri generated from the main Configuration" do
       expect(Sentry.configuration).to receive(:csp_report_uri).and_call_original
 

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -183,8 +183,18 @@ RSpec.describe Sentry do
 
     it "sends the exception via current hub" do
       expect do
-        described_class.capture_exception(exception, tags: { foo: "baz" })
+        described_class.capture_exception(exception)
       end.to change { transport.events.count }.by(1)
+    end
+
+    it "doesn't send captured exception" do
+      expect do
+        described_class.capture_exception(exception)
+      end.to change { transport.events.count }.by(1)
+
+      expect do
+        described_class.capture_exception(exception)
+      end.to change { transport.events.count }.by(0)
     end
 
     it "doesn't do anything if the exception is excluded" do
@@ -519,6 +529,18 @@ RSpec.describe Sentry do
       expect(Sentry.configuration).to receive(:csp_report_uri).and_call_original
 
       expect(described_class.csp_report_uri).to eq("http://sentry.localdomain/api/42/security/?sentry_key=12345&sentry_environment=development")
+    end
+  end
+
+  describe ".exception_captured?" do
+    let(:exception) { Exception.new }
+
+    it "returns true if the exception has been captured by the SDK" do
+      expect(described_class.exception_captured?(exception)).to eq(false)
+
+      described_class.capture_exception(exception)
+
+      expect(described_class.exception_captured?(exception)).to eq(true)
     end
   end
 


### PR DESCRIPTION
As described in #1731, the SDK can have duplicated exception report in Rails 7+ applications because of the new `Rails.error` support introduced in version `5.1.0`. 

After a [discussion with the feature author](https://github.com/rails/rails/pull/43625/files#r809532572), we decided to let whichever mechanism captures the exception first report it (could be either `Rails.error` or Sentry's integration in different scenarios). Although it's possible that we'd loss some contextual data with `Rails.error`, the difference is acceptable.

Also, `sentry-python` already has [a similar mechanism](https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/dedupe.py) to de-dup error reports, so it's been proven to work.

Fixes #1731 