### PR TITLE
Prepare for Rails 7.1's error reporter API change

### DIFF
--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -24,7 +24,9 @@ jobs:
           - { os: ubuntu-latest, ruby_version: '3.1', rails_version: 6.1.0, options: { codecov: 1 } }
           - { os: ubuntu-latest, ruby_version: '2.7', rails_version: 7.0.0 }
           - { os: ubuntu-latest, ruby_version: '3.0', rails_version: 7.0.0 }
+          - { os: ubuntu-latest, ruby_version: '3.0', rails_version: 7.1.0 }
           - { os: ubuntu-latest, ruby_version: '3.1', rails_version: 7.0.0 }
+          - { os: ubuntu-latest, ruby_version: '3.1', rails_version: 7.1.0 }
         exclude:
           - ruby_version: 2.4
             rails_version: 6.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
      1/0 #=> ZeroDivisionError will be reported and re-raised
     end
     ```
+- Prepare for Rails 7.1's error reporter API change [#1834](https://github.com/getsentry/sentry-ruby/pull/1834)
 
 ### Refactoring
 

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -18,8 +18,8 @@ else
   gem "sqlite3", platform: :ruby
 end
 
-if rails_version >= Gem::Version.new("7.0.0")
-  gem "rails", github: "rails/rails", branch: "7-0-stable"
+if rails_version > Gem::Version.new("7.0.0")
+  gem "rails", github: "rails/rails"
 else
   gem "rails", "~> #{rails_version}"
 end

--- a/sentry-rails/lib/sentry/rails/error_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/error_subscriber.rb
@@ -3,13 +3,13 @@ module Sentry
     # This is not a user-facing class. You should use it with Rails 7.0's error reporter feature and its interfaces.
     # See https://github.com/rails/rails/blob/main/activesupport/lib/active_support/error_reporter.rb for more information.
     class ErrorSubscriber
-      SKIP_SOURCES = [/.*_cache_store.active_support/]
+      SKIP_SOURCES = Regexp.union([/.*_cache_store.active_support/])
 
       def report(error, handled:, severity:, context:, source: nil)
         tags = { handled: handled }
 
         if source
-          return if SKIP_SOURCES.any? { |skip_source| skip_source.match?(source) }
+          return if SKIP_SOURCES.match?(source)
           tags[:source] = source
         end
 

--- a/sentry-rails/lib/sentry/rails/error_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/error_subscriber.rb
@@ -3,8 +3,11 @@ module Sentry
     # This is not a user-facing class. You should use it with Rails 7.0's error reporter feature and its interfaces.
     # See https://github.com/rails/rails/blob/main/activesupport/lib/active_support/error_reporter.rb for more information.
     class ErrorSubscriber
-      def report(error, handled:, severity:, context:)
-        Sentry::Rails.capture_exception(error, level: severity, contexts: { "rails.error" => context }, tags: { handled: handled })
+      def report(error, handled:, severity:, context:, source: nil)
+        tags = { handled: handled }
+        tags[:source] = source if source
+
+        Sentry::Rails.capture_exception(error, level: severity, contexts: { "rails.error" => context }, tags: tags)
       end
     end
   end

--- a/sentry-rails/lib/sentry/rails/error_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/error_subscriber.rb
@@ -3,9 +3,15 @@ module Sentry
     # This is not a user-facing class. You should use it with Rails 7.0's error reporter feature and its interfaces.
     # See https://github.com/rails/rails/blob/main/activesupport/lib/active_support/error_reporter.rb for more information.
     class ErrorSubscriber
+      SKIP_SOURCES = [/.*_cache_store.active_support/]
+
       def report(error, handled:, severity:, context:, source: nil)
         tags = { handled: handled }
-        tags[:source] = source if source
+
+        if source
+          return if SKIP_SOURCES.any? { |skip_source| skip_source.match?(source) }
+          tags[:source] = source
+        end
 
         Sentry::Rails.capture_exception(error, level: severity, contexts: { "rails.error" => context }, tags: tags)
       end

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -250,7 +250,13 @@ RSpec.describe Sentry::Rails, type: :request do
         expect(transport.events.count).to eq(1)
 
         event = transport.events.first
-        expect(event.tags).to eq({ handled: true })
+
+        if Rails.version.to_f > 7.0
+          expect(event.tags).to eq({ handled: true, source: "application" })
+        else
+          expect(event.tags).to eq({ handled: true })
+        end
+
         expect(event.level).to eq(:info)
         expect(event.contexts).to include({ "rails.error" => { foo: "bar" }})
       end

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -260,6 +260,14 @@ RSpec.describe Sentry::Rails, type: :request do
         expect(event.level).to eq(:info)
         expect(event.contexts).to include({ "rails.error" => { foo: "bar" }})
       end
+
+      it "skips cache storage sources", skip: Rails.version.to_f < 7.1 do
+        Rails.error.handle(severity: :info, source: "mem_cache_store.active_support") do
+          1/0
+        end
+
+        expect(transport.events.count).to eq(0)
+      end
     end
   end
 end


### PR DESCRIPTION
Rails 7.1 will introduce a new `source` keyword argument to `ErrorReporter` APIs. So we should support that as well.

Related PR: https://github.com/rails/rails/pull/44998