### PR TITLE
Replace manual connection control with abstracted execution wrapper

### DIFF
--- a/sentry-rails/lib/sentry/rails/background_worker.rb
+++ b/sentry-rails/lib/sentry/rails/background_worker.rb
@@ -2,7 +2,7 @@ module Sentry
   class BackgroundWorker
     def _perform(&block)
       # make sure the background worker returns AR connection if it accidentally acquire one during serialization
-      ActiveRecord::Base.connection_pool.with_connection do
+      ::Rails.application.executor.wrap do
         block.call
       end
     end

--- a/sentry-rails/spec/dummy/test_rails_app/app.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/app.rb
@@ -2,7 +2,7 @@ ENV["RAILS_ENV"] = "test"
 
 require "rails"
 
-require "active_record"
+require "active_record/railtie"
 require "active_job/railtie"
 require "action_view/railtie"
 require "action_controller/railtie"


### PR DESCRIPTION
As described in [this document](https://github.com/rails/rails/blob/1d9d53831600c974fcccd4b5574f0e03d7e1513c/guides/source/threading_and_code_execution.md#executor), `Rails.application.executor.wrap` should provide a higher-level of abstraction to achieve concurrent execution, which includes returning acquired ActiveRecord connection.

This prevents us from locking in a particular ORM's database connection mechanism.