### PR TITLE
Check envelope size before sending it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 - Log Redis command arguments when sending PII is enabled [#1726](https://github.com/getsentry/sentry-ruby/pull/1726)
 - Add request env to sampling context [#1749](https://github.com/getsentry/sentry-ruby/pull/1749)
+- Check envelope size before sending it [#1747](https://github.com/getsentry/sentry-ruby/pull/1747)
+
+  The SDK will now check if the envelope's event items are oversized before sending the envelope. It goes like this:
+
+  1. If an event is oversized (200kb), the SDK will remove its breadcrumbs (which in our experience is the most common cause).
+  2-1. If the event size now falls within the limit, it'll be sent.
+  2-2. Otherwise, the event will be thrown away. The SDK will also log a debug message about the event's attributes size breakdown. For example,
+
+  ```
+  {event_id: 34, level: 7, timestamp: 22, environment: 13, server_name: 14, modules: 935, message: 5, user: 2, tags: 2, contexts: 820791, extra: 2, fingerprint: 2, platform: 6, sdk: 40, threads: 51690}
+  ```
+
+  This will help users report size-related issues in the future.
+
 
 - Automatic session tracking [#1715](https://github.com/getsentry/sentry-ruby/pull/1715)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@
   The SDK will now check if the envelope's event items are oversized before sending the envelope. It goes like this:
 
   1. If an event is oversized (200kb), the SDK will remove its breadcrumbs (which in our experience is the most common cause).
-  2-1. If the event size now falls within the limit, it'll be sent.
-  2-2. Otherwise, the event will be thrown away. The SDK will also log a debug message about the event's attributes size breakdown. For example,
+  2. If the event size now falls within the limit, it'll be sent.
+  3. Otherwise, the event will be thrown away. The SDK will also log a debug message about the event's attributes size (in bytes) breakdown. For example,
 
   ```
   {event_id: 34, level: 7, timestamp: 22, environment: 13, server_name: 14, modules: 935, message: 5, user: 2, tags: 2, contexts: 820791, extra: 2, fingerprint: 2, platform: 6, sdk: 40, threads: 51690}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,26 @@
-## Unreleased
+## 5.2.0
 
 ### Features
 
 - Log Redis command arguments when sending PII is enabled [#1726](https://github.com/getsentry/sentry-ruby/pull/1726)
 - Add request env to sampling context [#1749](https://github.com/getsentry/sentry-ruby/pull/1749)
+
+  **Example**
+
+  ```rb
+  Sentry.init do |config|
+    config.traces_sampler = lambda do |sampling_context|
+      env = sampling_context[:env]
+
+      if env["REQUEST_METHOD"] == "GET"
+        0.01
+      else
+        0.1
+      end
+    end
+  end
+  ```
+
 - Check envelope size before sending it [#1747](https://github.com/getsentry/sentry-ruby/pull/1747)
 
   The SDK will now check if the envelope's event items are oversized before sending the envelope. It goes like this:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,8 @@
 - Automatic session tracking [#1715](https://github.com/getsentry/sentry-ruby/pull/1715)
 
   **Example**:
-  
-  ![image](https://user-images.githubusercontent.com/6536764/157057827-2893527e-7973-4901-a070-bd78a720574a.png)
 
+  <img width="80%" src="https://user-images.githubusercontent.com/6536764/157057827-2893527e-7973-4901-a070-bd78a720574a.png">
 
   The SDK now supports [automatic session tracking / release health](https://docs.sentry.io/product/releases/health/) by default in Rack based applications.  
   Aggregate statistics on successful / errored requests are collected and sent to the server every minute.  

--- a/sentry-ruby/lib/sentry/envelope.rb
+++ b/sentry-ruby/lib/sentry/envelope.rb
@@ -34,10 +34,6 @@ module Sentry
       @items << Item.new(headers, payload)
     end
 
-    def to_s
-      [JSON.generate(@headers), *@items.map(&:to_s)].join("\n")
-    end
-
     def item_types
       @items.map(&:type)
     end

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -23,6 +23,7 @@ module Sentry
     WRITER_ATTRIBUTES = SERIALIZEABLE_ATTRIBUTES - %i(type timestamp level)
 
     MAX_MESSAGE_SIZE_IN_BYTES = 1024 * 8
+    MAX_SERIALIZED_PAYLOAD_SIZE = 1024 * 200
 
     SKIP_INSPECTION_ATTRIBUTES = [:@modules, :@stacktrace_builder, :@send_default_pii, :@trusted_proxies, :@rack_env_whitelist]
 

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Sentry::HTTPTransport do
   let(:client) { Sentry::Client.new(configuration) }
   let(:event) { client.event_from_message("foobarbaz") }
   let(:data) do
-    subject.envelope_from_event(event.to_hash).to_s
+    subject.serialize_envelope(subject.envelope_from_event(event.to_hash))
   end
 
   subject { client.transport }

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Sentry::HTTPTransport do
   let(:client) { Sentry::Client.new(configuration) }
   let(:event) { client.event_from_message("foobarbaz") }
   let(:data) do
-    subject.serialize_envelope(subject.envelope_from_event(event.to_hash))
+    subject.serialize_envelope(subject.envelope_from_event(event.to_hash)).first
   end
 
   subject { client.transport }

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Sentry::Transport do
       let(:envelope) { subject.envelope_from_event(event) }
 
       it "generates correct envelope content" do
-        result = subject.serialize_envelope(envelope)
+        result, _ = subject.serialize_envelope(envelope)
 
         envelope_header, item_header, item = result.split("\n")
 
@@ -50,7 +50,7 @@ RSpec.describe Sentry::Transport do
       let(:envelope) { subject.envelope_from_event(event) }
 
       it "generates correct envelope content" do
-        result = subject.serialize_envelope(envelope)
+        result, _ = subject.serialize_envelope(envelope)
 
         envelope_header, item_header, item = result.split("\n")
 
@@ -78,7 +78,7 @@ RSpec.describe Sentry::Transport do
 
       it "incudes client report in envelope" do
         Timecop.travel(Time.now + 90) do
-          result = subject.serialize_envelope(envelope)
+          result, _ = subject.serialize_envelope(envelope)
 
           client_report_header, client_report_payload = result.split("\n").last(2)
 
@@ -113,7 +113,7 @@ RSpec.describe Sentry::Transport do
       end
 
       it "removes breadcrumbs and carry on" do
-        data = subject.serialize_envelope(envelope)
+        data, _ = subject.serialize_envelope(envelope)
         expect(data.bytesize).to be < Sentry::Event::MAX_SERIALIZED_PAYLOAD_SIZE
 
         expect(envelope.items.count).to eq(1)
@@ -130,7 +130,7 @@ RSpec.describe Sentry::Transport do
         end
 
         it "rejects the item and logs attributes size breakdown" do
-          data = subject.serialize_envelope(envelope)
+          data, _ = subject.serialize_envelope(envelope)
           expect(data).to be_nil
           expect(io.string).not_to match(/Sending envelope with items \[event\]/)
           expect(io.string).to match(/tags: 2, contexts: 820791, extra: 2/)


### PR DESCRIPTION
Because we now need to check if a serialized envelope item is oversized (see https://github.com/getsentry/sentry-ruby/issues/1603#issuecomment-1019216106), envelope serialization is better performed by Transport to have more control to filter oversized items.