### PR TITLE
bugfix: sentry crash when exeception message is an array.

### DIFF
--- a/sentry-ruby/lib/sentry/interfaces/single_exception.rb
+++ b/sentry-ruby/lib/sentry/interfaces/single_exception.rb
@@ -15,7 +15,7 @@ module Sentry
 
     def initialize(exception:, stacktrace: nil)
       @type = exception.class.to_s
-      @value = (exception.message || "").byteslice(0..Event::MAX_MESSAGE_SIZE_IN_BYTES)
+      @value = (exception.message || "").try(:byteslice, 0..Event::MAX_MESSAGE_SIZE_IN_BYTES).to_s
       @module = exception.class.to_s.split('::')[0...-1].join('::')
       @thread_id = Thread.current.object_id
       @stacktrace = stacktrace


### PR DESCRIPTION
## Problem

when the exception message is not a string, the sentry will crash and sentry SDK will cause main application to crash.

Here is an example to crash sentry.

For example

```
raise StandardError.new(message: ["msg1", "msg2"])
```

I know the developer should use a standard string as the exception
message, but not all developers are well educated. Sentry as a service
provider can't always assume the exception message is a string.

Sometimes it's a hash or array.

## Solution

if the exception message is not a string, the `byteslice` should not be called.