### PR TITLE
Make transaction a required argument of Span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 -  Remove bad encoding arguments in redis span descriptions [#1914](https://github.com/getsentry/sentry-ruby/pull/1914)
   - Fixes [#1911](https://github.com/getsentry/sentry-ruby/issues/1911)
 
+### Refactoring
+
+- Make transaction a required argument of Span [#1921](https://github.com/getsentry/sentry-ruby/pull/1921)
+
 ## 5.5.0
 
 ### Features

--- a/sentry-ruby/lib/sentry/span.rb
+++ b/sentry-ruby/lib/sentry/span.rb
@@ -60,9 +60,10 @@ module Sentry
     # The Transaction object the Span belongs to.
     # Every span needs to be attached to a Transaction and their child spans will also inherit the same transaction.
     # @return [Transaction]
-    attr_accessor :transaction
+    attr_reader :transaction
 
     def initialize(
+      transaction:,
       description: nil,
       op: nil,
       status: nil,
@@ -79,6 +80,7 @@ module Sentry
       @start_timestamp = start_timestamp || Sentry.utc_now.to_f
       @timestamp = timestamp
       @description = description
+      @transaction = transaction
       @op = op
       @status = status
       @data = {}
@@ -105,10 +107,10 @@ module Sentry
     end
 
     # Generates a W3C Baggage header string for distributed tracing
-    # from the incoming baggage stored on the transation.
+    # from the incoming baggage stored on the transaction.
     # @return [String, nil]
     def to_baggage
-      transaction&.get_baggage&.serialize
+      transaction.get_baggage&.serialize
     end
 
     # @return [Hash]
@@ -143,9 +145,8 @@ module Sentry
     # Starts a child span with given attributes.
     # @param attributes [Hash] the attributes for the child span.
     def start_child(**attributes)
-      attributes = attributes.dup.merge(trace_id: @trace_id, parent_span_id: @span_id, sampled: @sampled)
+      attributes = attributes.dup.merge(transaction: @transaction, trace_id: @trace_id, parent_span_id: @span_id, sampled: @sampled)
       new_span = Span.new(**attributes)
-      new_span.transaction = transaction
       new_span.span_recorder = span_recorder
 
       if span_recorder

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -58,12 +58,11 @@ module Sentry
       baggage: nil,
       **options
     )
-      super(**options)
+      super(transaction: self, **options)
 
       @name = name
       @source = SOURCES.include?(source) ? source.to_sym : :custom
       @parent_sampled = parent_sampled
-      @transaction = self
       @hub = hub
       @baggage = baggage
       @configuration = hub.configuration # to be removed

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe Sentry::Client do
   end
   subject { Sentry::Client.new(configuration) }
 
+  let(:transaction) do
+    hub = Sentry::Hub.new(subject, Sentry::Scope.new)
+    Sentry::Transaction.new(
+      name: "test transaction",
+      hub: hub,
+      sampled: true
+    )
+  end
+
   let(:fake_time) { Time.now }
 
   before do
@@ -406,7 +415,7 @@ RSpec.describe Sentry::Client do
       configuration.logger = logger
     end
 
-    let(:span) { Sentry::Span.new }
+    let(:span) { Sentry::Span.new(transaction: transaction) }
 
     it "generates the trace with given span and logs correct message" do
       expect(subject.generate_sentry_trace(span)).to eq(span.to_sentry_trace)

--- a/sentry-ruby/spec/sentry/scope/setters_spec.rb
+++ b/sentry-ruby/spec/sentry/scope/setters_spec.rb
@@ -24,12 +24,24 @@ RSpec.describe Sentry::Scope do
   end
 
   describe "#set_span" do
-    let(:span) { Sentry::Span.new(op: "foo") }
+    let(:transaction) do
+      client = Sentry::Client.new(Sentry::Configuration.new)
+      hub = Sentry::Hub.new(client, subject)
+      Sentry::Transaction.new(name: "test transaction", hub: hub)
+    end
+
+    let(:span) { Sentry::Span.new(op: "foo", transaction: transaction) }
 
     it "sets the Span" do
       subject.set_span(span)
 
       expect(subject.span).to eq(span)
+    end
+
+    it "sets the Transaction" do
+      subject.set_span(transaction)
+
+      expect(subject.span).to eq(transaction)
     end
 
     it "raises error when passed non-Span argument" do

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -111,18 +111,13 @@ RSpec.describe Sentry::Scope do
   end
 
   describe "#clear" do
-    subject do
-      scope = described_class.new
-      scope.set_tags({foo: "bar"})
-      scope.set_extras({additional_info: "hello"})
-      scope.set_user({id: 1})
-      scope.set_transaction_name("WelcomeController#index")
-      scope.set_span(Sentry::Span.new)
-      scope.set_fingerprint(["foo"])
-      scope
-    end
-
     it "resets the scope's data" do
+      subject.set_tags({foo: "bar"})
+      subject.set_extras({additional_info: "hello"})
+      subject.set_user({id: 1})
+      subject.set_transaction_name("WelcomeController#index")
+      subject.set_span(Sentry::Transaction.new(op: "foo", hub: hub))
+      subject.set_fingerprint(["foo"])
       scope_id = subject.object_id
 
       subject.clear
@@ -241,12 +236,12 @@ RSpec.describe Sentry::Scope do
     end
 
     it "sets trace context if there's a span" do
-      span = Sentry::Span.new(op: "foo")
-      subject.set_span(span)
+      transaction = Sentry::Transaction.new(op: "foo", hub: hub)
+      subject.set_span(transaction)
 
       subject.apply_to_event(event)
 
-      expect(event.contexts[:trace]).to eq(span.get_trace_context)
+      expect(event.contexts[:trace]).to eq(transaction.get_trace_context)
       expect(event.contexts.dig(:trace, :op)).to eq("foo")
     end
 

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -494,7 +494,10 @@ RSpec.describe Sentry do
     end
 
     context "when the current span is present" do
-      let(:parent_span) { Sentry::Span.new(op: "parent") }
+      let(:parent_span) do
+        transaction = Sentry::Transaction.new(op: "foo", hub: Sentry.get_current_hub)
+        Sentry::Span.new(op: "parent", transaction: transaction)
+      end
 
       before do
         described_class.get_current_scope.set_span(parent_span)


### PR DESCRIPTION
According to the specification, a Span must has a Transaction, whether it's directly assigned to it or inherited from its parent Span.

So this commit enforces that by requiring the `transaction:` argument on Span's constructor.

Although it makes test setup a bit more complicated, it does make tests reflect our real-world expectation more accurately.

**Although this PR changes the constructor of the `Span` and `Transaction` classes, they were never designed to be initialized directly by users. So this is not considered a breaking change**


Closes #1890 