### PR TITLE
Explicitly use https as github-sourced gems' protocol

### DIFF
--- a/sentry-delayed_job/Gemfile
+++ b/sentry-delayed_job/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+git_source(:github) { |name| "https://github.com/#{name}.git" }
 
 # Specify your gem's dependencies in sentry-ruby.gemspec
 gemspec

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+git_source(:github) { |name| "https://github.com/#{name}.git" }
 
 # Specify your gem's dependencies in sentry-ruby.gemspec
 gemspec

--- a/sentry-raven/Gemfile
+++ b/sentry-raven/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org/"
+git_source(:github) { |name| "https://github.com/#{name}.git" }
 
 gemspec
 

--- a/sentry-resque/Gemfile
+++ b/sentry-resque/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+git_source(:github) { |name| "https://github.com/#{name}.git" }
 
 # Specify your gem's dependencies in sentry-ruby.gemspec
 gemspec

--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+git_source(:github) { |name| "https://github.com/#{name}.git" }
 
 gem "sentry-ruby-core", path: "./"
 gem "sentry-ruby", path: "./"

--- a/sentry-sidekiq/Gemfile
+++ b/sentry-sidekiq/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+git_source(:github) { |name| "https://github.com/#{name}.git" }
 
 # Specify your gem's dependencies in sentry-ruby.gemspec
 gemspec


### PR DESCRIPTION
To resolve build failures like https://github.com/getsentry/sentry-ruby/runs/5593092069?check_suite_focus=true