### PR TITLE
Fix missing `spec.files` in `sentry-ruby.gemspec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 5.4.1
+
+### Bug Fixes
+
+- Fix missing `spec.files` in `sentry-ruby.gemspec`
+  - Fixes [#1856](https://github.com/getsentry/sentry-ruby/issues/1856)
+
 ## 5.4.0
 
 ### Features

--- a/sentry-ruby/sentry-ruby.gemspec
+++ b/sentry-ruby/sentry-ruby.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.platform = Gem::Platform::RUBY
   spec.required_ruby_version = '>= 2.4'
   spec.extra_rdoc_files = ["README.md", "LICENSE.txt"]
+  spec.files = `git ls-files | grep -Ev '^(spec|benchmarks|examples)'`.split("\n")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
the sentry-ruby-core change in https://github.com/getsentry/sentry-ruby/pull/1825 forgot to add this.
fixes #1856 