### PR TITLE
Replace sentry-ruby-core with sentry-ruby as integration dependency

### DIFF
--- a/.scripts/batch_release.rb
+++ b/.scripts/batch_release.rb
@@ -22,7 +22,7 @@ end
 def update_gemspec_dependency(gem_name, version)
   file_name = "#{gem_name}/#{gem_name}.gemspec"
   text = File.read(file_name)
-  new_contents = text.gsub(/spec.add_dependency "sentry-ruby-core", ".+"/, "spec.add_dependency \"sentry-ruby-core\", \"~> #{version}\"")
+  new_contents = text.gsub(/spec.add_dependency "sentry-ruby", ".+"/, "spec.add_dependency \"sentry-ruby\", \"~> #{version}\"")
   File.open(file_name, "w") {|file| file.puts new_contents }
 end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Refactoring
 
 - Move envelope item processing/trimming logic to the Item class [#1824](https://github.com/getsentry/sentry-ruby/pull/1824)
+- Replace sentry-ruby-core with sentry-ruby as integration dependency [#1825](https://github.com/getsentry/sentry-ruby/pull/1825)
 
 ## 5.3.1
 

--- a/sentry-delayed_job/sentry-delayed_job.gemspec
+++ b/sentry-delayed_job/sentry-delayed_job.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sentry-ruby-core", "~> 5.3.1"
+  spec.add_dependency "sentry-ruby", "~> 5.3.1"
   spec.add_dependency "delayed_job", ">= 4.0"
 end

--- a/sentry-rails/sentry-rails.gemspec
+++ b/sentry-rails/sentry-rails.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "railties", ">= 5.0"
-  spec.add_dependency "sentry-ruby-core", "~> 5.3.1"
+  spec.add_dependency "sentry-ruby", "~> 5.3.1"
 end

--- a/sentry-resque/sentry-resque.gemspec
+++ b/sentry-resque/sentry-resque.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sentry-ruby-core", "~> 5.3.1"
+  spec.add_dependency "sentry-ruby", "~> 5.3.1"
   spec.add_dependency "resque", ">= 1.24"
 end

--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 git_source(:github) { |name| "https://github.com/#{name}.git" }
 
-gem "sentry-ruby-core", path: "./"
 gem "sentry-ruby", path: "./"
 
 gem "rack" unless ENV["WITHOUT_RACK"] == "1"

--- a/sentry-ruby/sentry-ruby-core.gemspec
+++ b/sentry-ruby/sentry-ruby-core.gemspec
@@ -18,9 +18,6 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"
 
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
-
+  spec.add_dependency "sentry-ruby", Sentry::VERSION
   spec.add_dependency "concurrent-ruby"
 end

--- a/sentry-ruby/sentry-ruby.gemspec
+++ b/sentry-ruby/sentry-ruby.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"
 
-  spec.add_dependency "sentry-ruby-core", Sentry::VERSION
+  spec.require_paths = ["lib"]
+
   spec.add_dependency "concurrent-ruby", '~> 1.0', '>= 1.0.2'
 end

--- a/sentry-sidekiq/sentry-sidekiq.gemspec
+++ b/sentry-sidekiq/sentry-sidekiq.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sentry-ruby-core", "~> 5.3.1"
+  spec.add_dependency "sentry-ruby", "~> 5.3.1"
   spec.add_dependency "sidekiq", ">= 3.0"
 end


### PR DESCRIPTION
`sentry-ruby-core` was created for loosing version requirement on faraday. It's the actual code container and `sentry-ruby` just wraps around it with a version requirement. But since faraday is now dropped, this extra structure is not needed anymore.

The plan is to make `sentry-ruby` the gem that holds the logic and point integrations to it. And `sentry-ruby-core` will just depend on `sentry-ruby` and does nothing for backward compatibility.

Closes #1815