### PR TITLE
Create config.yml for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📚 SDK Documentation
+    url: https://docs.sentry.io/
+    about: Check the SDK documentation
+    
+  - name: 📚 Ruby API Documentation
+    url: https://www.rubydoc.info/gems/sentry-ruby-core/Sentry
+    about: Check the SDK's Ruby API documentation
+
+  - name: 💬 Community Discord
+    url: https://discord.gg/PXa5Apfe7K
+    about: Ping us on Discord if you have questions


### PR DESCRIPTION
This can add helpful links to issue opening page. Here's an example from @banzaicloud's (where I got the inspiration)

<img width="80%" alt="截圖 2022-05-11 11 30 12" src="https://user-images.githubusercontent.com/5079556/167829527-3a0630fd-b59c-4d24-9195-6e1f771b159a.png">

