### PR TITLE
Don't load application code before application is initialized

### DIFF
--- a/sentry-rails/spec/dummy/test_rails_app/app.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/app.rb
@@ -23,18 +23,22 @@ v6_1 = Gem::Version.new("6.1")
 v7_0 = Gem::Version.new("7.0")
 v7_1 = Gem::Version.new("7.1")
 
-case Gem::Version.new(Rails.version)
-when -> (v) { v < v5_2 }
-  require "dummy/test_rails_app/apps/5-0"
-when -> (v) { v.between?(v5_2, v6_0) }
-  require "dummy/test_rails_app/apps/5-2"
-when -> (v) { v.between?(v6_0, v6_1) }
-  require "dummy/test_rails_app/apps/6-0"
-when -> (v) { v.between?(v6_1, v7_0) }
-  require "dummy/test_rails_app/apps/6-1"
-when -> (v) { v.between?(v7_0, v7_1) }
-  require "dummy/test_rails_app/apps/7-0"
-end
+FILE_NAME =
+  case Gem::Version.new(Rails.version)
+  when -> (v) { v < v5_2 }
+    "5-0"
+  when -> (v) { v.between?(v5_2, v6_0) }
+    "5-2"
+  when -> (v) { v.between?(v6_0, v6_1) }
+    "6-0"
+  when -> (v) { v.between?(v6_1, v7_0) }
+    "6-1"
+  when -> (v) { v.between?(v7_0, v7_1) }
+    "7-0"
+  end
+
+# require files and defined relevant setup methods for the Rails version
+require "dummy/test_rails_app/configs/#{FILE_NAME}"
 
 def make_basic_app(&block)
   run_pre_initialize_cleanup
@@ -85,6 +89,9 @@ def make_basic_app(&block)
   app.initialize!
 
   Rails.application = app
+
+  # load application code for the Rails version
+  require "dummy/test_rails_app/apps/#{FILE_NAME}"
 
   Post.all.to_a # to run the sqlte version query first
 

--- a/sentry-rails/spec/dummy/test_rails_app/app.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/app.rb
@@ -13,7 +13,6 @@ ActiveSupport::Deprecation.silenced = true
 ActiveRecord::Base.logger = Logger.new(nil)
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "db")
 
-# need to init app before establish connection so sqlite can place the database file under the correct project root
 class TestApp < Rails::Application
 end
 

--- a/sentry-rails/spec/dummy/test_rails_app/apps/5-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/5-0.rb
@@ -69,7 +69,3 @@ class HelloController < ActionController::Base
     raise ActionController::BadRequest
   end
 end
-
-def run_pre_initialize_cleanup; end
-
-def configure_app(app); end

--- a/sentry-rails/spec/dummy/test_rails_app/apps/5-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/5-0.rb
@@ -7,15 +7,11 @@ ActiveRecord::Schema.define do
   end
 end
 
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-end
-
-class Post < ApplicationRecord
+class Post < ActiveRecord::Base
   has_many :comments
 end
 
-class Comment < ApplicationRecord
+class Comment < ActiveRecord::Base
   belongs_to :post
 end
 

--- a/sentry-rails/spec/dummy/test_rails_app/apps/5-2.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/5-2.rb
@@ -1,5 +1,3 @@
-require "active_storage/engine"
-
 ActiveRecord::Schema.define do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -115,10 +113,3 @@ class HelloController < ActionController::Base
     raise ActionController::BadRequest
   end
 end
-
-def run_pre_initialize_cleanup; end
-
-def configure_app(app)
-  app.config.active_storage.service = :test
-end
-

--- a/sentry-rails/spec/dummy/test_rails_app/apps/5-2.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/5-2.rb
@@ -35,18 +35,12 @@ ActiveRecord::Schema.define do
   end
 end
 
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-
-  extend ActiveStorage::Attached::Macros
-end
-
-class Post < ApplicationRecord
+class Post < ActiveRecord::Base
   has_many :comments
   has_one_attached :cover
 end
 
-class Comment < ApplicationRecord
+class Comment < ActiveRecord::Base
   belongs_to :post
 end
 

--- a/sentry-rails/spec/dummy/test_rails_app/apps/6-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/6-0.rb
@@ -1,6 +1,3 @@
-require "active_storage/engine"
-require "action_cable/engine"
-
 ActiveRecord::Schema.define do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -118,15 +115,3 @@ class HelloController < ActionController::Base
     raise ActionController::BadRequest
   end
 end
-
-def run_pre_initialize_cleanup
-  ActionCable::Channel::Base.reset_callbacks(:subscribe)
-  ActionCable::Channel::Base.reset_callbacks(:unsubscribe)
-end
-
-def configure_app(app)
-  app.config.active_storage.service = :test
-  app.config.active_record.sqlite3 = ActiveSupport::OrderedOptions.new
-  app.config.active_record.sqlite3.represent_boolean_as_integer = nil
-end
-

--- a/sentry-rails/spec/dummy/test_rails_app/apps/6-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/6-0.rb
@@ -35,20 +35,12 @@ ActiveRecord::Schema.define do
   end
 end
 
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-
-  include ActiveStorage::Attached::Model
-  include ActiveStorage::Reflection::ActiveRecordExtensions
-  ActiveRecord::Reflection.singleton_class.prepend(ActiveStorage::Reflection::ReflectionExtension)
-end
-
-class Post < ApplicationRecord
+class Post < ActiveRecord::Base
   has_many :comments
   has_one_attached :cover
 end
 
-class Comment < ApplicationRecord
+class Comment < ActiveRecord::Base
   belongs_to :post
 end
 

--- a/sentry-rails/spec/dummy/test_rails_app/apps/6-1.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/6-1.rb
@@ -1,6 +1,3 @@
-require "active_storage/engine"
-require "action_cable/engine"
-
 ActiveRecord::Schema.define do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -119,13 +116,3 @@ class HelloController < ActionController::Base
     raise ActionController::BadRequest
   end
 end
-
-def run_pre_initialize_cleanup
-  ActionCable::Channel::Base.reset_callbacks(:subscribe)
-  ActionCable::Channel::Base.reset_callbacks(:unsubscribe)
-end
-
-def configure_app(app)
-  app.config.active_storage.service = :test
-end
-

--- a/sentry-rails/spec/dummy/test_rails_app/apps/6-1.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/6-1.rb
@@ -35,20 +35,12 @@ ActiveRecord::Schema.define do
   end
 end
 
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-
-  include ActiveStorage::Attached::Model
-  include ActiveStorage::Reflection::ActiveRecordExtensions
-  ActiveRecord::Reflection.singleton_class.prepend(ActiveStorage::Reflection::ReflectionExtension)
-end
-
-class Post < ApplicationRecord
+class Post < ActiveRecord::Base
   has_many :comments
   has_one_attached :cover
 end
 
-class Comment < ApplicationRecord
+class Comment < ActiveRecord::Base
   belongs_to :post
 end
 

--- a/sentry-rails/spec/dummy/test_rails_app/apps/7-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/7-0.rb
@@ -1,6 +1,3 @@
-require "active_storage/engine"
-require "action_cable/engine"
-
 ActiveRecord::Schema.define do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -118,32 +115,4 @@ class HelloController < ActionController::Base
   def not_found
     raise ActionController::BadRequest
   end
-end
-
-def run_pre_initialize_cleanup
-  # Zeitwerk checks if registered loaders load paths repeatedly and raises error if that happens.
-  # And because every new Rails::Application instance registers its own loader, we need to clear previously registered ones from Zeitwerk.
-  Zeitwerk::Registry.loaders.clear
-
-  # Rails removes the support of multiple instances, which includes freezing some setting values.
-  # This is the workaround to avoid FrozenError. Related issue: https://github.com/rails/rails/issues/42319
-  ActiveSupport::Dependencies.autoload_once_paths = []
-  ActiveSupport::Dependencies.autoload_paths = []
-
-  # there are a few Rails initializers/finializers that register hook to the executor
-  # because the callbacks are stored inside the `ActiveSupport::Executor` class instead of an instance
-  # the callbacks duplicate after each time we initialize the application and cause issues when they're executed
-  ActiveSupport::Executor.reset_callbacks(:run)
-  ActiveSupport::Executor.reset_callbacks(:complete)
-
-  # Rails uses this module to set a global context for its ErrorReporter feature.
-  # this needs to be cleared so previously set context won't pollute later reportings (see ErrorSubscriber).
-  ActiveSupport::ExecutionContext.clear
-
-  ActionCable::Channel::Base.reset_callbacks(:subscribe)
-  ActionCable::Channel::Base.reset_callbacks(:unsubscribe)
-end
-
-def configure_app(app)
-  app.config.active_storage.service = :test
 end

--- a/sentry-rails/spec/dummy/test_rails_app/apps/7-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/7-0.rb
@@ -35,20 +35,12 @@ ActiveRecord::Schema.define do
   end
 end
 
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-
-  include ActiveStorage::Attached::Model
-  include ActiveStorage::Reflection::ActiveRecordExtensions
-  ActiveRecord::Reflection.singleton_class.prepend(ActiveStorage::Reflection::ReflectionExtension)
-end
-
-class Post < ApplicationRecord
+class Post < ActiveRecord::Base
   has_many :comments
   has_one_attached :cover
 end
 
-class Comment < ApplicationRecord
+class Comment < ActiveRecord::Base
   belongs_to :post
 end
 

--- a/sentry-rails/spec/dummy/test_rails_app/configs/5-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/5-0.rb
@@ -1,0 +1,3 @@
+def run_pre_initialize_cleanup; end
+
+def configure_app(app); end

--- a/sentry-rails/spec/dummy/test_rails_app/configs/5-2.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/5-2.rb
@@ -1,0 +1,8 @@
+require "active_storage/engine"
+
+def run_pre_initialize_cleanup; end
+
+def configure_app(app)
+  app.config.active_storage.service = :test
+end
+

--- a/sentry-rails/spec/dummy/test_rails_app/configs/6-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/6-0.rb
@@ -1,0 +1,14 @@
+require "active_storage/engine"
+require "action_cable/engine"
+
+def run_pre_initialize_cleanup
+  ActionCable::Channel::Base.reset_callbacks(:subscribe)
+  ActionCable::Channel::Base.reset_callbacks(:unsubscribe)
+end
+
+def configure_app(app)
+  app.config.active_storage.service = :test
+  app.config.active_record.sqlite3 = ActiveSupport::OrderedOptions.new
+  app.config.active_record.sqlite3.represent_boolean_as_integer = nil
+end
+

--- a/sentry-rails/spec/dummy/test_rails_app/configs/6-1.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/6-1.rb
@@ -1,0 +1,12 @@
+require "active_storage/engine"
+require "action_cable/engine"
+
+def run_pre_initialize_cleanup
+  ActionCable::Channel::Base.reset_callbacks(:subscribe)
+  ActionCable::Channel::Base.reset_callbacks(:unsubscribe)
+end
+
+def configure_app(app)
+  app.config.active_storage.service = :test
+end
+

--- a/sentry-rails/spec/dummy/test_rails_app/configs/7-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/7-0.rb
@@ -1,0 +1,30 @@
+require "active_storage/engine"
+require "action_cable/engine"
+
+def run_pre_initialize_cleanup
+  # Zeitwerk checks if registered loaders load paths repeatedly and raises error if that happens.
+  # And because every new Rails::Application instance registers its own loader, we need to clear previously registered ones from Zeitwerk.
+  Zeitwerk::Registry.loaders.clear
+
+  # Rails removes the support of multiple instances, which includes freezing some setting values.
+  # This is the workaround to avoid FrozenError. Related issue: https://github.com/rails/rails/issues/42319
+  ActiveSupport::Dependencies.autoload_once_paths = []
+  ActiveSupport::Dependencies.autoload_paths = []
+
+  # there are a few Rails initializers/finializers that register hook to the executor
+  # because the callbacks are stored inside the `ActiveSupport::Executor` class instead of an instance
+  # the callbacks duplicate after each time we initialize the application and cause issues when they're executed
+  ActiveSupport::Executor.reset_callbacks(:run)
+  ActiveSupport::Executor.reset_callbacks(:complete)
+
+  # Rails uses this module to set a global context for its ErrorReporter feature.
+  # this needs to be cleared so previously set context won't pollute later reportings (see ErrorSubscriber).
+  ActiveSupport::ExecutionContext.clear
+
+  ActionCable::Channel::Base.reset_callbacks(:subscribe)
+  ActionCable::Channel::Base.reset_callbacks(:unsubscribe)
+end
+
+def configure_app(app)
+  app.config.active_storage.service = :test
+end


### PR DESCRIPTION
Basically, Rails app (things fall under `/app`) is expected to be loaded **after** the application is initialized.  But I tried to contain all stuff in a single file (per-version) so I didn't do that. As a result, we need to manually extend `ApplicationRecord` with `ActiveStorage` stuff, which was fine.

However, during my testing with Rails main (for error reporting API improvements), I found that we'll need to add more that kind of workaround. So I think it's time to split things up and make it cleaner.