### PR TITLE
Warn users about config.async's deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Miscellaneous
+
+- Warn users about `config.async`'s deprecation [#1803](https://github.com/getsentry/sentry-ruby/pull/1803)
+
 ## 5.3.0
 
 ### Features

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -290,6 +290,16 @@ module Sentry
     def async=(value)
       check_callable!("async", value)
 
+      log_warn <<~MSG
+
+        sentry-ruby now sends events asynchronously by default with its backgrounrd worker (supported since 4.1.0).
+        The `config.async` callback has become redundant while continuing to cause issues.
+        (The problems of `async` are detailed in https://github.com/getsentry/sentry-ruby/issues/1522)
+
+        Therefore, we encourage you to remove it and let the background worker take care of async job sending.
+      It's deprecation is planned in the next major release (6.0), which is scheduled around the 3rd quarter of 2022.
+      MSG
+
       @async = value
     end
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -292,7 +292,7 @@ module Sentry
 
       log_warn <<~MSG
 
-        sentry-ruby now sends events asynchronously by default with its backgrounrd worker (supported since 4.1.0).
+        sentry-ruby now sends events asynchronously by default with its background worker (supported since 4.1.0).
         The `config.async` callback has become redundant while continuing to cause issues.
         (The problems of `async` are detailed in https://github.com/getsentry/sentry-ruby/issues/1522)
 


### PR DESCRIPTION
Since we're going to drop `config.async` in `6.0` (as explained in #1522), I think we should start warning users about the change.

I did my best to make the message clear and compact, but it'd be great if we can have real professionals to polish it a bit 🙂 