### PR TITLE
Pin jruby to 9.3 for sentry-raven

### DIFF
--- a/.github/workflows/sentry_raven_test.yml
+++ b/.github/workflows/sentry_raven_test.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - 'sentry-raven/**'
+      - '.github/workflows/sentry_raven_test.yml'
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
@@ -23,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rails_version: [0, 4.2, 5.2, 6.0.0]
-        ruby_version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', jruby]
+        ruby_version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', jruby-9.3]
         os: [ubuntu-latest]
         include:
           - ruby_version: '3.0'
@@ -38,7 +39,7 @@ jobs:
             rails_version: 6.0.0
           - ruby_version: 2.7
             rails_version: 4.2
-          - ruby_version: jruby
+          - ruby_version: jruby-9.3
             rails_version: 4.2
           - ruby_version: '3.0'
             rails_version: 4.2


### PR DESCRIPTION
CI on sentry-raven is failing on master after jruby 9.4 release, just pin it since we sentry-raven is in maintenance mode.