### PR TITLE
Capture Rails runner's exceptions before exiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Features
+
+- Capture Rails runner's exceptions before exiting [#1820](https://github.com/getsentry/sentry-ruby/pull/1820)
+
 ## 5.3.1
 
 ### Bug Fixes

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -53,6 +53,11 @@ module Sentry
     runner do
       next unless Sentry.initialized?
       Sentry.configuration.background_worker_threads = 0
+
+      at_exit do
+        # TODO: Add a condition for Rails 7.1 to avoid confliction with https://github.com/rails/rails/pull/44999
+        Sentry::Rails.capture_exception($ERROR_INFO, tags: { source: "runner" }) if $ERROR_INFO
+      end
     end
 
     def configure_project_root


### PR DESCRIPTION
Rails currently doesn't provide any callback for capturing Rails runner's exceptions, so we need to use `at_exit` for it. But it should be supported in 7.1 (PR: https://github.com/rails/rails/pull/44999) via the enhanced error reporter integration.

And because it's very complicated, if not impossible, to monitor if a Rails runner process reports to Sentry, so I didn't add any test for it. I used this for testing instead:

```
bundle exec rails runner "1/0" # should be reported
bundle exec rails runner "1/1" # doesn't do anything
```

Implements and closes #1789