### PR TITLE
Fix net-http tracing's span nesting issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Register SentryContextClientMiddleware on sidekiq workers [#1774](https://github.com/getsentry/sentry-ruby/pull/1774)
 - Add request env to sampling context when using `sentry-rails` [#1792](https://github.com/getsentry/sentry-ruby/pull/1792)
   - Fixes [#1791](https://github.com/getsentry/sentry-ruby/issues/1791)
+- Fix net-http tracing's span nesting issue [#1796](https://github.com/getsentry/sentry-ruby/pull/1796)
 
 ### Refactoring
 

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -74,11 +74,11 @@ module Sentry
       end
 
       def start_sentry_span
-        return unless Sentry.initialized? && transaction = Sentry.get_current_scope.get_transaction
+        return unless Sentry.initialized? && span = Sentry.get_current_scope.get_span
         return if from_sentry_sdk?
-        return if transaction.sampled == false
+        return if span.sampled == false
 
-        transaction.start_child(op: OP_NAME, start_timestamp: Sentry.utc_now.to_f)
+        span.start_child(op: OP_NAME, start_timestamp: Sentry.utc_now.to_f)
       end
 
       def finish_sentry_span(sentry_span)


### PR DESCRIPTION
As mentioned in https://github.com/getsentry/sentry-ruby/pull/1723#issuecomment-1106603275, `net-http` spans should attach to the current span instead of always the top-level transaction.