### PR TITLE
Make `sentry-sidekiq` compatible with Sidekiq 7

### DIFF
--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        sidekiq_version: [5.0, 6.0]
+        sidekiq_version: ['5.0', '6.0', '7.0']
         ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', '3.1', head, jruby]
         os: [ubuntu-latest]
         include:
@@ -30,6 +30,14 @@ jobs:
         exclude:
           - ruby_version: 2.4
             sidekiq_version: 6.0
+          - ruby_version: 2.4
+            sidekiq_version: 7.0
+          - ruby_version: 2.5
+            sidekiq_version: 7.0
+          - ruby_version: 2.6
+            sidekiq_version: 7.0
+          - ruby_version: jruby
+            sidekiq_version: 7.0
     steps:
     - uses: actions/checkout@v1
 
@@ -41,7 +49,7 @@ jobs:
     - name: Start Redis
       uses: supercharge/redis-github-action@1.1.0
       with:
-        redis-version: 5
+        redis-version: ${{ matrix.sidekiq_version == '7.0' && 6 || 5 }}
 
     - name: Run specs with Sidekiq ${{ matrix.sidekiq_version }}
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,30 +4,32 @@
 
 - Allow users to configure their asset-skipping pattern [#1915](https://github.com/getsentry/sentry-ruby/pull/1915)
 
-  Users can now configure their own pattern to skip asset requests' transactions
+    Users can now configure their own pattern to skip asset requests' transactions
 
-  ```rb
-  Sentry.init do |config|
-    config.rails.assets_regexp = /my_regexp/
-  end
-  ```
+    ```rb
+    Sentry.init do |config|
+      config.rails.assets_regexp = /my_regexp/
+    end
+    ```
+
 - Use `Sentry.with_child_span` in redis and net/http instead of `span.start_child` [#1920](https://github.com/getsentry/sentry-ruby/pull/1920)
-  - This might change the nesting of some spans and make it more accurate
-  - Followup fix to set the sentry-trace header in the correct place [#1922](https://github.com/getsentry/sentry-ruby/pull/1922)
+    - This might change the nesting of some spans and make it more accurate
+    - Followup fix to set the sentry-trace header in the correct place [#1922](https://github.com/getsentry/sentry-ruby/pull/1922)
 
 - Use `Exception#detailed_message` when generating exception message if applicable [#1924](https://github.com/getsentry/sentry-ruby/pull/1924)
+- Make `sentry-sidekiq` compatible with Sidekiq 7 [#1930](https://github.com/getsentry/sentry-ruby/pull/1930)
 
 ### Bug Fixes
 
 - `Sentry::BackgroundWorker` will release `ActiveRecord` connection pool only when the `ActiveRecord` connection is established
 -  Remove bad encoding arguments in redis span descriptions [#1914](https://github.com/getsentry/sentry-ruby/pull/1914)
-  - Fixes [#1911](https://github.com/getsentry/sentry-ruby/issues/1911)
+    - Fixes [#1911](https://github.com/getsentry/sentry-ruby/issues/1911)
 - Add missing `initialized?` checks to `sentry-rails` [#1919](https://github.com/getsentry/sentry-ruby/pull/1919)
-  - Fixes [#1885](https://github.com/getsentry/sentry-ruby/issues/1885)
+    - Fixes [#1885](https://github.com/getsentry/sentry-ruby/issues/1885)
 - Update Tracing Span's op names [#1923](https://github.com/getsentry/sentry-ruby/pull/1923)
 
-  Currently, Ruby integrations' Span op names aren't aligned with the core specification's convention, so we decided to update them altogether in this PR.
-  **If you rely on Span op names for fine-grained event filtering, this may affect the data your app sends to Sentry.**
+    Currently, Ruby integrations' Span op names aren't aligned with the core specification's convention, so we decided to update them altogether in this PR.
+    **If you rely on Span op names for fine-grained event filtering, this may affect the data your app sends to Sentry.**
 
 ### Refactoring
 

--- a/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
@@ -3,6 +3,8 @@ require 'sentry/sidekiq/context_filter'
 module Sentry
   module Sidekiq
     class ErrorHandler
+      WITH_SIDEKIQ_7 = ::Gem::Version.new(::Sidekiq::VERSION) >= ::Gem::Version.new("7.0")
+
       def call(ex, context)
         return unless Sentry.initialized?
 
@@ -40,7 +42,13 @@ module Sentry
         when Integer
           limit
         when TrueClass
-          ::Sidekiq.options[:max_retries] || 25
+          max_retries =
+            if WITH_SIDEKIQ_7
+              ::Sidekiq.default_configuration[:max_retries]
+            else
+              ::Sidekiq.options[:max_retries]
+            end
+          max_retries || 25
         else
           0
         end

--- a/sentry-sidekiq/spec/sentry/sidekiq/error_handler_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/error_handler_spec.rb
@@ -30,8 +30,14 @@ RSpec.describe Sentry::Sidekiq::ErrorHandler do
   end
 
   it "captures exceptions raised during events" do
-    Sidekiq.options[:lifecycle_events][:startup] = [proc { raise "Uhoh!" }]
-    processor.fire_event(:startup)
+    if WITH_SIDEKIQ_7
+      config = Sidekiq.instance_variable_get(:@config)
+      config[:lifecycle_events][:startup] = [proc { raise "Uhoh!" }]
+      Sidekiq::Embedded.new(config).fire_event(:startup)
+    else
+      Sidekiq.options[:lifecycle_events][:startup] = [proc { raise "Uhoh!" }]
+      processor.fire_event(:startup)
+    end
 
     event = transport.events.last.to_hash
     expect(Sentry::Event.get_message_from_exception(event)).to match("RuntimeError: Uhoh!")

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -4,7 +4,13 @@ require "debug" if RUBY_VERSION.to_f >= 2.6
 
 # this enables sidekiq's server mode
 require "sidekiq/cli"
-# require "support/test_sidekiq_app/app"
+
+WITH_SIDEKIQ_7 = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("7.0")
+WITH_SIDEKIQ_6 = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("6.0") && !WITH_SIDEKIQ_7
+
+if WITH_SIDEKIQ_7
+  require "sidekiq/embedded"
+end
 
 require "sentry-ruby"
 
@@ -47,7 +53,17 @@ RSpec.configure do |config|
   end
 
   config.before :all do
-    Sidekiq.logger = Logger.new(nil)
+    silence_sidekiq
+  end
+end
+
+def silence_sidekiq
+  logger = Logger.new(nil)
+
+  if WITH_SIDEKIQ_7
+    Sidekiq.instance_variable_get(:@config).logger = logger
+  else
+    Sidekiq.logger = logger
   end
 end
 
@@ -142,15 +158,18 @@ class TagsWorker
 end
 
 def new_processor
-  options =
-    if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("6.0")
+  manager =
+    case
+    when WITH_SIDEKIQ_7
+      capsule = Sidekiq.instance_variable_get(:@config).default_capsule
+      Sidekiq::Manager.new(capsule)
+    when WITH_SIDEKIQ_6
       Sidekiq[:queue] = ['default']
-      Sidekiq
+      Sidekiq::Manager.new(Sidekiq)
     else
-      { queues: ['default'] }
+      Sidekiq::Manager.new({ queues: ['default'] })
     end
 
-  manager = Sidekiq::Manager.new(options)
   manager.workers.first
 end
 


### PR DESCRIPTION
Most changes are for testing, but it also fixes an incompatible call in the `ErrorHandler` class.