### PR TITLE
Use `Sentry.with_child_span` in redis and net/http patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
     config.rails.assets_regexp = /my_regexp/
   end
   ```
+- Use `Sentry.with_child_span` in redis and net/http instead of `span.start_child` [#1920](https://github.com/getsentry/sentry-ruby/pull/1920)
+  - This might change the nesting of some spans and make it more accurate
 
 ### Bug Fixes
 

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -26,14 +26,21 @@ module Sentry
       #
       # So we're only instrumenting request when `Net::HTTP` is already started
       def request(req, body = nil, &block)
-        return super unless started?
+        return super unless started? && Sentry.initialized?
+        return super if from_sentry_sdk?
 
-        sentry_span = start_sentry_span
-        set_sentry_trace_header(req, sentry_span)
+        Sentry.with_child_span(op: OP_NAME, start_timestamp: Sentry.utc_now.to_f) do |sentry_span|
+          super.tap do |res|
+            record_sentry_breadcrumb(req, res)
 
-        super.tap do |res|
-          record_sentry_breadcrumb(req, res)
-          record_sentry_span(req, res, sentry_span)
+            if sentry_span
+              set_sentry_trace_header(req, sentry_span)
+
+              request_info = extract_request_info(req)
+              sentry_span.set_description("#{request_info[:method]} #{request_info[:url]}")
+              sentry_span.set_data(:status, res.code.to_i)
+            end
+          end
         end
       end
 
@@ -53,7 +60,6 @@ module Sentry
 
       def record_sentry_breadcrumb(req, res)
         return unless Sentry.initialized? && Sentry.configuration.breadcrumbs_logger.include?(:http_logger)
-        return if from_sentry_sdk?
 
         request_info = extract_request_info(req)
 
@@ -67,29 +73,6 @@ module Sentry
           }
         )
         Sentry.add_breadcrumb(crumb)
-      end
-
-      def record_sentry_span(req, res, sentry_span)
-        return unless Sentry.initialized? && sentry_span
-
-        request_info = extract_request_info(req)
-        sentry_span.set_description("#{request_info[:method]} #{request_info[:url]}")
-        sentry_span.set_data(:status, res.code.to_i)
-        finish_sentry_span(sentry_span)
-      end
-
-      def start_sentry_span
-        return unless Sentry.initialized? && span = Sentry.get_current_scope.get_span
-        return if from_sentry_sdk?
-        return if span.sampled == false
-
-        span.start_child(op: OP_NAME, start_timestamp: Sentry.utc_now.to_f)
-      end
-
-      def finish_sentry_span(sentry_span)
-        return unless Sentry.initialized? && sentry_span
-
-        sentry_span.set_timestamp(Sentry.utc_now.to_f)
       end
 
       def from_sentry_sdk?

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -294,21 +294,6 @@ RSpec.describe Sentry::Net::HTTP do
         end
       end
     end
-
-    context "with unsampled transaction" do
-      it "doesn't do anything" do
-        stub_normal_response
-
-        transaction = Sentry.start_transaction(sampled: false)
-        expect(transaction).not_to receive(:start_child)
-        Sentry.get_current_scope.set_span(transaction)
-
-        response = Net::HTTP.get_response(URI("http://example.com/path"))
-
-        expect(response.code).to eq("200")
-        expect(transaction.span_recorder.spans.count).to eq(1)
-      end
-    end
   end
 
   context "without tracing enabled nor http_logger" do


### PR DESCRIPTION
Move away from using `span.start_child` explicitly and use the top level `Sentry.with_child_span`.

This is necessary going forward for having some top-level api control for disabling sentry instrumentation if we're using open telemetry.

Note: I had to remove one net/http test for the unsampled case since that behaviour changed now. But this is fine as in principle the `sampled` flag just controls the final `hub.capture_event` and not the actual span recording.