### PR TITLE
Add config.rails.register_error_subscriber to control error reporter integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Set `last_event_id` only for error events [#1767](https://github.com/getsentry/sentry-ruby/pull/1767)
   - Fixes [#1766](https://github.com/getsentry/sentry-ruby/issues/1766)
+- Add `config.rails.register_error_subscriber` to control error reporter integration [#1771](https://github.com/getsentry/sentry-ruby/pull/1771)
+  - Fixes [#1731](https://github.com/getsentry/sentry-ruby/issues/1731), [#1754](https://github.com/getsentry/sentry-ruby/issues/1754), and [#1765](https://github.com/getsentry/sentry-ruby/issues/1765)
+  - [Discussion thread and explanation on the decision](https://github.com/rails/rails/pull/43625#issuecomment-1072514175)
 
 ## 5.2.1
 

--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -42,6 +42,12 @@ module Sentry
       'ActiveRecord::RecordNotFound'
     ].freeze
     class Configuration
+      # Rails 7.0 introduced a new error reporter feature, which the SDK once opted-in by default.
+      # But after receiving multiple issue reports, the integration seemed to cause serious troubles to some users.
+      # So the integration is now controlled by this configuration, which is disabled (false) by default.
+      # More information can be found from: https://github.com/rails/rails/pull/43625#issuecomment-1072514175
+      attr_accessor :register_error_subscriber
+
       # Rails catches exceptions in the ActionDispatch::ShowExceptions or
       # ActionDispatch::DebugExceptions middlewares, depending on the environment.
       # When `rails_report_rescued_exceptions` is true (it is by default), Sentry
@@ -55,6 +61,7 @@ module Sentry
       attr_accessor :tracing_subscribers
 
       def initialize
+        @register_error_subscriber = false
         @report_rescued_exceptions = true
         @skippable_job_adapters = []
         @tracing_subscribers = Set.new([

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -47,7 +47,7 @@ module Sentry
       inject_breadcrumbs_logger
       activate_tracing
 
-      register_error_subscriber(app) if ::Rails.version.to_f >= 7.0
+      register_error_subscriber(app) if ::Rails.version.to_f >= 7.0 && Sentry.configuration.rails.register_error_subscriber
     end
 
     runner do


### PR DESCRIPTION
As explained in https://github.com/rails/rails/pull/43625#issuecomment-1072514175, we decided to make the integration disabled by default.

Closes #1731, #1754, #1765