### PR TITLE
Add `Sentry.with_exception_captured` helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Unreleased
 
+## Features
+
+- Add `Sentry.with_exception_captured` helper [#1814](https://github.com/getsentry/sentry-ruby/pull/1814)
+
+    Usage:
+
+    ```rb
+    Sentry.with_exception_captured do
+     1/1 #=> 1 will be returned
+    end
+
+    Sentry.with_exception_captured do
+     1/0 #=> ZeroDivisionError will be reported and re-raised
+    end
+    ```
+
 ### Bug Fixes
 
 - Don't require a DB connection, but release one if it is acquired [#1812](https://github.com/getsentry/sentry-ruby/pull/1812)

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -360,6 +360,25 @@ module Sentry
       get_current_hub.capture_exception(exception, **options, &block)
     end
 
+    # Takes a block and evaluates it. If the block raised an exception, it reports the exception to Sentry and re-raises it.
+    # If the block ran without exception, it returns the evaluation result.
+    #
+    # @example
+    #   Sentry.with_exception_captured do
+    #     1/1 #=> 1 will be returned
+    #   end
+    #
+    #   Sentry.with_exception_captured do
+    #     1/0 #=> ZeroDivisionError will be reported and re-raised
+    #   end
+    #
+    def with_exception_captured(**options, &block)
+      yield
+    rescue Exception => e
+      capture_exception(e, **options)
+      raise
+    end
+
     # Takes a message string and reports it to Sentry via the currently active hub.
     #
     # @yieldparam scope [Scope]

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -240,6 +240,24 @@ RSpec.describe Sentry do
     end
   end
 
+  describe ".with_exception_captured" do
+    it "returns the block's result" do
+      result = described_class.with_exception_captured { 2 }
+
+      expect(result).to eq(2)
+      expect(transport.events.count).to eq(0)
+    end
+
+    it "rescues and reports the exception happened inside the block" do
+      expect do
+        described_class.with_exception_captured(tags: { foo: "bar" }) { 1/0 }
+      end.to raise_error(ZeroDivisionError)
+
+      expect(transport.events.count).to eq(1)
+      expect(transport.events.first.tags).to eq(foo: "bar")
+    end
+  end
+
   describe ".capture_message" do
     let(:message) { "Test" }
 


### PR DESCRIPTION
This PR adds the `Sentry.with_exception_captured` helper to simplify exception rescuing/reporting logic:

```rb
Sentry.with_exception_captured do
 1/1 #=> 1 will be returned
end

Sentry.with_exception_captured do
 1/0 #=> ZeroDivisionError will be reported and re-raised
end
```

It's the same as:

```rb
begin
  my_code
rescue Exception => e
  Sentry.caputre_exception(e)
  raise
end
```