### PR TITLE
Add `Sentry.with_child_span` for easier span recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Features
+
+- Add `Sentry.with_child_span` for easier span recording [#1783](https://github.com/getsentry/sentry-ruby/pull/1783)
+
 ### Bug Fixes
 
 - Set `last_event_id` only for error events [#1767](https://github.com/getsentry/sentry-ruby/pull/1767)


### PR DESCRIPTION
This PR adds a new `Sentry.with_child_span` API. It'll allow users to record a child span with a block without the need to getting the current span from scope, checking its presence...etc. A simple block wrapping will do the trick:

```rb
Sentry.with_child_span(op: "my op") do |child_span|
  # my operation
  # operation result will be the return value
end
```

Note that if there's no span in the current scope, the block will still be executed. But the yield `child_span` will be `nil` instead.

With this API, it's also easier to fix the child span nesting issue reported in #1723. 