### PR TITLE
Clarify op change for traces_sampler usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
     Currently, Ruby integrations' Span op names aren't aligned with the core specification's convention, so we decided to update them altogether in this PR.
     **If you rely on Span op names for fine-grained event filtering, this may affect the data your app sends to Sentry.**
+    **Also make sure to update your `traces_sampler` if you rely on the `op` for filtering some requests.**
 
 ### Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
     Currently, Ruby integrations' Span op names aren't aligned with the core specification's convention, so we decided to update them altogether in this PR.
     **If you rely on Span op names for fine-grained event filtering, this may affect the data your app sends to Sentry.**
-    **Also make sure to update your `traces_sampler` if you rely on the `op` for filtering some requests.**
+    **Also make sure to update your [`traces_sampler`](https://docs.sentry.io/platforms/ruby/configuration/sampling/#setting-a-sampling-function) if you rely on the `op` for filtering some requests.**
 
 ### Refactoring
 


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-ruby/issues/1938

#skip-changelog