### PR TITLE
Update error subscriber doc

### DIFF
--- a/sentry-rails/lib/sentry/rails/error_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/error_subscriber.rb
@@ -1,7 +1,8 @@
 module Sentry
   module Rails
     # This is not a user-facing class. You should use it with Rails 7.0's error reporter feature and its interfaces.
-    # See https://github.com/rails/rails/blob/main/activesupport/lib/active_support/error_reporter.rb for more information.
+    # See https://github.com/rails/rails/blob/main/activesupport/lib/active_support/error_reporter.rb to learn more about reporting APIs.
+    # If you want Sentry to subscribe to the error reporter, please set `config.rails.register_error_subscriber` to `true`.
     class ErrorSubscriber
       SKIP_SOURCES = Regexp.union([/.*_cache_store.active_support/])
 

--- a/sentry-resque/Gemfile
+++ b/sentry-resque/Gemfile
@@ -17,3 +17,6 @@ gem "sentry-rails", path: "../sentry-rails"
 
 gem "pry"
 gem "debug", github: "ruby/debug", platform: :ruby if RUBY_VERSION.to_f >= 2.6
+
+# remove this after https://github.com/resque/resque/pull/1828 is merged and released
+gem "redis", "< 5.0"


### PR DESCRIPTION
This PR also locks `sentry-resque`'s development `redis` version because it's unclear when https://github.com/resque/resque/pull/1828 will be released.