### PR TITLE
Follow Sidekiq's configuration refactor

### DIFF
--- a/sentry-sidekiq/spec/sentry/sidekiq/error_handler_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/error_handler_spec.rb
@@ -26,9 +26,7 @@ RSpec.describe Sentry::Sidekiq::ErrorHandler do
   end
 
   let(:processor) do
-    opts = { :queues => ['default'] }
-    manager = Sidekiq::Manager.new(opts)
-    manager.workers.first
+    new_processor
   end
 
   it "captures exceptions raised during events" do

--- a/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
@@ -4,8 +4,7 @@ RSpec.shared_context "sidekiq", shared_context: :metadata do
   let(:user) { { "id" => rand(10_000) } }
 
   let(:processor) do
-    options = { queues: ['default'] }
-    Sidekiq::Manager.new(options).workers.first
+    new_processor
   end
 
   let(:transport) do

--- a/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
@@ -27,9 +27,7 @@ RSpec.describe Sentry::Sidekiq do
   end
 
   let(:processor) do
-    opts = { :queues => ['default'] }
-    manager = Sidekiq::Manager.new(opts)
-    manager.workers.first
+    new_processor
   end
 
   let(:transport) do

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -141,6 +141,19 @@ class TagsWorker
   def perform; end
 end
 
+def new_processor
+  options =
+    if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("6.0")
+      Sidekiq[:queue] = ['default']
+      Sidekiq
+    else
+      { queues: ['default'] }
+    end
+
+  manager = Sidekiq::Manager.new(options)
+  manager.workers.first
+end
+
 def execute_worker(processor, klass, **options)
   klass_options = klass.sidekiq_options_hash || {}
 


### PR DESCRIPTION
Sidekiq starts to store/pass configurations differently, which doesn't
affect the SDK itself. But we need to update the test setup accordingly.

Related PR:https://github.com/mperham/sidekiq/pull/5340