### PR TITLE
Support rack 3

### DIFF
--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -43,7 +43,6 @@ jobs:
       env:
         RUBYOPT: ${{ matrix.options.rubyopt }}
       run: |
-        [[ "${{ matrix.ruby_version }}" =~ ^(2.4|2.5)$ ]] && bundle config force_ruby_platform true
         bundle install --jobs 4 --retry 3
         bundle exec rake
 

--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -44,6 +44,7 @@ jobs:
       env:
         RUBYOPT: ${{ matrix.options.rubyopt }}
       run: |
+        [[ "${{ matrix.ruby_version }}" =~ ^(2.4|2.5)$ ]] && bundle config force_ruby_platform true
         bundle install --jobs 4 --retry 3
         bundle exec rake
 

--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -37,7 +37,6 @@ jobs:
     - name: Set up Ruby ${{ matrix.ruby_version }}
       uses: ruby/setup-ruby@v1
       with:
-        bundler: 1
         ruby-version: ${{ matrix.ruby_version }}
 
     - name: Run specs

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -56,7 +56,6 @@ jobs:
     - name: Set up Ruby ${{ matrix.ruby_version }}
       uses: ruby/setup-ruby@v1
       with:
-        bundler: 1
         ruby-version: ${{ matrix.ruby_version }}
 
     - name: Build with Rails ${{ matrix.rails_version }}

--- a/.github/workflows/sentry_raven_test.yml
+++ b/.github/workflows/sentry_raven_test.yml
@@ -48,7 +48,6 @@ jobs:
     - name: Set up Ruby ${{ matrix.ruby_version }}
       uses: ruby/setup-ruby@v1
       with:
-        bundler: 1
         ruby-version: ${{ matrix.ruby_version }}
 
     - name: Start Redis

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -30,7 +30,6 @@ jobs:
     - name: Set up Ruby ${{ matrix.ruby_version }}
       uses: ruby/setup-ruby@v1
       with:
-        bundler: 1
         ruby-version: ${{ matrix.ruby_version }}
 
     - name: Start Redis

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -16,11 +16,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.4, 2.5, 2.6, 2.7, 3.0, 3.1, jruby]
+        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', jruby]
         rack_version: [2.0, 3.0]
         os: [ubuntu-latest]
         include:
           - { os: ubuntu-latest, ruby_version: 3.1, rack_version: 0 }
+          - { os: ubuntu-latest, ruby_version: 3.1, rack_version: 2.0 }
+          - { os: ubuntu-latest, ruby_version: 3.1, rack_version: 3.0 }
           - { os: ubuntu-latest, ruby_version: 3.1, rack_version: 3.0, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
           - { os: ubuntu-latest, ruby_version: 3.1, rack_version: 3.0, options: { codecov: 1 } }
     steps:

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -20,9 +20,11 @@ jobs:
         rack_version: [2.0, 3.0]
         os: [ubuntu-latest]
         include:
-          - { os: ubuntu-latest, ruby_version: '3.1', options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
           - { os: ubuntu-latest, ruby_version: '3.1', options: { without_rack: 1 } }
-          - { os: ubuntu-latest, ruby_version: '3.1', options: { codecov: 1 } }
+          - { os: ubuntu-latest, ruby_version: '3.1', rack_version: 2.0 }
+          - { os: ubuntu-latest, ruby_version: '3.1', rack_version: 3.0 }
+          - { os: ubuntu-latest, ruby_version: '3.1', rack_version: 3.0, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
+          - { os: ubuntu-latest, ruby_version: '3.1', rack_version: 3.0, options: { codecov: 1 } }
     steps:
     - uses: actions/checkout@v1
 
@@ -36,7 +38,7 @@ jobs:
       env:
         RUBYOPT: ${{ matrix.options.rubyopt }}
         WITHOUT_RACK: ${{ matrix.options.without_rack }}
-        RACK_VERSION: ${{ matrix.options.rack_version }}
+        RACK_VERSION: ${{ matrix.rack_version }}
       run: |
         bundle install --jobs 4 --retry 3
         bundle exec rake
@@ -44,6 +46,6 @@ jobs:
     - name: Upload Coverage
       if: ${{ matrix.options.codecov }}
       run: |
-        curl -Os https://uploader.codecov.io/latest/linux/codecov 
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
         chmod +x codecov
         ./codecov -t ${CODECOV_TOKEN} -R `pwd` -f coverage/coverage.xml

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -31,7 +31,6 @@ jobs:
     - name: Set up Ruby ${{ matrix.ruby_version }}
       uses: ruby/setup-ruby@v1
       with:
-        bundler: 1
         ruby-version: ${{ matrix.ruby_version }}
 
     - name: Run specs

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -12,17 +12,14 @@ jobs:
     defaults:
       run:
         working-directory: sentry-ruby
-    name: Ruby ${{ matrix.ruby_version }}, options - ${{ toJson(matrix.options) }}
+    name: Ruby ${{ matrix.ruby_version }} & Rack ${{ matrix.rack_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', jruby]
+        rack_version: [2.0, 3.0]
+        os: [ubuntu-latest]
         include:
-          - { os: ubuntu-latest, ruby_version: 2.4 }
-          - { os: ubuntu-latest, ruby_version: 2.5 }
-          - { os: ubuntu-latest, ruby_version: 2.6 }
-          - { os: ubuntu-latest, ruby_version: 2.7 }
-          - { os: ubuntu-latest, ruby_version: '3.0' }
-          - { os: ubuntu-latest, ruby_version: jruby }
           - { os: ubuntu-latest, ruby_version: '3.1', options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
           - { os: ubuntu-latest, ruby_version: '3.1', options: { without_rack: 1 } }
           - { os: ubuntu-latest, ruby_version: '3.1', options: { codecov: 1 } }
@@ -39,6 +36,7 @@ jobs:
       env:
         RUBYOPT: ${{ matrix.options.rubyopt }}
         WITHOUT_RACK: ${{ matrix.options.without_rack }}
+        RACK_VERSION: ${{ matrix.options.rack_version }}
       run: |
         bundle install --jobs 4 --retry 3
         bundle exec rake

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -36,7 +36,6 @@ jobs:
     - name: Run specs
       env:
         RUBYOPT: ${{ matrix.options.rubyopt }}
-        WITHOUT_RACK: ${{ matrix.options.without_rack }}
         RACK_VERSION: ${{ matrix.rack_version }}
       run: |
         bundle install --jobs 4 --retry 3

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -16,15 +16,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', jruby]
+        ruby_version: [2.4, 2.5, 2.6, 2.7, 3.0, 3.1, jruby]
         rack_version: [2.0, 3.0]
         os: [ubuntu-latest]
         include:
-          - { os: ubuntu-latest, ruby_version: '3.1', rack_version: 0 }
-          - { os: ubuntu-latest, ruby_version: '3.1', rack_version: 2.0 }
-          - { os: ubuntu-latest, ruby_version: '3.1', rack_version: 3.0 }
-          - { os: ubuntu-latest, ruby_version: '3.1', rack_version: 3.0, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
-          - { os: ubuntu-latest, ruby_version: '3.1', rack_version: 3.0, options: { codecov: 1 } }
+          - { os: ubuntu-latest, ruby_version: 3.1, rack_version: 0 }
+          - { os: ubuntu-latest, ruby_version: 3.1, rack_version: 3.0, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
+          - { os: ubuntu-latest, ruby_version: 3.1, rack_version: 3.0, options: { codecov: 1 } }
     steps:
     - uses: actions/checkout@v1
 

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -20,7 +20,7 @@ jobs:
         rack_version: [2.0, 3.0]
         os: [ubuntu-latest]
         include:
-          - { os: ubuntu-latest, ruby_version: '3.1', options: { without_rack: 1 } }
+          - { os: ubuntu-latest, ruby_version: '3.1', rack_version: 0 }
           - { os: ubuntu-latest, ruby_version: '3.1', rack_version: 2.0 }
           - { os: ubuntu-latest, ruby_version: '3.1', rack_version: 3.0 }
           - { os: ubuntu-latest, ruby_version: '3.1', rack_version: 3.0, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -31,7 +31,6 @@ jobs:
     - name: Set up Ruby ${{ matrix.ruby_version }}
       uses: ruby/setup-ruby@v1
       with:
-        bundler: 1
         ruby-version: ${{ matrix.ruby_version }}
 
     - name: Start Redis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Features
+
+- Support rack 3 [#1884](https://github.com/getsentry/sentry-ruby/pull/1884)
+  - We no longer need the `HTTP_VERSION` check for ignoring the header
+
 ## 5.4.2
 
 ### Bug Fixes

--- a/sentry-resque/Gemfile
+++ b/sentry-resque/Gemfile
@@ -17,6 +17,3 @@ gem "sentry-rails", path: "../sentry-rails"
 
 gem "pry"
 gem "debug", github: "ruby/debug", platform: :ruby if RUBY_VERSION.to_f >= 2.6
-
-# remove this after https://github.com/resque/resque/pull/1828 is merged and released
-gem "redis", "< 5.0"

--- a/sentry-resque/spec/spec_helper.rb
+++ b/sentry-resque/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "bundler/setup"
 require "pry"
-require "debug" if RUBY_VERSION.to_f >= 2.6
+require "debug" if RUBY_VERSION.to_f >= 2.7
 
 require "resque"
 

--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -3,7 +3,13 @@ git_source(:github) { |name| "https://github.com/#{name}.git" }
 
 gem "sentry-ruby", path: "./"
 
-gem "rack" unless ENV["WITHOUT_RACK"] == "1"
+unless ENV["WITHOUT_RACK"] == "1"
+  rack_version = ENV["RACK_VERSION"]
+  rack_version = "3.0.0" if rack_version.nil?
+  rack_version = Gem::Version.new(rack_version)
+
+  gem "rack", "~> #{rack_version}"
+end
 
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"

--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -3,13 +3,9 @@ git_source(:github) { |name| "https://github.com/#{name}.git" }
 
 gem "sentry-ruby", path: "./"
 
-unless ENV["WITHOUT_RACK"] == "1"
-  rack_version = ENV["RACK_VERSION"]
-  rack_version = "3.0.0" if rack_version.nil?
-  rack_version = Gem::Version.new(rack_version)
-
-  gem "rack", "~> #{rack_version}"
-end
+rack_version = ENV["RACK_VERSION"]
+rack_version = "3.0.0" if rack_version.nil?
+gem "rack", "~> #{Gem::Version.new(rack_version)}" unless rack_version == "0"
 
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"

--- a/sentry-ruby/lib/sentry/interfaces/request.rb
+++ b/sentry-ruby/lib/sentry/interfaces/request.rb
@@ -129,7 +129,8 @@ module Sentry
     # if the request has legitimately sent a Version header themselves.
     # See: https://github.com/rack/rack/blob/028438f/lib/rack/handler/cgi.rb#L29
     def is_server_protocol?(key, value, protocol_version)
-      return false if ::Rack.release.start_with?('3')
+      rack_version = Gem::Version.new(::Rack.release)
+      return false if rack_version >= Gem::Version.new("3.0")
 
       key == 'HTTP_VERSION' && value == protocol_version
     end

--- a/sentry-ruby/lib/sentry/interfaces/request.rb
+++ b/sentry-ruby/lib/sentry/interfaces/request.rb
@@ -123,13 +123,14 @@ module Sentry
         !(key.start_with?('HTTP_') || CONTENT_HEADERS.include?(key))
     end
 
-    # Rack adds in an incorrect HTTP_VERSION key, which causes downstream
+    # In versions < 3, Rack adds in an incorrect HTTP_VERSION key, which causes downstream
     # to think this is a Version header. Instead, this is mapped to
     # env['SERVER_PROTOCOL']. But we don't want to ignore a valid header
     # if the request has legitimately sent a Version header themselves.
     # See: https://github.com/rack/rack/blob/028438f/lib/rack/handler/cgi.rb#L29
-    # NOTE: This will be removed in version 3.0+
     def is_server_protocol?(key, value, protocol_version)
+      return false if ::Rack.release.start_with?('3')
+
       key == 'HTTP_VERSION' && value == protocol_version
     end
 

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
 
     it 'passes rack/lint' do
       app = proc do
-        [200, { 'Content-Type' => 'text/plain' }, ['OK']]
+        [200, { 'content-type' => 'text/plain' }, ['OK']]
       end
 
       stack = described_class.new(Rack::Lint.new(app))


### PR DESCRIPTION
* Fix `is_server_protocol?` check for rack 3 support
* fix rack lint spec since uppercase no longer allowed in response headers
 * expand CI matrix to test on rack 2 & 3
 * remove `bundler: 1` pin in actions
* ~sqlite3 1.5.0 has pre-built binaries from ruby 2.6 onwards so use `force_ruby_platform` for 2.4 and 2.5 for `delayed_job`~