### PR TITLE
Use latest rubygems for Rails 7.1+ on CI 

### DIFF
--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -65,6 +65,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby_version }}
         bundler: "2.3"
+        rubygems: ${{ matrix.rails_version == '7.1.0' && 'latest' || 'default' }}
 
     - name: Build with Rails ${{ matrix.rails_version }}
       env:


### PR DESCRIPTION
Rails 7.1 will require a newer version of rubygems, which is newer than most Ruby versions install by default. 

PR: https://github.com/rails/rails/pull/46817

So if we don't upgrade the default rubygems, `bundle install` would fail. However, we also can't upgrade it universally because newer rubygems requires Ruby 2.6+.

#skip-changelog
