### PR TITLE
Include Delayed::Job instance in hints

### DIFF
--- a/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
+++ b/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
@@ -72,7 +72,7 @@ module Sentry
       end
 
       def self.capture_exception(exception, job)
-        Sentry::DelayedJob.capture_exception(exception, hint: { background: false }) if report?(job)
+        Sentry::DelayedJob.capture_exception(exception, hint: { background: false, delayed_job: job }) if report?(job)
       end
 
       def self.report?(job)


### PR DESCRIPTION
It would be useful to include the `Delayed::Job` instance in `hint`, so it can be used for filtering in `before_send`.