### PR TITLE
Ensure breadcrumbs are cleared when using Sentry::TestHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Fix sentry_logger when SDK is closed from another thread [#1860](https://github.com/getsentry/sentry-ruby/pull/1860)
   - Fixes [#1858](https://github.com/getsentry/sentry-ruby/issues/1858)
 
+- Clear breadcrumbs in `Sentry::TestHelper#teardown_sentry_test` [#1881](https://github.com/getsentry/sentry-ruby/pull/1881)
+
 ## 5.4.1
 
 ### Bug Fixes

--- a/sentry-ruby/lib/sentry/test_helper.rb
+++ b/sentry-ruby/lib/sentry/test_helper.rb
@@ -41,6 +41,7 @@ module Sentry
 
       sentry_transport.events = []
       sentry_transport.envelopes = []
+      Sentry.get_current_scope.clear_breadcrumbs
     end
 
     # @return [Transport]
@@ -73,4 +74,3 @@ module Sentry
     end
   end
 end
-

--- a/sentry-ruby/spec/sentry/test_helper_spec.rb
+++ b/sentry-ruby/spec/sentry/test_helper_spec.rb
@@ -111,5 +111,14 @@ RSpec.describe Sentry::TestHelper do
 
       expect(sentry_envelopes.count).to eq(0)
     end
+
+    it "clears stored breadcrumbs" do
+      Sentry.add_breadcrumb(Sentry::Breadcrumb.new(message: "woopsie doopsie"))
+      expect(Sentry.get_current_scope.breadcrumbs.members.size).to eq(1)
+
+      teardown_sentry_test
+
+      expect(Sentry.get_current_scope.breadcrumbs.members.size).to eq(0)
+    end
   end
 end


### PR DESCRIPTION
<!--
Thanks for your Pull Request 🎉 

**Please keep these instructions in mind so we can review it more efficiently:**

- Add the references of all the related issues/PRs in the description
- Whether it's a new feature or a bug fix, make sure they're covered by new test cases
- If this PR contains any refactoring work, please give it its own commit(s)
- Finally, please add an entry to the corresponding changelog


**Other Notes**
- We squash all commits before merging
- We generally review new PRs within a week
- If you have any question, you can ask for feedback in our [discord community](https://discord.gg/Ww9hbqr) first

-->

## Description

Dear maintainers,

I am a happy early adopter of the new `Sentry::TestHelper` (#1773), and I would like to make an improvement.

I expected the `Sentry::TestHelper#teardown_sentry_test` method to clear the breadcrumbs, because it is good practice to avoid state leaking between tests. So I added a call to `Sentry.get_current_scope.clear_breadcrumbs` in the teardown method.

If we choose not to clear them within the teardown method, then we should add a note in the doc to inform people that breadcrumbs need to be manually cleared using `Sentry.get_current_scope.clear_breadcrumbs` after each test.

I would love to have your well-informed feedback on this matter! :pray: 

Note: This bug is due to the fact that we alter the current transport and scope instead of initializing a new one. I thus considered an alternative implementation, initializing a new scope within the `setup_sentry_test` method. However, my understanding is that we need to preserve the current scope because it might have been customized by the tested code, so all we may do is alter it. I also noted that the state altered in `setup_sentry_test` is not actually rolled back in `teardown_sentry_test`. Do you believe this might lead to similar issues in the future?