### PR TITLE
Lock sentry-raven's sidekiq to < 7.0

### DIFF
--- a/sentry-raven/Gemfile
+++ b/sentry-raven/Gemfile
@@ -12,7 +12,7 @@ if rails_version.to_f != 0
 end
 
 gem "delayed_job"
-gem "sidekiq"
+gem "sidekiq", "< 7.0"
 
 gem "rack", "< 3.0"
 gem "rack-timeout"


### PR DESCRIPTION
#skip-changelog