### PR TITLE
Fix `sentry-rails`'s flaky test

### DIFF
--- a/sentry-rails/spec/dummy/test_rails_app/app.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/app.rb
@@ -50,6 +50,7 @@ def make_basic_app(&block)
   app.config.secret_key_base = "test"
   app.config.logger = Logger.new(nil)
   app.config.eager_load = true
+  app.config.active_job.queue_adapter = :test
 
   configure_app(app)
 

--- a/sentry-rails/spec/sentry/rails/tracing/active_storage_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_storage_subscriber_spec.rb
@@ -14,21 +14,30 @@ RSpec.describe Sentry::Rails::Tracing::ActiveStorageSubscriber, :subscriber, typ
     end
 
     it "records the upload event" do
+      # make sure AnalyzeJob will be executed immediately
+      ActiveStorage::AnalyzeJob.queue_adapter.perform_enqueued_jobs = true
+
       p = Post.create!
       get "/posts/#{p.id}/attach"
 
       expect(response).to have_http_status(:ok)
-      expect(transport.events.count).to eq(1)
+      expect(transport.events.count).to eq(2)
 
-      transaction = transport.events.first.to_hash
-      expect(transaction[:type]).to eq("transaction")
-      expect(transaction[:spans].count).to eq(1)
+      analysis_transaction = transport.events.first.to_hash
+      expect(analysis_transaction[:type]).to eq("transaction")
+      expect(analysis_transaction[:spans].count).to eq(1)
+      span = analysis_transaction[:spans][0]
+      expect(span[:op]).to eq("service_streaming_download.active_storage")
 
-      span = transaction[:spans][0]
+      request_transaction = transport.events.last.to_hash
+      expect(request_transaction[:type]).to eq("transaction")
+      expect(request_transaction[:spans].count).to eq(1)
+
+      span = request_transaction[:spans][0]
       expect(span[:op]).to eq("service_upload.active_storage")
       expect(span[:description]).to eq("Disk")
       expect(span.dig(:data, :key)).to eq(p.cover.key)
-      expect(span[:trace_id]).to eq(transaction.dig(:contexts, :trace, :trace_id))
+      expect(span[:trace_id]).to eq(request_transaction.dig(:contexts, :trace, :trace_id))
     end
   end
 

--- a/sentry-rails/spec/sentry/rails/tracing/active_storage_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_storage_subscriber_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Sentry::Rails::Tracing::ActiveStorageSubscriber, :subscriber, typ
       get "/posts/#{p.id}/attach"
 
       expect(response).to have_http_status(:ok)
-      transport.events.each { |e| pp e } # TODO: Remove it once this test is not flaky anymore
       expect(transport.events.count).to eq(1)
 
       transaction = transport.events.first.to_hash


### PR DESCRIPTION
[Example run](https://github.com/getsentry/sentry-ruby/runs/6440070246?check_suite_focus=true)

And here's the extra event that occurs from time to time:

```
#<Sentry::TransactionEvent @event_id="87d53f125069472e960ca87fce3f832a", @timestamp=1652606444.550241, 
@platform=:ruby, @type="transaction", @sdk={"name"=>"sentry.ruby", "version"=>"5.3.0"}, @user={}, @extra={}, @contexts={:os=>{:name=>"Linux", :version=>"#26~20.04.1-Ubuntu SMP Thu Apr 7 19:42:45 UTC 2022", :build=>"5.13.0-1022-azure", :kernel_version=>"#26~20.04.1-Ubuntu SMP Thu Apr 7 19:42:45 UTC 2022"}, 
:runtime=>{:name=>"ruby", :version=>"ruby 2.7.6p219 (2022-04-12 revision c9c2245c0a) [x86_64-linux]"}, :trace=>{:trace_id=>"32b53b7d9ab147fa92c55b11f0cf6e3d", :span_id=>"e6066be62a6562ca", :parent_span_id=>nil, :description=>nil, :op=>"active_job", :status=>"ok"}}, @tags={}, @fingerprint=[], @server_name="fv-az201-315", @environment="development", @release="beta", @message="",
 @transaction="ActiveStorage::AnalyzeJob", @start_timestamp=1652606444.5391731, @spans=[{:trace_id=>"32b53b7d9ab147fa92c55b11f0cf6e3d", :span_id=>"8173d176fdd6ebd4", :parent_span_id=>"e6066be62a6562ca", :start_timestamp=>1652606444.5418904, 
:timestamp=>1652606444.5421257, :description=>"Disk", :op=>"service_streaming_download.active_storage", :status=>nil, :tags=>{}, :data=>{:key=>"7b4xf065rgqfw86mnycdb8q44a0u", :service=>"Disk"}}], @level=:error, 
@breadcrumbs=#<Sentry::BreadcrumbBuffer:0x00007f20e8029cb0 @buffer=[nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil]>>
```

We can see its transaction is: `ActiveStorage::AnalyzeJob`. 

The fix is to make sure it happens immediately after the upload, so we can have consistent number of transactions and also test the analyzing job's data.