### PR TITLE
fix: TransactionEvent should not set level to :error

### DIFF
--- a/sentry-ruby/lib/sentry/transaction_event.rb
+++ b/sentry-ruby/lib/sentry/transaction_event.rb
@@ -25,6 +25,7 @@ module Sentry
     def initialize(configuration:, integration_meta: nil, message: nil)
       super
       @type = TYPE
+      self.level = nil
     end
 
     # Sets the event's start_timestamp.


### PR DESCRIPTION
Currently, since we derive from `Event`, all transactions are marked with a level `:error` which is slightly confusing for the end user.