### PR TITLE
fix: Set last_event_id only for error events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Bug Fixes
+
+- Set `last_event_id` only for error events [#1767](https://github.com/getsentry/sentry-ruby/pull/1767)
+  - Fixes [#1766](https://github.com/getsentry/sentry-ruby/issues/1766)
+
 ## 5.2.1
 
 ### Bug Fixes

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -150,7 +150,7 @@ module Sentry
         configuration.log_debug(event.to_json_compatible)
       end
 
-      @last_event_id = event&.event_id
+      @last_event_id = event&.event_id unless event.is_a?(Sentry::TransactionEvent)
       event
     end
 

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -444,6 +444,20 @@ RSpec.describe Sentry::Hub do
 
       expect(subject.last_event_id).to eq(event.event_id)
     end
+
+    it 'only records last_event_id for error events' do
+      exception = ZeroDivisionError.new("divided by 0")
+      transaction = Sentry::Transaction.new(name: "test transaction", op: "rack.request", hub: subject)
+
+      error_event = client.event_from_exception(exception)
+      transaction_event = client.event_from_transaction(transaction)
+
+      subject.capture_event(error_event)
+      subject.capture_event(transaction_event)
+
+      expect(subject.last_event_id).to eq(error_event.event_id)
+      expect(subject.last_event_id).not_to eq(transaction_event.event_id)
+    end
   end
 
   describe "#with_background_worker_disabled" do


### PR DESCRIPTION
`last_event_id` only has a valid use case for cross-referencing errors on the end-user UI, updating it for transactions doesn't make sense and [is consistent with python](https://github.com/getsentry/sentry-python/blob/4410e284ad362e31447e060cb07caae9fb4b64a3/sentry_sdk/hub.py#L323-L324).

Fixes #1766 