### PR TITLE
Support redis-rb 5.0+

### DIFF
--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -21,34 +21,71 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', head, jruby]
+        ruby_version: [2.4, 2.5, 2.6, 2.7, "3.0", head, jruby]
         rack_version: [2.0, 3.0]
+        redis_rb_version: [4.0]
         os: [ubuntu-latest]
         include:
-          - { os: ubuntu-latest, ruby_version: 3.1, rack_version: 0 }
-          - { os: ubuntu-latest, ruby_version: 3.1, rack_version: 2.0 }
-          - { os: ubuntu-latest, ruby_version: 3.1, rack_version: 3.0 }
-          - { os: ubuntu-latest, ruby_version: 3.1, rack_version: 3.0, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
-          - { os: ubuntu-latest, ruby_version: 3.1, rack_version: 3.0, options: { codecov: 1 } }
+          - {
+              os: ubuntu-latest,
+              ruby_version: 3.1,
+              rack_version: 0,
+              redis_rb_version: 5.0,
+            }
+          - {
+              os: ubuntu-latest,
+              ruby_version: 3.1,
+              rack_version: 2.0,
+              redis_rb_version: 5.0,
+            }
+          - {
+              os: ubuntu-latest,
+              ruby_version: 3.1,
+              rack_version: 3.0,
+              redis_rb_version: 5.0,
+            }
+          - {
+              os: ubuntu-latest,
+              ruby_version: 3.1,
+              rack_version: 3.0,
+              redis_rb_version: 5.0,
+              options:
+                {
+                  rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal",
+                },
+            }
+          - {
+              os: ubuntu-latest,
+              ruby_version: 3.1,
+              rack_version: 3.0,
+              redis_rb_version: 5.0,
+              options: { codecov: 1 },
+            }
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    - name: Set up Ruby ${{ matrix.ruby_version }}
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby_version }}
+      - name: Set up Ruby ${{ matrix.ruby_version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
 
-    - name: Run specs
-      env:
-        RUBYOPT: ${{ matrix.options.rubyopt }}
-        RACK_VERSION: ${{ matrix.rack_version }}
-      run: |
-        bundle install --jobs 4 --retry 3
-        bundle exec rake
+      - name: Start Redis
+        uses: supercharge/redis-github-action@c169aa53af4cd5d9321e9114669dbd11be08d307
+        with:
+          redis-version: 6
 
-    - name: Upload Coverage
-      if: ${{ matrix.options.codecov }}
-      run: |
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        chmod +x codecov
-        ./codecov -t ${CODECOV_TOKEN} -R `pwd` -f coverage/coverage.xml
+      - name: Run specs with Rack ${{ matrix.rack_version }} and redis-rb ${{ matrix.redis_rb_version }}
+        env:
+          RUBYOPT: ${{ matrix.options.rubyopt }}
+          RACK_VERSION: ${{ matrix.rack_version }}
+          REDIS_RB_VERSION: ${{ matrix.redis_rb_version }}
+        run: |
+          bundle install --jobs 4 --retry 3
+          bundle exec rake
+
+      - name: Upload Coverage
+        if: ${{ matrix.options.codecov }}
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -t ${CODECOV_TOKEN} -R `pwd` -f coverage/coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 ## Unreleased
 
 ### Features
+
 - Allow [tags](https://docs.sentry.io/platforms/ruby/enriching-events/tags/) to be passed via the context hash when reporting errors using ActiveSupport::ErrorReporter and Sentry::Rails::ErrorSubscriber in `sentry-rails` [#1932](https://github.com/getsentry/sentry-ruby/pull/1932)
+
+### Bug Fixes
+
+- Support redis-rb 5.0+ [#1963](https://github.com/getsentry/sentry-ruby/pull/1963)
+  - Fixes [#1932](https://github.com/getsentry/sentry-ruby/pull/1932)
 
 ## 5.7.0
 

--- a/sentry-ruby/.rspec
+++ b/sentry-ruby/.rspec
@@ -1,3 +1,2 @@
 --format documentation
 --color
---require spec_helper

--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -10,10 +10,10 @@ gem "rack", "~> #{Gem::Version.new(rack_version)}" unless rack_version == "0"
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
 gem "rspec-retry"
-gem "fakeredis"
 gem "timecop"
-gem 'simplecov'
+gem "simplecov"
 gem "simplecov-cobertura", "~> 1.4"
+gem "redis"
 gem "rexml"
 
 gem "object_tracer"

--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -7,13 +7,15 @@ rack_version = ENV["RACK_VERSION"]
 rack_version = "3.0.0" if rack_version.nil?
 gem "rack", "~> #{Gem::Version.new(rack_version)}" unless rack_version == "0"
 
+redis_rb_version = ENV.fetch("REDIS_RB_VERSION", "5.0")
+gem "redis", "~> #{redis_rb_version}"
+
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
 gem "rspec-retry"
 gem "timecop"
 gem "simplecov"
 gem "simplecov-cobertura", "~> 1.4"
-gem "redis"
 gem "rexml"
 
 gem "object_tracer"

--- a/sentry-ruby/spec/sentry/breadcrumb/redis_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/redis_logger_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 
 RSpec.describe :redis_logger do
-  let(:redis) do
-    Redis.new
-  end
+  let(:redis) { Redis.new(host: "127.0.0.1") }
 
   before do
     perform_basic_setup do |config|
@@ -59,7 +57,7 @@ RSpec.describe :redis_logger do
     let(:result) { redis.info }
 
     it "doesn't cause an error" do
-      expect(result).to include("uptime_in_days" => 0)
+      expect(result["uptime_in_days"].to_s).to eq("0")
       expect(Sentry.get_current_scope.breadcrumbs.peek).to have_attributes(
         category: "db.redis",
         data: { commands: [{ command: "INFO", key: nil }], server: "127.0.0.1:6379/0" }

--- a/sentry-ruby/spec/sentry/redis_spec.rb
+++ b/sentry-ruby/spec/sentry/redis_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Sentry::Redis do
-  let(:redis) do
-    Redis.new
-  end
+  let(:redis) { Redis.new(host: "127.0.0.1") }
 
   context "with tracing enabled" do
     before do

--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require "pry"
 require "timecop"
 require "simplecov"
 require "rspec/retry"
-require "fakeredis/rspec"
+require "redis"
 
 SimpleCov.start do
   project_name "sentry-ruby"


### PR DESCRIPTION
This fixes #1931 

Changes:
- Use real Redis for testing because `fakeredis` doesn't support `redis-rb 5.0+`
- Add `REDIS_RB_VERSION` to control installed `redis-rb`'s version and test against bot `~> 4.0` and `~> 5.0` on CI
- Make `sentry-ruby` works with `redis-rb 5.0+` too.

