### PR TITLE
Log message when shutting down/killing SDK managed components

### DIFF
--- a/sentry-ruby/lib/sentry/background_worker.rb
+++ b/sentry-ruby/lib/sentry/background_worker.rb
@@ -29,7 +29,7 @@ module Sentry
           log_debug("config.background_worker_threads is set to 0, all events will be sent synchronously")
           Concurrent::ImmediateExecutor.new
         else
-          log_debug("initialized a background worker with #{@number_of_threads} threads")
+          log_debug("Initializing the background worker with #{@number_of_threads} threads")
 
           executor = Concurrent::ThreadPoolExecutor.new(
             min_threads: 0,
@@ -59,6 +59,7 @@ module Sentry
     end
 
     def shutdown
+      log_debug("Shutting down background worker")
       @shutdown_callback&.call
     end
 

--- a/sentry-ruby/lib/sentry/session_flusher.rb
+++ b/sentry-ruby/lib/sentry/session_flusher.rb
@@ -39,6 +39,7 @@ module Sentry
     end
 
     def kill
+      log_debug("Killing session flusher")
       @thread&.kill
     end
 

--- a/sentry-ruby/spec/sentry/background_worker_spec.rb
+++ b/sentry-ruby/spec/sentry/background_worker_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Sentry::BackgroundWorker do
         expect(worker.number_of_threads).to eq(5)
 
         expect(string_io.string).to match(
-          /initialized a background worker with 5 threads/
+          /Initializing the background worker with 5 threads/
         )
       end
     end
@@ -80,6 +80,17 @@ RSpec.describe Sentry::BackgroundWorker do
 
       sleep(0.1)
       expect(string_io.string).to match(/exception happened in background worker: divided by 0/)
+    end
+  end
+
+  describe "#shutdown" do
+    before { configuration.background_worker_threads = 1 }
+
+    it "logs message about the shutdown" do
+      worker = described_class.new(configuration)
+      worker.shutdown
+
+      expect(string_io.string).to match(/Shutting down background worker/)
     end
   end
 end

--- a/sentry-ruby/spec/sentry/session_flusher_spec.rb
+++ b/sentry-ruby/spec/sentry/session_flusher_spec.rb
@@ -127,4 +127,12 @@ RSpec.describe Sentry::SessionFlusher do
       expect(pending_aggregates.values.first).to include({ errored: 0, exited: 1 })
     end
   end
+
+  describe "#kill" do
+    it "logs message when killing the thread" do
+      subject.kill
+
+      expect(string_io.string).to match(/Killing session flusher/)
+    end
+  end
 end


### PR DESCRIPTION
It'll make issues like https://github.com/getsentry/sentry-ruby/issues/1778 easier to debug in the future.