### PR TITLE
Sentry.with_child_span should check SDK's initialization state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Don't require a DB connection, but release one if it is acquired [#1812](https://github.com/getsentry/sentry-ruby/pull/1812)
   - Fixes [#1808](https://github.com/getsentry/sentry-ruby/issues/1808)
+- `Sentry.with_child_span` should check SDK's initialization state [#1819](https://github.com/getsentry/sentry-ruby/pull/1819)
+  - Fixes [#1818](https://github.com/getsentry/sentry-ruby/issues/1818)
 
 ### Miscellaneous
 

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -399,9 +399,7 @@ module Sentry
     #   end
     #
     def with_child_span(**attributes, &block)
-      current_span = get_current_scope.get_span
-
-      if current_span
+      if Sentry.initialized? && current_span = get_current_scope.get_span
         result = nil
 
         begin

--- a/sentry-ruby/spec/initialization_check_spec.rb
+++ b/sentry-ruby/spec/initialization_check_spec.rb
@@ -25,5 +25,10 @@ RSpec.describe "with uninitialized SDK" do
   it do
     expect { Sentry.with_scope { raise "foo" } }.not_to raise_error(RuntimeError)
   end
+
+  it do
+    result = Sentry.with_child_span { "foo" }
+    expect(result).to eq("foo")
+  end
 end
 


### PR DESCRIPTION
Fixes #1818