### PR TITLE
Move with_child_span logic to hub

### DIFF
--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -442,22 +442,8 @@ module Sentry
     #   end
     #
     def with_child_span(**attributes, &block)
-      if Sentry.initialized? && current_span = get_current_scope.get_span
-        result = nil
-
-        begin
-          current_span.with_child_span(**attributes) do |child_span|
-            get_current_scope.set_span(child_span)
-            result = yield(child_span)
-          end
-        ensure
-          get_current_scope.set_span(current_span)
-        end
-
-        result
-      else
-        yield(nil)
-      end
+      return yield(nil) unless Sentry.initialized?
+      get_current_hub.with_child_span(**attributes, &block)
     end
 
     # Returns the id of the lastly reported Sentry::Event.

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -92,6 +92,24 @@ module Sentry
       transaction
     end
 
+    def with_child_span(**attributes, &block)
+      current_span = current_scope.get_span
+      return yield(nil) unless current_span
+
+      result = nil
+
+      begin
+        current_span.with_child_span(**attributes) do |child_span|
+          current_scope.set_span(child_span)
+          result = yield(child_span)
+        end
+      ensure
+        current_scope.set_span(current_span)
+      end
+
+      result
+    end
+
     def capture_exception(exception, **options, &block)
       check_argument_type!(exception, ::Exception)
 


### PR DESCRIPTION
all our other top-level methods in `sentry-ruby.rb` are passthroughs to `get_current_hub` so also move this there.