### PR TITLE
Configure Rails 7.1's test app separately

### DIFF
--- a/sentry-rails/spec/dummy/test_rails_app/app.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/app.rb
@@ -20,7 +20,7 @@ v5_2 = Gem::Version.new("5.2")
 v6_0 = Gem::Version.new("6.0")
 v6_1 = Gem::Version.new("6.1")
 v7_0 = Gem::Version.new("7.0")
-v7_1 = Gem::Version.new("7.1")
+v7_1 = Gem::Version.new("7.1.alpha")
 
 FILE_NAME =
   case Gem::Version.new(Rails.version)
@@ -32,8 +32,10 @@ FILE_NAME =
     "6-0"
   when -> (v) { v.between?(v6_1, v7_0) }
     "6-1"
-  when -> (v) { v.between?(v7_0, v7_1) }
+  when -> (v) { v > v7_0 && v < v7_1 }
     "7-0"
+  when -> (v) { v >= v7_1 }
+    "7-1"
   end
 
 # require files and defined relevant setup methods for the Rails version

--- a/sentry-rails/spec/dummy/test_rails_app/apps/7-1.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/7-1.rb
@@ -1,0 +1,110 @@
+ActiveRecord::Schema.define do
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.integer "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table :posts, force: true do |t|
+  end
+
+  create_table :comments, force: true do |t|
+    t.integer :post_id
+  end
+end
+
+class Post < ActiveRecord::Base
+  has_many :comments
+  has_one_attached :cover
+end
+
+class Comment < ActiveRecord::Base
+  belongs_to :post
+end
+
+class PostsController < ActionController::Base
+  def index
+    Post.all.to_a
+    raise "foo"
+  end
+
+  def show
+    p = Post.find(params[:id])
+
+    render plain: p.id
+  end
+
+  def attach
+    p = Post.find(params[:id])
+
+    attach_params = {
+      io: File.open(File.join(Rails.root, 'public', 'sentry-logo.png')),
+      filename: 'sentry-logo.png',
+      service_name: "test"
+    }
+
+    p.cover.attach(attach_params)
+
+    render plain: p.id
+  end
+end
+
+class HelloController < ActionController::Base
+  def exception
+    raise "An unhandled exception!"
+  end
+
+  def reporting
+    render plain: Sentry.last_event_id
+  end
+
+  def view_exception
+    render inline: "<%= foo %>"
+  end
+
+  def view
+    render template: "test_template"
+  end
+
+  def world
+    render :plain => "Hello World!"
+  end
+
+  def with_custom_instrumentation
+    custom_event = "custom.instrument"
+    ActiveSupport::Notifications.subscribe(custom_event) do |*args|
+      data = args[-1]
+      data += 1
+    end
+
+    ActiveSupport::Notifications.instrument(custom_event, 1)
+
+    head :ok
+  end
+
+  def not_found
+    raise ActionController::BadRequest
+  end
+end

--- a/sentry-rails/spec/dummy/test_rails_app/configs/7-1.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/7-1.rb
@@ -1,0 +1,35 @@
+require "active_storage/engine"
+require "action_cable/engine"
+require "sentry/rails/error_subscriber"
+
+def run_pre_initialize_cleanup
+  # Zeitwerk checks if registered loaders load paths repeatedly and raises error if that happens.
+  # And because every new Rails::Application instance registers its own loader, we need to clear previously registered ones from Zeitwerk.
+  Zeitwerk::Registry.loaders.clear
+
+  # Rails removes the support of multiple instances, which includes freezing some setting values.
+  # This is the workaround to avoid FrozenError. Related issue: https://github.com/rails/rails/issues/42319
+  ActiveSupport::Dependencies.autoload_once_paths = []
+  ActiveSupport::Dependencies.autoload_paths = []
+
+  # there are a few Rails initializers/finializers that register hook to the executor
+  # because the callbacks are stored inside the `ActiveSupport::Executor` class instead of an instance
+  # the callbacks duplicate after each time we initialize the application and cause issues when they're executed
+  ActiveSupport::Executor.reset_callbacks(:run)
+  ActiveSupport::Executor.reset_callbacks(:complete)
+
+  # Rails uses this module to set a global context for its ErrorReporter feature.
+  # this needs to be cleared so previously set context won't pollute later reportings (see ErrorSubscriber).
+  ActiveSupport::ExecutionContext.clear
+
+  ActionCable::Channel::Base.reset_callbacks(:subscribe)
+  ActionCable::Channel::Base.reset_callbacks(:unsubscribe)
+
+  # Rails 7.1 stores the error reporter directly under the ActiveSupport class.
+  # So we need to make sure the subscriber is not subscribed unexpectedly before any tests
+  ActiveSupport.error_reporter.unsubscribe(Sentry::Rails::ErrorSubscriber)
+end
+
+def configure_app(app)
+  app.config.active_storage.service = :test
+end


### PR DESCRIPTION
Rails 7.1 stores the error reporter directly under the `ActiveSupport` class (PR: https://github.com/rails/rails/pull/46029). So we need to make sure the subscriber is not subscribed unexpectedly before any tests.

And because both the change and the `unsubscribe` API is introduced in Rails 7.1, we should start having a dedicated test setup for it now.
