### PR TITLE
explain init explicit

### DIFF
--- a/sentry-ruby/README.md
+++ b/sentry-ruby/README.md
@@ -55,13 +55,17 @@ gem "sentry-resque"
 
 ### Configuration
 
-You can use `Sentry.init` to initialize and configure your SDK:
-
+You need to initialize Sentry once with:
 ```ruby
 Sentry.init do |config|
   config.dsn = "MY_DSN"
 end
+```
 
+The DSN can be also set via the `SENTRY_DSN` environment variable, then you
+only need to run:
+```ruby
+Sentry.init
 ```
 
 To learn more about available configuration options, please visit the [official documentation](https://docs.sentry.io/platforms/ruby/configuration/options/).


### PR DESCRIPTION
When i used the `sentry-ruby` standalone in my Sinatra project it didn't work, when i only add the gem. 
The `Sentry.init` command needs to be executed once, as you can see in the screenshots, so that the configuration is loaded.

Without init:
![Screenshot 2022-05-06 at 10 05 51](https://user-images.githubusercontent.com/8770225/167136886-f6168aaf-bee9-4ea5-ab50-57288111c362.png)

With the init command:
![Screenshot 2022-05-06 at 10 06 36](https://user-images.githubusercontent.com/8770225/167136876-e8088166-de80-4233-8f41-0323c25f3a13.png)

