### PR TITLE
Allow config.transport.proxy to be a String or URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   - [Discussion thread and explanation on the decision](https://github.com/rails/rails/pull/43625#issuecomment-1072514175)
 - Check if ActiveRecord connection exists before calling AR connection pool [#1769](https://github.com/getsentry/sentry-ruby/pull/1769)
   - Fixes [#1745](https://github.com/getsentry/sentry-ruby/issues/1745)
+- Update `config.transport.proxy` to allow String and URI values as previously supported by `sentry-ruby` versions <= 4.8 using Faraday
+  - Fixes [#1782](https://github.com/getsentry/sentry-ruby/issues/1782)
 
 ### Refactoring
 
@@ -79,8 +81,8 @@
 
   <img width="80%" src="https://user-images.githubusercontent.com/6536764/157057827-2893527e-7973-4901-a070-bd78a720574a.png">
 
-  The SDK now supports [automatic session tracking / release health](https://docs.sentry.io/product/releases/health/) by default in Rack based applications.  
-  Aggregate statistics on successful / errored requests are collected and sent to the server every minute.  
+  The SDK now supports [automatic session tracking / release health](https://docs.sentry.io/product/releases/health/) by default in Rack based applications.
+  Aggregate statistics on successful / errored requests are collected and sent to the server every minute.
   To use this feature, make sure the SDK can detect your app's release. Or you have set it with:
 
   ```ruby

--- a/sentry-ruby/lib/sentry/transport/http_transport.rb
+++ b/sentry-ruby/lib/sentry/transport/http_transport.rb
@@ -130,7 +130,7 @@ module Sentry
       server = URI(@dsn.server)
 
       connection =
-        if proxy = @transport_configuration.proxy
+        if proxy = normalize_proxy(@transport_configuration.proxy)
           ::Net::HTTP.new(server.hostname, server.port, proxy[:uri].hostname, proxy[:uri].port, proxy[:user], proxy[:password])
         else
           ::Net::HTTP.new(server.hostname, server.port, nil)
@@ -146,6 +146,20 @@ module Sentry
       end
 
       connection
+    end
+
+    def normalize_proxy(proxy)
+      return proxy unless proxy
+
+      case proxy
+      when String
+        uri = URI(proxy)
+        { uri: uri, user: uri.user, password: uri.password }
+      when URI
+        { uri: proxy, user: proxy.user, password: proxy.password }
+      when Hash
+        proxy
+      end
     end
 
     def ssl_configuration

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -103,6 +103,32 @@ RSpec.describe Sentry::HTTPTransport do
       subject.send_data(data)
     end
 
+    it "accepts a custom proxy string" do
+      configuration.transport.proxy = "https://stan:foobar@example.com:8080"
+
+      stub_request(fake_response) do |_, http_obj|
+        expect(http_obj.proxy_address).to eq("example.com")
+        expect(http_obj.proxy_user).to eq("stan")
+        expect(http_obj.proxy_pass).to eq("foobar")
+        expect(http_obj.proxy_port).to eq(8080)
+      end
+
+      subject.send_data(data)
+    end
+
+    it "accepts a custom proxy URI" do
+      configuration.transport.proxy = URI("https://stan:foobar@example.com:8080")
+
+      stub_request(fake_response) do |_, http_obj|
+        expect(http_obj.proxy_address).to eq("example.com")
+        expect(http_obj.proxy_user).to eq("stan")
+        expect(http_obj.proxy_pass).to eq("foobar")
+        expect(http_obj.proxy_port).to eq(8080)
+      end
+
+      subject.send_data(data)
+    end
+
     it "accepts custom timeout" do
       configuration.transport.timeout = 10
 


### PR DESCRIPTION
## Description
Fixes #1782

Update `config.transport.proxy` to allow String and URI values as
previously supported by `sentry-ruby` versions <= 4.8 using Faraday.
