### PR TITLE
Allow custom tags to be passed when using the ActiveSupport::ErrorReporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Features
+- Allow [tags](https://docs.sentry.io/platforms/ruby/enriching-events/tags/) to be passed via the context hash when reporting errors using ActiveSupport::ErrorReporter and Sentry::Rails::ErrorSubscriber in `sentry-rails` [#1932](https://github.com/getsentry/sentry-ruby/pull/1932)
+
 ## 5.7.0
 
 ### Features

--- a/sentry-rails/lib/sentry/rails/error_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/error_subscriber.rb
@@ -7,7 +7,6 @@ module Sentry
       SKIP_SOURCES = Regexp.union([/.*_cache_store.active_support/])
 
       def report(error, handled:, severity:, context:, source: nil)
-        context = context.deep_dup
         tags = { handled: handled }
 
         if source
@@ -15,7 +14,10 @@ module Sentry
           tags[:source] = source
         end
 
-        tags.merge!(context.delete(:tags)) if context[:tags].is_a?(Hash)
+        if context[:tags].is_a?(Hash)
+          context = context.dup
+          tags.merge!(context.delete(:tags))
+        end
 
         Sentry::Rails.capture_exception(error, level: severity, contexts: { "rails.error" => context }, tags: tags)
       end

--- a/sentry-rails/lib/sentry/rails/error_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/error_subscriber.rb
@@ -7,6 +7,7 @@ module Sentry
       SKIP_SOURCES = Regexp.union([/.*_cache_store.active_support/])
 
       def report(error, handled:, severity:, context:, source: nil)
+        context = context.deep_dup
         tags = { handled: handled }
 
         if source

--- a/sentry-rails/lib/sentry/rails/error_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/error_subscriber.rb
@@ -14,6 +14,8 @@ module Sentry
           tags[:source] = source
         end
 
+        tags.merge!(context.delete(:tags)) if context[:tags].is_a?(Hash)
+
         Sentry::Rails.capture_exception(error, level: severity, contexts: { "rails.error" => context }, tags: tags)
       end
     end

--- a/sentry-rails/spec/sentry/rails/error_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/error_subscriber_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'sentry/rails/error_subscriber'
 
-RSpec.describe Sentry::Rails::ErrorSubscriber do
+RSpec.describe Sentry::Rails::ErrorSubscriber, skip: Rails.version.to_f < 7.0 ? "ActiveSupport::ErrorReporter not available until Rails 7" : false do
   describe "#report" do
     it 'does not mutate context' do
       context = { tags: { foo: 'bar' } }

--- a/sentry-rails/spec/sentry/rails/error_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/error_subscriber_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+require 'sentry/rails/error_subscriber'
+
+RSpec.describe Sentry::Rails::ErrorSubscriber do
+  describe "#report" do
+    it 'does not mutate context' do
+      context = { tags: { foo: 'bar' } }
+      expect { described_class.new.report(StandardError.new, handled: true, severity: :error, context: context) }.not_to change { context }
+    end
+
+    it 'sets handled tag' do
+      expect(Sentry::Rails).to receive(:capture_exception) do |_, tags:, **_|
+        expect(tags[:handled]).to eq(true)
+      end
+      event = described_class.new.report(StandardError.new, handled: true, severity: :error, context: {})
+    end
+
+    context 'when source is not nil' do
+      it 'does not send event when source is skipped' do
+        expect(Sentry::Rails).not_to receive(:capture_exception)
+        described_class.new.report(StandardError.new, handled: true, severity: :error, context: {}, source: 'foo_cache_store.active_support')
+      end
+
+      it 'sends event when source is not skipped' do
+        expect(Sentry::Rails).to receive(:capture_exception)
+        described_class.new.report(StandardError.new, handled: true, severity: :error, context: {}, source: 'foo')
+      end
+
+      it 'sets the source as a tag' do
+        expect(Sentry::Rails).to receive(:capture_exception) do |_, tags:, **_|
+          expect(tags[:source]).to eq('foo')
+        end
+        described_class.new.report(StandardError.new, handled: true, severity: :error, context: {}, source: 'foo')
+      end
+    end
+
+    context 'when passed a context with tags key' do
+      context 'when tags is a Hash' do
+        it 'merges the tags into the event' do
+          expect(Sentry::Rails).to receive(:capture_exception) do |_, tags:, **_|
+            expect(tags[:foo]).to eq('bar')
+          end
+          described_class.new.report(StandardError.new, handled: true, severity: :error, context: { tags: { foo: 'bar' } })
+        end
+
+        it 'does not pass the tags to the context' do
+          expect(Sentry::Rails).to receive(:capture_exception) do |_, contexts:, **_|
+            expect(contexts["rails.error"]).not_to have_key(:tags)
+          end
+          described_class.new.report(StandardError.new, handled: true, severity: :error, context: { tags: { foo: 'bar' } })
+        end
+      end
+
+
+      context 'when tags is not a Hash' do
+        it 'does not merge the tags into the event' do
+          expect(Sentry::Rails).to receive(:capture_exception) do |_, tags:, **_|
+            expect(tags).not_to have_key(:foo)
+          end
+          described_class.new.report(StandardError.new, handled: true, severity: :error, context: { tags: 'foo' })
+        end
+
+        it 'passes the tags to the context' do
+          expect(Sentry::Rails).to receive(:capture_exception) do |_, contexts:, **_|
+            expect(contexts["rails.error"][:tags]).to eq('foo')
+          end
+          described_class.new.report(StandardError.new, handled: true, severity: :error, context: { tags: 'foo' })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Allows for passing tags within the ActiveRecord::ErrorReporter context, to properly be sent to Sentry. ~~I noticed that this file lacks spec coverage, should I add a spec file for it?~~

Q: `context[:tags]` or `context[:sentry_tags]` ? 
