### PR TITLE
Refactor workflow matrixes

### DIFF
--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -21,14 +21,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', '3.1', head, jruby]
+        os: [ubuntu-latest]
         include:
-          - { os: ubuntu-latest, ruby_version: 2.4 }
-          - { os: ubuntu-latest, ruby_version: 2.5 }
-          - { os: ubuntu-latest, ruby_version: 2.6 }
-          - { os: ubuntu-latest, ruby_version: 2.7 }
-          - { os: ubuntu-latest, ruby_version: '3.0' }
-          - { os: ubuntu-latest, ruby_version: head }
-          - { os: ubuntu-latest, ruby_version: jruby }
           - { os: ubuntu-latest, ruby_version: '3.1', options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
           - { os: ubuntu-latest, ruby_version: '3.1', options: { codecov: 1 } }
     steps:

--- a/.github/workflows/sentry_opentelemetry_test.yml
+++ b/.github/workflows/sentry_opentelemetry_test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.6, 2.7, '3.0', head, jruby]
+        ruby_version: [2.6, 2.7, '3.0', '3.1', head, jruby]
         # opentelemetry_version: [1.2.0]
         os: [ubuntu-latest]
         include:

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -21,37 +21,44 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rails_version: [5.0.0, 5.1.0, 5.2.0, 6.0.0, 6.1.0]
-        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', jruby]
+        rails_version: [6.1.0, 7.0.0, 7.1.0]
+        ruby_version: [2.7, "3.0", "3.1", head]
         os: [ubuntu-latest]
         include:
-          - { os: ubuntu-latest, ruby_version: '3.1', rails_version: 6.1.0, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
-          - { os: ubuntu-latest, ruby_version: '3.1', rails_version: 6.1.0, options: { codecov: 1 } }
-          - { os: ubuntu-latest, ruby_version: '2.7', rails_version: 7.0.0 }
-          - { os: ubuntu-latest, ruby_version: '3.0', rails_version: 7.0.0 }
-          - { os: ubuntu-latest, ruby_version: '3.0', rails_version: 7.1.0 }
-          - { os: ubuntu-latest, ruby_version: '3.1', rails_version: 7.0.0 }
-          - { os: ubuntu-latest, ruby_version: '3.1', rails_version: 7.1.0 }
-          - { os: ubuntu-latest, ruby_version: head, rails_version: 7.1.0 }
-        exclude:
-          - ruby_version: 2.4
-            rails_version: 6.0.0
-          - ruby_version: 2.4
-            rails_version: 6.1.0
-          - ruby_version: '3.0'
-            rails_version: 5.0.0
-          - ruby_version: '3.0'
-            rails_version: 5.1.0
-          - ruby_version: '3.0'
-            rails_version: 5.2.0
-          - ruby_version: jruby
-            rails_version: 5.0.0
-          - ruby_version: jruby
-            rails_version: 5.1.0
-          - ruby_version: jruby
-            rails_version: 5.2.0
-          - ruby_version: jruby
-            rails_version: 6.0.0
+          - { os: ubuntu-latest, ruby_version: "2.4", rails_version: 5.0.0 }
+          - { os: ubuntu-latest, ruby_version: "2.4", rails_version: 5.1.0 }
+          - { os: ubuntu-latest, ruby_version: "2.4", rails_version: 5.2.0 }
+          - { os: ubuntu-latest, ruby_version: "2.5", rails_version: 5.0.0 }
+          - { os: ubuntu-latest, ruby_version: "2.5", rails_version: 5.1.0 }
+          - { os: ubuntu-latest, ruby_version: "2.5", rails_version: 5.2.0 }
+          - { os: ubuntu-latest, ruby_version: "2.5", rails_version: 6.0.0 }
+          - { os: ubuntu-latest, ruby_version: "2.5", rails_version: 6.1.0 }
+          - { os: ubuntu-latest, ruby_version: "2.6", rails_version: 5.0.0 }
+          - { os: ubuntu-latest, ruby_version: "2.6", rails_version: 5.1.0 }
+          - { os: ubuntu-latest, ruby_version: "2.6", rails_version: 5.2.0 }
+          - { os: ubuntu-latest, ruby_version: "2.6", rails_version: 6.0.0 }
+          - { os: ubuntu-latest, ruby_version: "2.6", rails_version: 6.1.0 }
+          - { os: ubuntu-latest, ruby_version: "2.7", rails_version: 5.0.0 }
+          - { os: ubuntu-latest, ruby_version: "2.7", rails_version: 5.1.0 }
+          - { os: ubuntu-latest, ruby_version: "2.7", rails_version: 5.2.0 }
+          - { os: ubuntu-latest, ruby_version: "2.7", rails_version: 6.0.0 }
+          - { os: ubuntu-latest, ruby_version: "2.7", rails_version: 6.1.0 }
+          - { os: ubuntu-latest, ruby_version: "jruby", rails_version: 6.1.0 }
+          - {
+              os: ubuntu-latest,
+              ruby_version: "3.1",
+              rails_version: 7.1.0,
+              options:
+                {
+                  rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal",
+                },
+            }
+          - {
+              os: ubuntu-latest,
+              ruby_version: "3.1",
+              rails_version: 7.1.0,
+              options: { codecov: 1 },
+            }
     steps:
     - uses: actions/checkout@v1
     - name: Install sqlite and ImageMagick

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -21,14 +21,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', '3.1', head, jruby]
+        os: [ubuntu-latest]
         include:
-          - { os: ubuntu-latest, ruby_version: 2.4 }
-          - { os: ubuntu-latest, ruby_version: 2.5 }
-          - { os: ubuntu-latest, ruby_version: 2.6 }
-          - { os: ubuntu-latest, ruby_version: 2.7 }
-          - { os: ubuntu-latest, ruby_version: '3.0' }
-          - { os: ubuntu-latest, ruby_version: head }
-          - { os: ubuntu-latest, ruby_version: jruby }
           - { os: ubuntu-latest, ruby_version: '3.1', options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
           - { os: ubuntu-latest, ruby_version: '3.1', options: { codecov: 1 } }
     steps:

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.4, 2.5, 2.6, 2.7, "3.0", head, jruby]
+        ruby_version: [2.4, 2.5, 2.6, 2.7, "3.0", "3.1", head, jruby]
         rack_version: [2.0, 3.0]
         redis_rb_version: [4.0]
         os: [ubuntu-latest]
@@ -36,12 +36,6 @@ jobs:
               os: ubuntu-latest,
               ruby_version: 3.1,
               rack_version: 2.0,
-              redis_rb_version: 5.0,
-            }
-          - {
-              os: ubuntu-latest,
-              ruby_version: 3.1,
-              rack_version: 3.0,
               redis_rb_version: 5.0,
             }
           - {

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -22,22 +22,18 @@ jobs:
     strategy:
       matrix:
         sidekiq_version: ['5.0', '6.0', '7.0']
-        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', '3.1', head, jruby]
+        ruby_version: [2.7, '3.0', '3.1', head, jruby]
         os: [ubuntu-latest]
         include:
+          - { os: ubuntu-latest, ruby_version: 2.4, sidekiq_version: 5.0 }
+          - { os: ubuntu-latest, ruby_version: 2.5, sidekiq_version: 5.0 }
+          - { os: ubuntu-latest, ruby_version: 2.5, sidekiq_version: 6.0 }
+          - { os: ubuntu-latest, ruby_version: 2.6, sidekiq_version: 5.0 }
+          - { os: ubuntu-latest, ruby_version: 2.6, sidekiq_version: 6.0 }
+          - { os: ubuntu-latest, ruby_version: jruby, sidekiq_version: 5.0 }
+          - { os: ubuntu-latest, ruby_version: jruby, sidekiq_version: 6.0 }
           - { os: ubuntu-latest, ruby_version: '3.1', sidekiq_version: 6.0, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
           - { os: ubuntu-latest, ruby_version: '3.1', sidekiq_version: 6.0, options: { codecov: 1 } }
-        exclude:
-          - ruby_version: 2.4
-            sidekiq_version: 6.0
-          - ruby_version: 2.4
-            sidekiq_version: 7.0
-          - ruby_version: 2.5
-            sidekiq_version: 7.0
-          - ruby_version: 2.6
-            sidekiq_version: 7.0
-          - ruby_version: jruby
-            sidekiq_version: 7.0
     steps:
     - uses: actions/checkout@v1
 


### PR DESCRIPTION
Instead of putting newer Ruby/lib versions into the ever-growing `exclude` list, we should put old Ruby/lib version to the `include` list. This will allow us to just remove those entries when we decide to drop them in the future.

#skip-changelog