### PR TITLE
Fix sentry-rails' controller span nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   - Fixes [#1956](https://github.com/getsentry/sentry-ruby/issues/1956)
 - Return value from `perform_action` in ActionCable::Channel instances when initialized [#1966](https://github.com/getsentry/sentry-ruby/pull/1966)
 - `Span#with_child_span` should finish the span even with exception raised [#1982](https://github.com/getsentry/sentry-ruby/pull/1982)
+- Fix sentry-rails' controller span nesting [#1973](https://github.com/getsentry/sentry-ruby/pull/1973)
+  - Fixes [#1899](https://github.com/getsentry/sentry-ruby/issues/1899)
 
 ## 5.7.0
 

--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -83,7 +83,6 @@ module Sentry
           %r(\A/{0,2}#{::Rails.application.config.assets.prefix})
         end
         @tracing_subscribers = Set.new([
-          Sentry::Rails::Tracing::ActionControllerSubscriber,
           Sentry::Rails::Tracing::ActionViewSubscriber,
           Sentry::Rails::Tracing::ActiveRecordSubscriber,
           Sentry::Rails::Tracing::ActiveStorageSubscriber

--- a/sentry-rails/lib/sentry/rails/controller_transaction.rb
+++ b/sentry-rails/lib/sentry/rails/controller_transaction.rb
@@ -2,10 +2,34 @@ module Sentry
   module Rails
     module ControllerTransaction
       def self.included(base)
-        base.prepend_before_action do |controller|
-          if Sentry.initialized?
-            Sentry.get_current_scope.set_transaction_name("#{controller.class}##{controller.action_name}", source: :view)
+        base.prepend_around_action(:sentry_around_action)
+      end
+
+      private
+
+      def sentry_around_action
+        if Sentry.initialized?
+          transaction_name = "#{self.class}##{action_name}"
+          Sentry.get_current_scope.set_transaction_name(transaction_name, source: :view)
+          Sentry.with_child_span(op: "view.process_action.action_controller", description: transaction_name) do |child_span|
+            if child_span
+              begin
+                result = yield
+              ensure
+                child_span.set_http_status(response.status)
+                child_span.set_data(:format, request.format)
+                child_span.set_data(:method, request.method)
+                child_span.set_data(:path, request.path)
+                child_span.set_data(:params, request.params)
+              end
+
+              result
+            else
+              yield
+            end
           end
+        else
+          yield
         end
       end
     end

--- a/sentry-rails/lib/sentry/rails/tracing/action_controller_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/action_controller_subscriber.rb
@@ -11,6 +11,11 @@ module Sentry
         OP_NAME = "view.process_action.action_controller".freeze
 
         def self.subscribe!
+          Sentry.logger.warn <<~MSG
+            DEPRECATION WARNING: sentry-rails has changed its approach on controller span recording and #{self.name} is now depreacted.
+            Please stop using or referencing #{self.name} as it will be removed in the next major release.
+          MSG
+
           subscribe_to_event(EVENT_NAMES) do |event_name, duration, payload|
             controller = payload[:controller]
             action = payload[:action]

--- a/sentry-rails/spec/sentry/rails/configuration_spec.rb
+++ b/sentry-rails/spec/sentry/rails/configuration_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe Sentry::Rails::Configuration do
     class MySubscriber; end
 
     it "returns the default subscribers" do
-      expect(subject.tracing_subscribers.size).to eq(4)
+      expect(subject.tracing_subscribers.size).to eq(3)
     end
 
     it "is customizable" do
       subject.tracing_subscribers << MySubscriber
-      expect(subject.tracing_subscribers.size).to eq(5)
+      expect(subject.tracing_subscribers.size).to eq(4)
     end
 
     it "is replaceable" do

--- a/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe Sentry::Rails::Tracing::ActionControllerSubscriber, :subscriber, 
       expect(span[:op]).to eq("view.process_action.action_controller")
       expect(span[:description]).to eq("HelloController#world")
       expect(span[:trace_id]).to eq(transaction.dig(:contexts, :trace, :trace_id))
-      expect(span[:data][:payload].keys).not_to include(:request)
-      expect(span[:data][:payload].keys).not_to include(:headers)
+      expect(span[:data].keys).to match_array(["status_code", :format, :method, :path, :params])
     end
   end
 

--- a/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
@@ -6,11 +6,23 @@ RSpec.describe Sentry::Rails::Tracing::ActionControllerSubscriber, :subscriber, 
   end
 
   context "when transaction is sampled" do
+    let(:string_io) { StringIO.new }
+    let(:logger) do
+      ::Logger.new(string_io)
+    end
+
     before do
       make_basic_app do |config|
         config.traces_sample_rate = 1.0
         config.rails.tracing_subscribers = [described_class]
+        config.logger = logger
       end
+    end
+
+    it "logs deprecation message" do
+      expect(string_io.string).to include(
+        "DEPRECATION WARNING: sentry-rails has changed its approach on controller span recording and Sentry::Rails::Tracing::ActionControllerSubscriber is now depreacted."
+      )
     end
 
     it "records controller action processing event" do
@@ -20,7 +32,7 @@ RSpec.describe Sentry::Rails::Tracing::ActionControllerSubscriber, :subscriber, 
 
       transaction = transport.events.first.to_hash
       expect(transaction[:type]).to eq("transaction")
-      expect(transaction[:spans].count).to eq(1)
+      expect(transaction[:spans].count).to eq(2)
 
       span = transaction[:spans][0]
       expect(span[:op]).to eq("view.process_action.action_controller")

--- a/sentry-rails/spec/sentry/rails/tracing/action_view_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_view_subscriber_spec.rb
@@ -20,9 +20,10 @@ RSpec.describe Sentry::Rails::Tracing::ActionViewSubscriber, :subscriber, type: 
 
       transaction = transport.events.first.to_hash
       expect(transaction[:type]).to eq("transaction")
-      expect(transaction[:spans].count).to eq(1)
+      expect(transaction[:spans].count).to eq(2)
 
-      span = transaction[:spans][0]
+      # ignore the first span, which is for controller action
+      span = transaction[:spans][1]
       expect(span[:op]).to eq("template.render_template.action_view")
       expect(span[:description]).to match(/test_template\.html\.erb/)
       expect(span[:trace_id]).to eq(transaction.dig(:contexts, :trace, :trace_id))

--- a/sentry-rails/spec/sentry/rails/tracing/active_storage_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_storage_subscriber_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe Sentry::Rails::Tracing::ActiveStorageSubscriber, :subscriber, typ
 
       request_transaction = transport.events.last.to_hash
       expect(request_transaction[:type]).to eq("transaction")
-      expect(request_transaction[:spans].count).to eq(1)
+      expect(request_transaction[:spans].count).to eq(2)
 
-      span = request_transaction[:spans][0]
+      span = request_transaction[:spans][1]
       expect(span[:op]).to eq("file.service_upload.active_storage")
       expect(span[:description]).to eq("Disk")
       expect(span.dig(:data, :key)).to eq(p.cover.key)


### PR DESCRIPTION
As described in #1899, the controller span's nesting is not correct because we record it through ActiveSupport instrumentation.

So this PR I did a few things:

1. Make sure `Span#with_child_span` finishes the span properly when exceptions occurred, so users don't have to add boilerplate code in every call.
    - @sl0thentr0py I probably should make an isolated PR for this. Wdyt?
3. Use `Sentry.with_child_span` around Rails' controller action so spans generated during actions can be attached to the controller span.
4. Deprecate (not remove) the `ActionControllerSubscriber`. This is because tracing subscribers are public classes and removing them should be considered a breaking change.

Fixes #1899 