### PR TITLE
Register SentryContextClientMiddleware on sidekiq workers

### DIFF
--- a/sentry-sidekiq/lib/sentry-sidekiq.rb
+++ b/sentry-sidekiq/lib/sentry-sidekiq.rb
@@ -29,6 +29,9 @@ Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
     chain.add Sentry::Sidekiq::SentryContextServerMiddleware
   end
+  config.client_middleware do |chain|
+    chain.add Sentry::Sidekiq::SentryContextClientMiddleware
+  end
 end
 
 Sidekiq.configure_client do |config|

--- a/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Sentry::Sidekiq do
   it "registers error handlers and middlewares" do
     expect(Sidekiq.error_handlers).to include(described_class::ErrorHandler)
     expect(Sidekiq.server_middleware.entries.first.klass).to eq(described_class::SentryContextServerMiddleware)
+    expect(Sidekiq.client_middleware.entries.first.klass).to eq(described_class::SentryContextClientMiddleware)
   end
 
   it "captues exception raised in the worker" do


### PR DESCRIPTION
This configuration was missing in order to support the scenario where a sidekiq job itself pushes new jobs.

This meant that although the Sentry user was propagated from the client to the sidekiq server when running a job, it was not propagated again to any new jobs launched from this worker.

This is what is recommend as per [sidekiq's documentation](https://github.com/mperham/sidekiq/wiki/Middleware#client-middleware-registered-in-both-places)
