### PR TITLE
Expose `:values` in `ExceptionInterface`

### DIFF
--- a/sentry-ruby/lib/sentry/interfaces/exception.rb
+++ b/sentry-ruby/lib/sentry/interfaces/exception.rb
@@ -3,6 +3,9 @@ require "set"
 
 module Sentry
   class ExceptionInterface < Interface
+    # @return [<Array[SingleExceptionInterface]>]
+    attr_reader :values
+
     # @param exceptions [Array<SingleExceptionInterface>]
     def initialize(exceptions:)
       @values = exceptions

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Sentry::Transport do
         let(:frame_list_size) { frame_list_limit * 4 }
 
         before do
-          single_exception = event.exception.instance_variable_get(:@values)[0]
+          single_exception = event.exception.values[0]
           new_stacktrace = Sentry::StacktraceInterface.new(
             frames: frame_list_size.times.map do |zero_based_index|
               Sentry::StacktraceInterface::Frame.new(


### PR DESCRIPTION
useful for some `before_send` cases

fixes #1841 