### PR TITLE
Fix sentry_logger when SDK is closed from another thread

### DIFF
--- a/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb
@@ -22,7 +22,7 @@ module Sentry
       def add_breadcrumb(severity, message = nil, progname = nil)
         # because the breadcrumbs now belongs to different Hub's Scope in different threads
         # we need to make sure the current thread's Hub has been set before adding breadcrumbs
-        return unless Sentry.get_current_hub
+        return unless Sentry.initialized? && Sentry.get_current_hub
 
         category = "logger"
 

--- a/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
@@ -60,4 +60,40 @@ RSpec.describe "Sentry::Breadcrumbs::SentryLogger" do
       expect(breadcrumbs.peek.category).to eq("test category")
     end
   end
+
+  describe "when closed" do
+    it "noops" do
+      Sentry.close
+      expect(Sentry).not_to receive(:add_breadcrumb)
+      logger.info("foo")
+    end
+
+    # see https://github.com/getsentry/sentry-ruby/issues/1858
+    it "noops on thread with cloned hub" do
+      mutex = Mutex.new
+      cv = ConditionVariable.new
+
+      a = Thread.new do
+        mutex.synchronize do
+          expect(Sentry.get_current_hub).to be_a(Sentry::Hub)
+
+          # wait for other thread to close SDK
+          cv.wait(mutex)
+
+          expect(Sentry).not_to receive(:add_breadcrumb)
+          logger.info("foo")
+        end
+      end
+
+      b = Thread.new do
+        mutex.synchronize do
+          Sentry.close
+          cv.signal
+        end
+      end
+
+      a.join
+      b.join
+    end
+  end
 end

--- a/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
@@ -75,10 +75,8 @@ RSpec.describe "Sentry::Breadcrumbs::SentryLogger" do
 
       a = Thread.new do
         mutex.synchronize do
-          expect(Sentry.get_current_hub).to be_a(Sentry::Hub)
-
           # wait for other thread to close SDK
-          cv.wait(mutex)
+          cv.wait(mutex) unless Sentry.get_current_hub.nil?
 
           expect(Sentry).not_to receive(:add_breadcrumb)
           logger.info("foo")


### PR DESCRIPTION
fixes #1858 

I was able to repro the issue with the two threaded test case and the older code.

```
#<Thread:0x00007f95886593a0 /home/neel/sentry/sdks/sentry-ruby/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb:76 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	6: from /home/neel/sentry/sdks/sentry-ruby/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb:77:in `block (4 levels) in <top (required)>'
	5: from /home/neel/sentry/sdks/sentry-ruby/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb:77:in `synchronize'
	4: from /home/neel/sentry/sdks/sentry-ruby/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb:84:in `block (5 levels) in <top (required)>'
	3: from /home/neel/.rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/logger.rb:528:in `info'
	2: from /home/neel/sentry/sdks/sentry-ruby/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb:18:in `add'
	1: from /home/neel/sentry/sdks/sentry-ruby/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb:55:in `add_breadcrumb'
/home/neel/sentry/sdks/sentry-ruby/sentry-ruby/lib/sentry/breadcrumb/sentry_logger.rb:80:in `ignored_logger?': undefined method `exclude_loggers' for nil:NilClass (NoMethodError)
    noops on thread with cloned hub (FAILED - 1)


```