### PR TITLE
Remove resque redis pin since upstream is fixed

### DIFF
--- a/sentry-resque/Gemfile
+++ b/sentry-resque/Gemfile
@@ -17,6 +17,3 @@ gem "sentry-rails", path: "../sentry-rails"
 
 gem "pry"
 gem "debug", github: "ruby/debug", platform: :ruby if RUBY_VERSION.to_f >= 2.6
-
-# remove this after https://github.com/resque/resque/pull/1828 is merged and released
-gem "redis", "< 5.0"

--- a/sentry-resque/spec/spec_helper.rb
+++ b/sentry-resque/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "bundler/setup"
 require "pry"
-require "debug" if RUBY_VERSION.to_f >= 2.6
+require "debug" if RUBY_VERSION.to_f >= 2.7
 
 require "resque"
 


### PR DESCRIPTION
https://github.com/resque/resque/pull/1828
https://github.com/resque/resque/pull/1822
https://github.com/resque/resque/releases/tag/v2.4.0