### PR TITLE
Add config.instrumenter to switch between sentry and otel instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Features
+
+- Add OpenTelemetry support with new `sentry-opentelemetry` gem
+  - Add `config.instrumenter` to switch between sentry and otel instrumentation [#1944](https://github.com/getsentry/sentry-ruby/pull/1944)
+
 ## 5.6.0
 
 ### Features

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -115,7 +115,7 @@ module Sentry
     end
 
     def activate_tracing
-      if Sentry.configuration.tracing_enabled?
+      if Sentry.configuration.tracing_enabled? && Sentry.configuration.instrumenter == :sentry
         subscribers = Sentry.configuration.rails.tracing_subscribers
         Sentry::Rails::Tracing.register_subscribers(subscribers)
         Sentry::Rails::Tracing.subscribe_tracing_events

--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -91,6 +91,23 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
     end
   end
 
+  context "with instrumenter :otel" do
+    before do
+      make_basic_app do |config|
+        config.traces_sample_rate = 1.0
+        config.instrumenter = :otel
+      end
+    end
+
+    it "doesn't do any tracing" do
+      p = Post.create!
+      get "/posts/#{p.id}"
+
+      expect(response).to have_http_status(:ok)
+      expect(transport.events.count).to eq(0)
+    end
+  end
+
   context "with sprockets-rails" do
     let(:string_io) { StringIO.new }
     let(:logger) do

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -211,6 +211,10 @@ module Sentry
     # @return [Boolean]
     attr_accessor :auto_session_tracking
 
+    # The instrumenter to use, :sentry or :otel
+    # @return [Symbol]
+    attr_reader :instrumenter
+
     # these are not config options
     # @!visibility private
     attr_reader :errors, :gem_specs
@@ -236,6 +240,8 @@ module Sentry
     LOG_PREFIX = "** [Sentry] ".freeze
     MODULE_SEPARATOR = "::".freeze
     SKIP_INSPECTION_ATTRIBUTES = [:@linecache, :@stacktrace_builder]
+
+    INSTRUMENTERS = [:sentry, :otel]
 
     # Post initialization callbacks are called at the end of initialization process
     # allowing extending the configuration of sentry-ruby by multiple extensions
@@ -269,6 +275,7 @@ module Sentry
       self.trusted_proxies = []
       self.dsn = ENV['SENTRY_DSN']
       self.server_name = server_name_from_env
+      self.instrumenter = :sentry
 
       self.before_send = nil
       self.rack_env_whitelist = RACK_ENV_WHITELIST_DEFAULT
@@ -330,6 +337,10 @@ module Sentry
 
     def environment=(environment)
       @environment = environment.to_s
+    end
+
+    def instrumenter=(instrumenter)
+      @instrumenter = INSTRUMENTERS.include?(instrumenter) ? instrumenter : :sentry
     end
 
     def sending_allowed?

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -76,8 +76,9 @@ module Sentry
       @stack.pop
     end
 
-    def start_transaction(transaction: nil, custom_sampling_context: {}, **options)
+    def start_transaction(transaction: nil, custom_sampling_context: {}, instrumenter: :sentry, **options)
       return unless configuration.tracing_enabled?
+      return unless instrumenter == configuration.instrumenter
 
       transaction ||= Transaction.new(**options.merge(hub: self))
 
@@ -92,7 +93,9 @@ module Sentry
       transaction
     end
 
-    def with_child_span(**attributes, &block)
+    def with_child_span(instrumenter: :sentry, **attributes, &block)
+      return yield(nil) unless instrumenter == configuration.instrumenter
+
       current_span = current_scope.get_span
       return yield(nil) unless current_span
 

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -351,4 +351,25 @@ RSpec.describe Sentry::Configuration do
       expect(subject.auto_session_tracking).to eq(false)
     end
   end
+
+  describe "#instrumenter" do
+    it "returns :sentry by default" do
+      expect(subject.instrumenter).to eq(:sentry)
+    end
+
+    it "can be set to :sentry" do
+      subject.instrumenter = :sentry
+      expect(subject.instrumenter).to eq(:sentry)
+    end
+
+    it "can be set to :otel" do
+      subject.instrumenter = :otel
+      expect(subject.instrumenter).to eq(:otel)
+    end
+
+    it "defaults to :sentry if invalid" do
+      subject.instrumenter = :foo
+      expect(subject.instrumenter).to eq(:sentry)
+    end
+  end
 end

--- a/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
@@ -229,6 +229,22 @@ RSpec.describe Sentry::Sidekiq do
       event = transport.events.last
       expect(event.contexts.dig(:trace, :trace_id)).to eq(transaction.contexts.dig(:trace, :trace_id))
     end
+
+    context "with instrumenter :otel" do
+      before do
+        perform_basic_setup do |config|
+          config.traces_sample_rate = 1.0
+          config.instrumenter = :otel
+        end
+      end
+
+      it "does not record transaction" do
+        execute_worker(processor, SadWorker)
+        expect(transport.events.count).to eq(1)
+        event = transport.events.first
+        expect(event).to be_a(Sentry::ErrorEvent)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
The new `config.instrumenter` will act as a top-level switch to disable on sentry transactions/spans when we are in `:otel` mode.

* Disable rails subscribers when instrumenter is not `:sentry`
* Noop top level `start_transaction` and `with_child_span` APIs when the instrumenter don't match with the currently active instrumenter (defaults to `:sentry`)