### PR TITLE
Return value from 'perform_action' when initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### Features
 
 - Allow [tags](https://docs.sentry.io/platforms/ruby/enriching-events/tags/) to be passed via the context hash when reporting errors using ActiveSupport::ErrorReporter and Sentry::Rails::ErrorSubscriber in `sentry-rails` [#1932](https://github.com/getsentry/sentry-ruby/pull/1932)
-- Return value from `perform_action` in ActionCable::Channel instances when initialized [#1966](https://github.com/getsentry/sentry-ruby/pull/1966)
 
 ### Bug Fixes
 
@@ -11,6 +10,7 @@
   - Fixes [#1932](https://github.com/getsentry/sentry-ruby/pull/1932)
 - Skip private _config context in Sidekiq 7+ [#1967](https://github.com/getsentry/sentry-ruby/pull/1967)
   - Fixes [#1956](https://github.com/getsentry/sentry-ruby/issues/1956)
+- Return value from `perform_action` in ActionCable::Channel instances when initialized [#1966](https://github.com/getsentry/sentry-ruby/pull/1966)
 
 ## 5.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - Allow [tags](https://docs.sentry.io/platforms/ruby/enriching-events/tags/) to be passed via the context hash when reporting errors using ActiveSupport::ErrorReporter and Sentry::Rails::ErrorSubscriber in `sentry-rails` [#1932](https://github.com/getsentry/sentry-ruby/pull/1932)
+- Return value from `perform_action` in ActionCable::Channel instances when initialized [#1966](https://github.com/getsentry/sentry-ruby/pull/1966)
 
 ### Bug Fixes
 

--- a/sentry-rails/lib/sentry/rails/action_cable.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable.rb
@@ -22,7 +22,7 @@ module Sentry
               begin
                 result = block.call
                 finish_transaction(transaction, 200)
-                return result
+                result
               rescue Exception => e # rubocop:disable Lint/RescueException
                 Sentry::Rails.capture_exception(e)
                 finish_transaction(transaction, 500)

--- a/sentry-rails/lib/sentry/rails/action_cable.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable.rb
@@ -20,8 +20,9 @@ module Sentry
               scope.set_span(transaction) if transaction
 
               begin
-                block.call
+                result = block.call
                 finish_transaction(transaction, 200)
+                return result
               rescue Exception => e # rubocop:disable Lint/RescueException
                 Sentry::Rails.capture_exception(e)
                 finish_transaction(transaction, 500)


### PR DESCRIPTION
We use `ActionCable::Channel::Base#perform_action` in our Action Cable testing and would like to use its return value as part of those tests. At the minute, when the SDK is not initialized then this works OK, as the return value of `block.call` is immediately returned: https://github.com/getsentry/sentry-ruby/blob/dce8ef069ddf2393497863e6c62a22221a4454ff/sentry-rails/lib/sentry/rails/action_cable.rb#L9

However, if we initialize the SDK, then the return value is swallowed. This change ensures that the result of `block.call` is returned in all situations, apart from when an error is raised in the block.