### PR TITLE
Support `Transaction#set_measurement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@
     end
     ```
 
+- Support `Sentry::Transaction#set_measurement` [#1838](https://github.com/getsentry/sentry-ruby/pull/1838)
+
+    Usage:
+
+    ```rb
+    transaction = Sentry.get_current_scope.get_transaction
+    transaction.set_measurement("metrics.foo", 0.5, "millisecond")
+    ```
+
 ### Bug Fixes
 
 - Support redis-rb 5.0+ [#1963](https://github.com/getsentry/sentry-ruby/pull/1963)

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -37,6 +37,10 @@ module Sentry
     # @return [Baggage, nil]
     attr_reader :baggage
 
+    # The measurements added to the transaction.
+    # @return [Hash]
+    attr_reader :measurements
+
     # @deprecated Use Sentry.get_current_hub instead.
     attr_reader :hub
 
@@ -78,6 +82,7 @@ module Sentry
       @dsn = hub.configuration.dsn
       @effective_sample_rate = nil
       @contexts = {}
+      @measurements = {}
       init_span_recorder
     end
 
@@ -161,6 +166,15 @@ module Sentry
       end
 
       copy
+    end
+
+    # Sets a custom measurement on the transaction.
+    # @param name [String] name of the measurement
+    # @param value [Float] value of the measurement
+    # @param unit [String] unit of the measurement
+    # @return [void]
+    def set_measurement(name, value, unit = "")
+      @measurements[name] = { value: value, unit: unit }
     end
 
     # Sets initial sampling decision of the transaction.

--- a/sentry-ruby/lib/sentry/transaction_event.rb
+++ b/sentry-ruby/lib/sentry/transaction_event.rb
@@ -11,6 +11,9 @@ module Sentry
     # @return [Hash, nil]
     attr_accessor :dynamic_sampling_context
 
+    # @return [Hash]
+    attr_accessor :measurements
+
     # @return [Float, nil]
     attr_reader :start_timestamp
 
@@ -25,6 +28,7 @@ module Sentry
       self.start_timestamp = transaction.start_timestamp
       self.tags = transaction.tags
       self.dynamic_sampling_context = transaction.get_baggage.dynamic_sampling_context
+      self.measurements = transaction.measurements
 
       finished_spans = transaction.span_recorder.spans.select { |span| span.timestamp && span != transaction }
       self.spans = finished_spans.map(&:to_hash)
@@ -42,6 +46,7 @@ module Sentry
       data = super
       data[:spans] = @spans.map(&:to_hash) if @spans
       data[:start_timestamp] = @start_timestamp
+      data[:measurements] = @measurements
       data
     end
   end


### PR DESCRIPTION
This PR adds the concept of custom measurement to `Transaction` and a new `Transaction#set_measurement` API. It should be the Ruby equivalent of https://github.com/getsentry/sentry-python/pull/1359.

### Changes

- Add `config.custom_measurements` for toggling custom measurement's activation (default: inactive).
- Add `Transaction#measurements` and `Transaction#set_measurement(name, value, unit = "")`. 

