### PR TITLE
Execute with_scope's block even when SDK is not initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 - Memoize session.aggregation_key [#1892](https://github.com/getsentry/sentry-ruby/pull/1892)
   - Fixes [#1891](https://github.com/getsentry/sentry-ruby/issues/1891)
+- Execute `with_scope`'s block even when SDK is not initialized [#1897](https://github.com/getsentry/sentry-ruby/pull/1897)
+  - Fixes [#1896](https://github.com/getsentry/sentry-ruby/issues/1896)
 
 ## 5.4.2
 

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -348,7 +348,7 @@ module Sentry
     # @yieldparam scope [Scope]
     # @return [void]
     def with_scope(&block)
-      return unless initialized?
+      return yield unless initialized?
       get_current_hub.with_scope(&block)
     end
 

--- a/sentry-ruby/spec/initialization_check_spec.rb
+++ b/sentry-ruby/spec/initialization_check_spec.rb
@@ -23,11 +23,21 @@ RSpec.describe "with uninitialized SDK" do
   end
 
   it do
-    expect { Sentry.with_scope { raise "foo" } }.not_to raise_error(RuntimeError)
+    expect { Sentry.with_exception_captured { raise "foo" } }.to raise_error(RuntimeError)
   end
 
   it do
-    result = Sentry.with_child_span { "foo" }
+    result = Sentry.with_child_span { |span| "foo" }
+    expect(result).to eq("foo")
+  end
+
+  it do
+    result = Sentry.with_scope { |scope| "foo" }
+    expect(result).to eq("foo")
+  end
+
+  it do
+    result = Sentry.with_session_tracking { |scope| "foo" }
     expect(result).to eq("foo")
   end
 end


### PR DESCRIPTION
Fixes #1896 
