### PR TITLE
Respect `report_rescued_exceptions` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
     ```
 - Prepare for Rails 7.1's error reporter API change [#1834](https://github.com/getsentry/sentry-ruby/pull/1834)
 
+### Bug Fixes
+
+- Respect `report_rescued_exceptions` config [#1847](https://github.com/getsentry/sentry-ruby/pull/1847)
+  - Fixes [#1840](https://github.com/getsentry/sentry-ruby/issues/1840)
+
 ### Refactoring
 
 - Move envelope item processing/trimming logic to the Item class [#1824](https://github.com/getsentry/sentry-ruby/pull/1824)

--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -20,10 +20,15 @@ module Sentry
         "rails.request".freeze
       end
 
-      def capture_exception(exception)
+      def capture_exception(exception, env)
+        request = ActionDispatch::Request.new(env)
+
+        # the exception will be swallowed by ShowExceptions middleware
+        return if request.show_exceptions? && !Sentry.configuration.rails.report_rescued_exceptions
+
         current_scope = Sentry.get_current_scope
 
-        if original_transaction = current_scope.rack_env["sentry.original_transaction"]
+        if original_transaction = env["sentry.original_transaction"]
           current_scope.set_transaction_name(original_transaction)
         end
 

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -83,16 +83,11 @@ RSpec.describe Sentry::Rails, type: :request do
     end
   end
 
-  context "with development config" do
-    before do
-      make_basic_app do |config, app|
-        app.config.consider_all_requests_local = true
-        config.rails.report_rescued_exceptions = report_rescued_exceptions
-      end
-    end
-
+  RSpec.shared_examples "report_rescued_exceptions" do
     context "with report_rescued_exceptions = true" do
-      let(:report_rescued_exceptions) { true }
+      before do
+        Sentry.configuration.rails.report_rescued_exceptions = true
+      end
 
       it "captures exceptions" do
         get "/exception"
@@ -105,7 +100,9 @@ RSpec.describe Sentry::Rails, type: :request do
     end
 
     context "with report_rescued_exceptions = false" do
-      let(:report_rescued_exceptions) { false }
+      before do
+        Sentry.configuration.rails.report_rescued_exceptions = false
+      end
 
       it "doesn't report rescued exceptions" do
         get "/exception"
@@ -115,12 +112,24 @@ RSpec.describe Sentry::Rails, type: :request do
     end
   end
 
+  context "with development config" do
+    before do
+      make_basic_app do |config, app|
+        app.config.consider_all_requests_local = true
+      end
+    end
+
+    include_examples "report_rescued_exceptions"
+  end
+
   context "with production config" do
     before do
       make_basic_app do |config, app|
         app.config.consider_all_requests_local = false
       end
     end
+
+    include_examples "report_rescued_exceptions"
 
     it "doesn't do anything on a normal route" do
       get "/"

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -28,13 +28,13 @@ module Sentry
               finish_transaction(transaction, 500)
               raise # Don't capture Sentry errors
             rescue Exception => e
-              capture_exception(e)
+              capture_exception(e, env)
               finish_transaction(transaction, 500)
               raise
             end
 
             exception = collect_exception(env)
-            capture_exception(exception) if exception
+            capture_exception(exception, env) if exception
 
             finish_transaction(transaction, response[0])
 
@@ -53,7 +53,7 @@ module Sentry
         "rack.request".freeze
       end
 
-      def capture_exception(exception)
+      def capture_exception(exception, _env)
         Sentry.capture_exception(exception)
       end
 


### PR DESCRIPTION
When an exception is going to be swallowed by ShowExceptions middleware, we should check the report_rescued_exceptions config before reporting it.

Fixes #1840 