### PR TITLE
Install mini_magick to let ActiveStorage tests finish analyzing too

### DIFF
--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -47,12 +47,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Install sqlite
+    - name: Install sqlite and ImageMagick
       run: |
         # See https://github.community/t5/GitHub-Actions/ubuntu-latest-Apt-repository-list-issues/td-p/41122/page/2
         for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
         sudo apt-get update
-        sudo apt-get install libsqlite3-dev
+        sudo apt-get install libsqlite3-dev imagemagick
     - name: Set up Ruby ${{ matrix.ruby_version }}
       uses: ruby/setup-ruby@v1
       with:

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -24,6 +24,8 @@ else
   gem "rails", "~> #{rails_version}"
 end
 
+gem "mini_magick"
+
 gem "sprockets-rails"
 
 gem "sidekiq"

--- a/sentry-rails/spec/sentry/rails/tracing/active_storage_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_storage_subscriber_spec.rb
@@ -25,9 +25,15 @@ RSpec.describe Sentry::Rails::Tracing::ActiveStorageSubscriber, :subscriber, typ
 
       analysis_transaction = transport.events.first.to_hash
       expect(analysis_transaction[:type]).to eq("transaction")
-      expect(analysis_transaction[:spans].count).to eq(1)
-      span = analysis_transaction[:spans][0]
-      expect(span[:op]).to eq("service_streaming_download.active_storage")
+
+      if Rails.version.to_f > 6.1
+        expect(analysis_transaction[:spans].count).to eq(2)
+        expect(analysis_transaction[:spans][0][:op]).to eq("service_streaming_download.active_storage")
+        expect(analysis_transaction[:spans][1][:op]).to eq("analyze.active_storage")
+      else
+        expect(analysis_transaction[:spans].count).to eq(1)
+        expect(analysis_transaction[:spans][0][:op]).to eq("service_streaming_download.active_storage")
+      end
 
       request_transaction = transport.events.last.to_hash
       expect(request_transaction[:type]).to eq("transaction")


### PR DESCRIPTION
Currently, the ActiveStorage analyzing job is never completed because of the lack of `mini_magick`. To make sure we have a more realistic test setup, we should prevent this from happening again.

Spotted this because https://github.com/rails/rails/commit/95322be0ed92ea77c4ec58cb5a7eaa474a1f5f84 changed how the job is performed without `mini_magick`.