### PR TITLE
Fix: Handle exception with large stacktrace without dropping entire item - by keeping N frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Features
+
+- Handle exception with large stacktrace without dropping entire item [#1807](https://github.com/getsentry/sentry-ruby/pull/1807)
+
 ## 5.3.1
 
 ### Bug Fixes

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -9,6 +9,7 @@ module Sentry
     PROTOCOL_VERSION = '7'
     USER_AGENT = "sentry-ruby/#{Sentry::VERSION}"
     CLIENT_REPORT_INTERVAL = 30
+    STACKTRACE_FRAME_LIMIT_ON_OVERSIZED_PAYLOAD = 500
 
     # https://develop.sentry.dev/sdk/client-reports/#envelope-item-payload
     CLIENT_REPORT_REASONS = [
@@ -77,6 +78,26 @@ module Sentry
             item.payload.delete(:breadcrumbs)
           elsif item.payload.key?("breadcrumbs")
             item.payload.delete("breadcrumbs")
+          end
+
+          result = item.to_s
+        end
+
+        if result.bytesize > Event::MAX_SERIALIZED_PAYLOAD_SIZE
+          if single_exceptions = item.payload.dig(:exception, :values)
+            single_exceptions.each do |single_exception|
+              traces = single_exception.dig(:stacktrace, :frames)
+              if traces && traces.size > STACKTRACE_FRAME_LIMIT_ON_OVERSIZED_PAYLOAD
+                traces.replace(traces[-STACKTRACE_FRAME_LIMIT_ON_OVERSIZED_PAYLOAD..-1])
+              end
+            end
+          elsif single_exceptions = item.payload.dig("exception", "values")
+            single_exceptions.each do |single_exception|
+              traces = single_exception.dig("stacktrace", "frames")
+              if traces && traces.size > STACKTRACE_FRAME_LIMIT_ON_OVERSIZED_PAYLOAD
+                traces.replace(traces[-STACKTRACE_FRAME_LIMIT_ON_OVERSIZED_PAYLOAD..-1])
+              end
+            end
           end
 
           result = item.to_s

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -88,14 +88,20 @@ module Sentry
             single_exceptions.each do |single_exception|
               traces = single_exception.dig(:stacktrace, :frames)
               if traces && traces.size > STACKTRACE_FRAME_LIMIT_ON_OVERSIZED_PAYLOAD
-                traces.replace(traces[-STACKTRACE_FRAME_LIMIT_ON_OVERSIZED_PAYLOAD..-1])
+                size_on_both_ends = STACKTRACE_FRAME_LIMIT_ON_OVERSIZED_PAYLOAD / 2
+                traces.replace(
+                  traces[0..(size_on_both_ends - 1)] + traces[-size_on_both_ends..-1],
+                )
               end
             end
           elsif single_exceptions = item.payload.dig("exception", "values")
             single_exceptions.each do |single_exception|
               traces = single_exception.dig("stacktrace", "frames")
               if traces && traces.size > STACKTRACE_FRAME_LIMIT_ON_OVERSIZED_PAYLOAD
-                traces.replace(traces[-STACKTRACE_FRAME_LIMIT_ON_OVERSIZED_PAYLOAD..-1])
+                size_on_both_ends = STACKTRACE_FRAME_LIMIT_ON_OVERSIZED_PAYLOAD / 2
+                traces.replace(
+                  traces[0..(size_on_both_ends - 1)] + traces[-size_on_both_ends..-1],
+                )
               end
             end
           end


### PR DESCRIPTION

## Description
This should fix #1799

Certain exception type such as `SystemStackError` has long backtrace (thus the stack error)
The whole envelope item was dropped due to payload size limit logic

This ensures it tries to remove most of the stacktrace frames (except first 10) when payload is too large, so that the envelope item won't be dropped = exception still reported

This is an alternative to #1806

Note: `10` is a random number I picked so feel free to suggest other numbers
