### PR TITLE
Allow users to configure their asset-skipping pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Unreleased
 
+### Features
+
+- Allow users to configure their asset-skipping pattern [#1915](https://github.com/getsentry/sentry-ruby/pull/1915)
+
+  Users can now configure their own pattern to skip asset requests' transactions
+
+  ```rb
+  Sentry.init do |config|
+    config.rails.assets_regexp = /my_regexp/
+  end
+  ```
+
 ### Bug Fixes
 
 - `Sentry::BackgroundWorker` will release `ActiveRecord` connection pool only when the `ActiveRecord` connection is established

--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -1,11 +1,11 @@
 module Sentry
   module Rails
     class CaptureExceptions < Sentry::Rack::CaptureExceptions
-      def initialize(app)
+      def initialize(_)
         super
 
-        if defined?(::Sprockets::Rails)
-          @assets_regex = %r(\A/{0,2}#{::Rails.application.config.assets.prefix})
+        if Sentry.initialized?
+          @assets_regexp = Sentry.configuration.rails.assets_regexp
         end
       end
 
@@ -36,7 +36,7 @@ module Sentry
 
         options = { name: scope.transaction_name, source: scope.transaction_source, op: transaction_op }
 
-        if @assets_regex && scope.transaction_name.match?(@assets_regex)
+        if @assets_regexp && scope.transaction_name.match?(@assets_regexp)
           options.merge!(sampled: false)
         end
 

--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -60,10 +60,28 @@ module Sentry
 
       attr_accessor :tracing_subscribers
 
+      # sentry-rails by default skips asset request' transactions by checking if the path matches
+      #
+      # ```rb
+      # %r(\A/{0,2}#{::Rails.application.config.assets.prefix})
+      # ```
+      #
+      # If you want to use a different pattern, you can configure the `assets_regexp` option like:
+      #
+      # ```rb
+      # Sentry.init do |config|
+      #   config.rails.assets_regexp = /my_regexp/
+      # end
+      # ```
+      attr_accessor :assets_regexp
+
       def initialize
         @register_error_subscriber = false
         @report_rescued_exceptions = true
         @skippable_job_adapters = []
+        @assets_regexp = if defined?(::Sprockets::Rails)
+          %r(\A/{0,2}#{::Rails.application.config.assets.prefix})
+        end
         @tracing_subscribers = Set.new([
           Sentry::Rails::Tracing::ActionControllerSubscriber,
           Sentry::Rails::Tracing::ActionViewSubscriber,


### PR DESCRIPTION
Some users have customized asset paths, so the SDK's default pattern may not work for them. In such cases, they can use the new configuration option to set their own path pattern.

```rb
Sentry.init do |config|
  config.rails.assets_regexp = /my_regexp/
end
```
