### PR TITLE
Tag an ActiveRecord span as cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - Allow [tags](https://docs.sentry.io/platforms/ruby/enriching-events/tags/) to be passed via the context hash when reporting errors using ActiveSupport::ErrorReporter and Sentry::Rails::ErrorSubscriber in `sentry-rails` [#1932](https://github.com/getsentry/sentry-ruby/pull/1932)
+- Pass a `cached: true` tag for SQL query spans that utilized the ActiveRecord QueryCache when using ActiveRecordSubscriber in `sentry-rails` [#1968](https://github.com/getsentry/sentry-ruby/pull/1968)
 
 ### Bug Fixes
 

--- a/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
@@ -14,6 +14,7 @@ module Sentry
 
             record_on_current_span(op: SPAN_PREFIX + event_name, start_timestamp: payload[START_TIMESTAMP_NAME], description: payload[:sql], duration: duration) do |span|
               span.set_data(:connection_id, payload[:connection_id])
+              span.set_tag(:cached, true) if payload.fetch(:cached, false) # cached key is only set for hits in the QueryCache, from Rails 5.1
             end
           end
         end

--- a/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
       expect(transaction[:type]).to eq("transaction")
       expect(transaction[:spans].count).to eq(2)
 
-      span = transaction[:spans][1]
-      expect(span[:op]).to eq("db.sql.active_record")
-      expect(span[:description]).to eq("SELECT \"posts\".* FROM \"posts\"")
-      expect(span[:tags]).to include({cached: true})
+      cached_query_span = transaction[:spans][1]
+      expect(cached_query_span[:op]).to eq("db.sql.active_record")
+      expect(cached_query_span[:description]).to eq("SELECT \"posts\".* FROM \"posts\"")
+      expect(cached_query_span[:tags]).to include({cached: true})
     end
   end
 

--- a/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
@@ -32,6 +32,29 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
       expect(span[:description]).to eq("SELECT \"posts\".* FROM \"posts\"")
       expect(span[:trace_id]).to eq(transaction.dig(:contexts, :trace, :trace_id))
     end
+
+    it "records database cached query events", skip: Rails.version.to_f < 5.1 do
+      transaction = Sentry::Transaction.new(sampled: true, hub: Sentry.get_current_hub)
+      Sentry.get_current_scope.set_span(transaction)
+
+      ActiveRecord::Base.connection.cache do
+        Post.all.to_a
+        Post.all.to_a # Execute a second time, hitting the query cache
+      end
+
+      transaction.finish
+
+      expect(transport.events.count).to eq(1)
+
+      transaction = transport.events.first.to_hash
+      expect(transaction[:type]).to eq("transaction")
+      expect(transaction[:spans].count).to eq(2)
+
+      span = transaction[:spans][1]
+      expect(span[:op]).to eq("db.sql.active_record")
+      expect(span[:description]).to eq("SELECT \"posts\".* FROM \"posts\"")
+      expect(span[:tags]).to include({cached: true})
+    end
   end
 
   context "when transaction is not sampled" do

--- a/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
       span = transaction[:spans][0]
       expect(span[:op]).to eq("db.sql.active_record")
       expect(span[:description]).to eq("SELECT \"posts\".* FROM \"posts\"")
+      expect(span[:tags].key?(:cached)).to eq(false)
       expect(span[:trace_id]).to eq(transaction.dig(:contexts, :trace, :trace_id))
     end
 


### PR DESCRIPTION
When digging through a transaction, we could not readily confirm if a repeated ActiveRecord query was using the cache or not. The information is already sent along with the `sql.active_record` instrumentation since [Rails 5.1](https://github.com/rails/rails/blob/6cacbac68e25e1c98b838409498a70e9b4f3bf12/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb#L152) but only from the QueryCache origin.
The tag is added only if `cached: true` is in the payload.