### PR TITLE
Don't require a DB connection, but release one if it is acquired

### DIFF
--- a/sentry-rails/lib/sentry/rails/background_worker.rb
+++ b/sentry-rails/lib/sentry/rails/background_worker.rb
@@ -1,15 +1,10 @@
 module Sentry
   class BackgroundWorker
     def _perform(&block)
-      # some applications have partial or even no AR connection
-      if ActiveRecord::Base.connected?
-        # make sure the background worker returns AR connection if it accidentally acquire one during serialization
-        ActiveRecord::Base.connection_pool.with_connection do
-          block.call
-        end
-      else
-        block.call
-      end
+      block.call
+    ensure
+      # make sure the background worker returns AR connection if it accidentally acquire one during serialization
+      ActiveRecord::Base.connection_pool.release_connection
     end
   end
 end


### PR DESCRIPTION
solves https://github.com/getsentry/sentry-ruby/issues/1808 which evolved from https://github.com/getsentry/sentry-ruby/pull/1320. tip from https://stackoverflow.com/a/26733385.
