### PR TITLE
Set sentry.error_event_id in request env if the middleware captures errors

### DIFF
--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -32,7 +32,9 @@ module Sentry
           current_scope.set_transaction_name(original_transaction)
         end
 
-        Sentry::Rails.capture_exception(exception)
+        Sentry::Rails.capture_exception(exception).tap do |event|
+          env[ERROR_EVENT_ID_KEY] = event.event_id if event
+        end
       end
 
       def start_transaction(env, scope)

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -81,6 +81,12 @@ RSpec.describe Sentry::Rails, type: :request do
 
       expect(event.dig("request", "url")).to eq("http://www.example.com/exception")
     end
+
+    it "sets the error event id to env" do
+      get "/exception"
+
+      expect(response.request.env["sentry.error_event_id"]).to eq(event["event_id"])
+    end
   end
 
   RSpec.shared_examples "report_rescued_exceptions" do

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -3,6 +3,8 @@
 module Sentry
   module Rack
     class CaptureExceptions
+      ERROR_EVENT_ID_KEY = "sentry.error_event_id"
+
       def initialize(app)
         @app = app
       end
@@ -53,8 +55,10 @@ module Sentry
         "rack.request".freeze
       end
 
-      def capture_exception(exception, _env)
-        Sentry.capture_exception(exception)
+      def capture_exception(exception, env)
+        Sentry.capture_exception(exception).tap do |event|
+          env[ERROR_EVENT_ID_KEY] = event.event_id if event
+        end
       end
 
       def start_transaction(env, scope)

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
 
       event = transport.events.last.to_hash
       expect(event.dig(:request, :url)).to eq("http://example.org/test")
+      expect(env["sentry.error_event_id"]).to eq(event[:event_id])
       last_frame = event.dig(:exception, :values, 0, :stacktrace, :frames).last
       expect(last_frame[:vars]).to eq(nil)
     end
@@ -40,6 +41,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
       end.to change { transport.events.count }.by(1)
 
       event = transport.events.last
+      expect(env["sentry.error_event_id"]).to eq(event.event_id)
       expect(event.to_hash.dig(:request, :url)).to eq("http://example.org/test")
     end
 
@@ -81,6 +83,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
 
       stack = described_class.new(Rack::Lint.new(app))
       expect { stack.call(env) }.to_not raise_error
+      expect(env.key?("sentry.error_event_id")).to eq(false)
     end
 
     context "with config.capture_exception_frame_locals = true" do


### PR DESCRIPTION
It will allow users/libraries to implement mechanisms displaying relevant error events' ids. Which will help their users report issues.

Closes #1846