### PR TITLE
Fix: Handle exception with large stacktrace without dropping entire item - by removing stacktrace

### DIFF
--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Individual gem's changelog has been deprecated. Please check the [project changelog](https://github.com/getsentry/sentry-ruby/blob/master/CHANGELOG.md).
 
+## Unreleased
+
+### Bug Fixes
+
+- Fix: Handle exception with large stacktrace without dropping entire item [#1806](https://github.com/getsentry/sentry-ruby/pull/1806)
+
 ## 4.4.2
 
 - Fix NoMethodError when SDK's dsn is nil [#1433](https://github.com/getsentry/sentry-ruby/pull/1433)

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -83,6 +83,26 @@ module Sentry
         end
 
         if result.bytesize > Event::MAX_SERIALIZED_PAYLOAD_SIZE
+          if single_exceptions = item.payload.dig(:exception, :values)
+            single_exceptions.each do |single_exception|
+              traces = single_exception.dig(:stacktrace, :frames)
+              if traces && traces.size > 0
+                single_exception.delete(:stacktrace)
+              end
+            end
+          elsif single_exceptions = item.payload.dig("exception", "values")
+            single_exceptions.each do |single_exception|
+              traces = single_exception.dig("stacktrace", "frames")
+              if traces && traces.size > 0
+                single_exception.delete("stacktrace")
+              end
+            end
+          end
+
+          result = item.to_s
+        end
+
+        if result.bytesize > Event::MAX_SERIALIZED_PAYLOAD_SIZE
           size_breakdown = item.payload.map do |key, value|
             "#{key}: #{JSON.generate(value).bytesize}"
           end.join(", ")


### PR DESCRIPTION
## Description
This should fix #1799

Certain exception type such as `SystemStackError` has long backtrace (thus the stack error)
The whole envelope item was dropped due to payload size limit logic

This ensures it tries to remove the stacktrace when payload is too large, so that the envelope item won't be dropped = exception still reported


Maybe it's better to keep some frames like #1807 instead of removing whole stacktrace