### PR TITLE
Manually require `sidekiq/api` for RetrySet class

### DIFF
--- a/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require 'sidekiq/manager'
+require 'sidekiq/api'
 
 RSpec.describe Sentry::Sidekiq do
   before do


### PR DESCRIPTION
After https://github.com/mperham/sidekiq/commit/345ba002bc7035d8135d58f4c5dad6dadef298dc
`sidekiq/api` is not required with server logic anymore, which means RetrySet is also not loaded by default. So to use it in tests, we need to require `sidekiq/api` manually.

[Relate failure](https://github.com/getsentry/sentry-ruby/runs/7802900637?check_suite_focus=true)