### PR TITLE
Lock workflows' bundler version to 2.3

### DIFF
--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -44,6 +44,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
+        bundler: "2.3"
 
     - name: Run specs
       env:

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -64,6 +64,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
+        bundler: "2.3"
 
     - name: Build with Rails ${{ matrix.rails_version }}
       env:

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -37,6 +37,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
+        bundler: "2.3"
 
     - name: Start Redis
       uses: supercharge/redis-github-action@1.1.0
@@ -53,6 +54,6 @@ jobs:
     - name: Upload Coverage
       if: ${{ matrix.options.codecov }}
       run: |
-        curl -Os https://uploader.codecov.io/latest/linux/codecov 
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
         chmod +x codecov
         ./codecov -t ${CODECOV_TOKEN} -R `pwd` -f coverage/coverage.xml

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -68,6 +68,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
+          bundler: "2.3"
 
       - name: Start Redis
         uses: supercharge/redis-github-action@c169aa53af4cd5d9321e9114669dbd11be08d307

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -45,6 +45,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
+        bundler: "2.3"
 
     - name: Start Redis
       uses: supercharge/redis-github-action@1.1.0
@@ -62,6 +63,6 @@ jobs:
     - name: Upload Coverage
       if: ${{ matrix.options.codecov }}
       run: |
-        curl -Os https://uploader.codecov.io/latest/linux/codecov 
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
         chmod +x codecov
         ./codecov -t ${CODECOV_TOKEN} -R `pwd` -f coverage/coverage.xml


### PR DESCRIPTION
Bundler 2.4 was recently released but because it only supports Ruby 2.6+, all our matrixes for Ruby 2.4 and 2.5 would constantly fail.

This PR avoids the problem by locking Bundle to 2.3.

#skip-changelog
