### PR TITLE
Fix: Don't expect `.backtrace` to be present

### DIFF
--- a/sentry-raven/CHANGELOG.md
+++ b/sentry-raven/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix: user_context with block does not reset context after block exits
+- fix: Don't expect `.backtrace` to be present
 
 ## 3.1.2
 

--- a/sentry-raven/lib/raven/event.rb
+++ b/sentry-raven/lib/raven/event.rb
@@ -163,7 +163,7 @@ module Raven
             int.module = e.class.to_s.split('::')[0...-1].join('::')
 
             int.stacktrace =
-              if e.backtrace && !backtraces.include?(e.backtrace.object_id)
+              if e.respond_to?(:backtrace) && e.backtrace && !backtraces.include?(e.backtrace.object_id)
                 backtraces << e.backtrace.object_id
                 StacktraceInterface.new do |stacktrace|
                   stacktrace.frames = stacktrace_interface_from(e.backtrace)

--- a/sentry-raven/spec/raven/event_spec.rb
+++ b/sentry-raven/spec/raven/event_spec.rb
@@ -786,6 +786,26 @@ RSpec.describe Raven::Event do
       end
     end
 
+    context 'when the exception does not have a backtrace' do
+      context 'when a Hash' do
+        let(:exception) { {} }
+
+        it 'does not error' do
+          stacktrace = hash[:exception][:values][0][:stacktrace]
+          expect(stacktrace).to be_nil
+        end
+      end
+
+      context 'when a Class' do
+        let(:exception) { Class.new }
+
+        it 'does not error' do
+          stacktrace = hash[:exception][:values][0][:stacktrace]
+          expect(stacktrace).to be_nil
+        end
+      end
+    end
+
     it 'uses an annotation if one exists' do
       Raven.annotate_exception(exception, logger: 'logger')
       expect(Raven::Event.capture_exception(exception, **essential_options).logger).to eq('logger')


### PR DESCRIPTION
## Description

If a non-`Error` type is passed to the `Raven.capture_exception` method,
for instance when ActiveRecord errors are returned, and we've set up
`backtrace`s to be recorded, Raven itself raises an exception because
the `.backtrace` isn't found.

By checking that `:backtrace` is present first, we can make sure we
don't hit these error conditions.

