### PR TITLE
Add Span#set_extra and Span#set_extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - Allow [tags](https://docs.sentry.io/platforms/ruby/enriching-events/tags/) to be passed via the context hash when reporting errors using ActiveSupport::ErrorReporter and Sentry::Rails::ErrorSubscriber in `sentry-rails` [#1932](https://github.com/getsentry/sentry-ruby/pull/1932)
+- Add `Span#set_extra` and `Span#set_extras` api. [link to pull request]
 
 ### Bug Fixes
 

--- a/sentry-ruby/lib/sentry/span.rb
+++ b/sentry-ruby/lib/sentry/span.rb
@@ -4,6 +4,8 @@ require "securerandom"
 
 module Sentry
   class Span
+    include ArgumentCheckingHelper
+
     STATUS_MAP = {
       400 => "invalid_argument",
       401 => "unauthenticated",
@@ -51,6 +53,9 @@ module Sentry
     # Span data
     # @return [Hash]
     attr_reader :data
+    # Span extra
+    # @return [Hash]
+    attr_reader :extra
 
     # The SpanRecorder the current span belongs to.
     # SpanRecorder holds all spans under the same Transaction object (including the Transaction itself).
@@ -86,6 +91,7 @@ module Sentry
       @status = status
       @data = {}
       @tags = {}
+      @extra = {}
     end
 
     # Finishes the span by adding a timestamp.
@@ -227,6 +233,20 @@ module Sentry
     # @param value [String]
     def set_tag(key, value)
       @tags[key] = value
+    end
+
+    # Inserts a key-value pair to the span's extra payload.
+    # @param key [String, Symbol]
+    # @param value [String]
+    def set_extra(key, value)
+      @extra[key] = value
+    end
+
+    # Inserts a multiple key-value pairs to the span's extra payload.
+    # @param extras_hash [Hash]
+    def set_extras(extras_hash)
+      check_argument_type!(extras_hash, Hash)
+      @extra.merge!(extras_hash)
     end
   end
 end

--- a/sentry-ruby/lib/sentry/transaction_event.rb
+++ b/sentry-ruby/lib/sentry/transaction_event.rb
@@ -24,6 +24,7 @@ module Sentry
       self.timestamp = transaction.timestamp
       self.start_timestamp = transaction.start_timestamp
       self.tags = transaction.tags
+      self.extra = transaction.extra
       self.dynamic_sampling_context = transaction.get_baggage.dynamic_sampling_context
 
       finished_spans = transaction.span_recorder.spans.select { |span| span.timestamp && span != transaction }

--- a/sentry-ruby/spec/sentry/span_spec.rb
+++ b/sentry-ruby/spec/sentry/span_spec.rb
@@ -272,4 +272,20 @@ RSpec.describe Sentry::Span do
       expect(subject.tags).to eq({ foo: "bar" })
     end
   end
+
+  describe "#set_extra" do
+    it "sets extra" do
+      subject.set_extra(:foo, "bar")
+
+      expect(subject.extra).to eq({ foo: "bar" })
+    end
+  end
+
+  describe "#set_extras" do
+    it "sets extras" do
+      subject.set_extras({ foo: "bar", bar: "foo" })
+
+      expect(subject.extra).to eq({ foo: "bar", bar: "foo" })
+    end
+  end
 end


### PR DESCRIPTION
Hi! I'm implementing a feature that tracks performance for our heavy operations with many steps.

This feature allows adding extra payload to performance transactional events.

It can be beneficial to find out bottlenecks with transactions that don't relate to any users or requests, for example. 
