### PR TITLE
Add missing initialized? checks to sentry-rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - `Sentry::BackgroundWorker` will release `ActiveRecord` connection pool only when the `ActiveRecord` connection is established
 -  Remove bad encoding arguments in redis span descriptions [#1914](https://github.com/getsentry/sentry-ruby/pull/1914)
   - Fixes [#1911](https://github.com/getsentry/sentry-ruby/issues/1911)
+- Add missing `initialized?` checks to `sentry-rails` [#1919](https://github.com/getsentry/sentry-ruby/pull/1919)
+  - Fixes [#1885](https://github.com/getsentry/sentry-ruby/issues/1885)
 
 ## 5.5.0
 

--- a/sentry-rails/lib/sentry/rails/controller_transaction.rb
+++ b/sentry-rails/lib/sentry/rails/controller_transaction.rb
@@ -3,6 +3,7 @@ module Sentry
     module ControllerTransaction
       def self.included(base)
         base.prepend_before_action do |controller|
+          return unless Sentry.initialized?
           Sentry.get_current_scope.set_transaction_name("#{controller.class}##{controller.action_name}", source: :view)
         end
       end

--- a/sentry-rails/lib/sentry/rails/tracing.rb
+++ b/sentry-rails/lib/sentry/rails/tracing.rb
@@ -67,7 +67,7 @@ module Sentry
       end
 
       def self.get_current_transaction
-        Sentry.get_current_scope.get_transaction
+        Sentry.get_current_scope.get_transaction if Sentry.initialized?
       end
 
       # it's just a container for the extended method


### PR DESCRIPTION
The `at_exit` `Sentry.close` call might cause these `Sentry.get_current_scope`s to return nil and break some setups.

Fixes #1885 