### PR TITLE
Don't mask real error when converting an event to JSON fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add request env to sampling context when using `sentry-rails` [#1792](https://github.com/getsentry/sentry-ruby/pull/1792)
   - Fixes [#1791](https://github.com/getsentry/sentry-ruby/issues/1791)
 - Fix net-http tracing's span nesting issue [#1796](https://github.com/getsentry/sentry-ruby/pull/1796)
+- Don't mask real error when converting an event to JSON fails [#1797](https://github.com/getsentry/sentry-ruby/pull/1797)
 
 ### Refactoring
 

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -176,7 +176,7 @@ module Sentry
         async_block.call(event_hash)
       end
     rescue => e
-      log_error("Async #{event_hash["type"]} sending failed", e, debug: configuration.debug)
+      log_error("Async #{(event_hash.nil? ? nil : event_hash["type"] )|| "unknown"} sending failed", e, debug: configuration.debug)
       send_event(event, hint)
     end
   end


### PR DESCRIPTION
If the event is unable to be converted to JSON, trying to key into `event_hash` errors because it is `nil`. I'm going to look into how to prevent that issue in a later PR.