### PR TITLE
Fix setting the sentry-trace header in net/http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   ```
 - Use `Sentry.with_child_span` in redis and net/http instead of `span.start_child` [#1920](https://github.com/getsentry/sentry-ruby/pull/1920)
   - This might change the nesting of some spans and make it more accurate
+  - Followup fix to set the sentry-trace header in the correct place [#1922](https://github.com/getsentry/sentry-ruby/pull/1922)
 
 - Use `Exception#detailed_message` when generating exception message if applicable [#1924](https://github.com/getsentry/sentry-ruby/pull/1924)
 

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -30,12 +30,12 @@ module Sentry
         return super if from_sentry_sdk?
 
         Sentry.with_child_span(op: OP_NAME, start_timestamp: Sentry.utc_now.to_f) do |sentry_span|
+          set_sentry_trace_header(req, sentry_span)
+
           super.tap do |res|
             record_sentry_breadcrumb(req, res)
 
             if sentry_span
-              set_sentry_trace_header(req, sentry_span)
-
               request_info = extract_request_info(req)
               sentry_span.set_description("#{request_info[:method]} #{request_info[:url]}")
               sentry_span.set_data(:status, res.code.to_i)

--- a/sentry-ruby/spec/contexts/with_request_mock.rb
+++ b/sentry-ruby/spec/contexts/with_request_mock.rb
@@ -33,7 +33,7 @@ RSpec.shared_context "with request mock" do
     stub_request(build_fake_response("400", body: { data: "bad sentry DSN public key" }))
   end
 
-  def stub_normal_response(code: "200")
-    stub_request(build_fake_response(code))
+  def stub_normal_response(code: "200", &block)
+    stub_request(build_fake_response(code), &block)
   end
 end


### PR DESCRIPTION
Sorry I made a mistake in #1920 that wasn't caught by the tests that just check the request object after everything happens.
The header should be set before the request actually runs in `super`.