### PR TITLE
explain init explicit

### DIFF
--- a/sentry-ruby/README.md
+++ b/sentry-ruby/README.md
@@ -55,13 +55,11 @@ gem "sentry-resque"
 
 ### Configuration
 
-You can use `Sentry.init` to initialize and configure your SDK:
-
+You need to use Sentry.init to initialize and configure your SDK:
 ```ruby
 Sentry.init do |config|
   config.dsn = "MY_DSN"
 end
-
 ```
 
 To learn more about available configuration options, please visit the [official documentation](https://docs.sentry.io/platforms/ruby/configuration/options/).


### PR DESCRIPTION
I accidentally closed the other PR: [https://github.com/getsentry/sentry-ruby/pull/1811](https://github.com/getsentry/sentry-ruby/pull/1811), where @sl0thentr0py suggested to only change the basic wording.

So that it is clear that the `init` call is mandatory.