### PR TITLE
Make sure test helper clears the current scope before/after a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Fixes [#1891](https://github.com/getsentry/sentry-ruby/issues/1891)
 - Execute `with_scope`'s block even when SDK is not initialized [#1897](https://github.com/getsentry/sentry-ruby/pull/1897)
   - Fixes [#1896](https://github.com/getsentry/sentry-ruby/issues/1896)
+- Make sure test helper clears the current scope before/after a test [#1900](https://github.com/getsentry/sentry-ruby/pull/1900)
 
 ## 5.4.2
 

--- a/sentry-ruby/lib/sentry/test_helper.rb
+++ b/sentry-ruby/lib/sentry/test_helper.rb
@@ -31,6 +31,7 @@ module Sentry
 
       test_client = Sentry::Client.new(copied_config)
       Sentry.get_current_hub.bind_client(test_client)
+      Sentry.get_current_scope.clear
     end
 
     # Clears all stored events and envelopes.
@@ -41,6 +42,7 @@ module Sentry
 
       sentry_transport.events = []
       sentry_transport.envelopes = []
+      Sentry.get_current_scope.clear
     end
 
     # @return [Transport]

--- a/sentry-ruby/spec/sentry/test_helper_spec.rb
+++ b/sentry-ruby/spec/sentry/test_helper_spec.rb
@@ -111,5 +111,13 @@ RSpec.describe Sentry::TestHelper do
 
       expect(sentry_envelopes.count).to eq(0)
     end
+
+    it "clears the scope" do
+      Sentry.set_tags(foo: "bar")
+
+      teardown_sentry_test
+
+      expect(Sentry.get_current_scope.tags).to eq({})
+    end
   end
 end


### PR DESCRIPTION
Because the `setup_sentry_test` helper provides a clean client, the scope should be clean too. I also imagine `teardown_sentry_test` includes clearing the current scope's contextual data.

And because there's not a `bind_client` equivalent API for scope, we clear the scope's value with `Scope#clear` instead of creating a new scope. But in practice that both of them should work the same.
