### PR TITLE
Remove webmock

### DIFF
--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -8,7 +8,6 @@ gem "rack" unless ENV["WITHOUT_RACK"] == "1"
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
 gem "rspec-retry"
-gem "webmock"
 gem "fakeredis"
 gem "timecop"
 gem 'simplecov'

--- a/sentry-ruby/spec/contexts/with_request_mock.rb
+++ b/sentry-ruby/spec/contexts/with_request_mock.rb
@@ -1,11 +1,7 @@
-require "webmock"
-
 # because our patch on Net::HTTP is relatively low-level, we need to stub methods on socket level
 # which is not supported by most of the http mocking library
 # so we need to put something together ourselves
 RSpec.shared_context "with request mock" do
-  before { stub_const('Net::BufferedIO', Net::WebMockNetBufferedIO) }
-
   class FakeSocket < StringIO
     def setsockopt(*args); end
   end


### PR DESCRIPTION
While working on https://github.com/getsentry/sentry-ruby/pull/1869, I noticed that `webmock` [removed ` Net::WebMockNetBufferedIO`](https://github.com/bblimke/webmock/pull/991) in the newer versions.

It seems we have our own stubs anyway so we don't need `webmock` anymore I believe? Let me know if I missed something.