### PR TITLE
Add Sentry.add_global_event_processor API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 - Allow [tags](https://docs.sentry.io/platforms/ruby/enriching-events/tags/) to be passed via the context hash when reporting errors using ActiveSupport::ErrorReporter and Sentry::Rails::ErrorSubscriber in `sentry-rails` [#1932](https://github.com/getsentry/sentry-ruby/pull/1932)
 - Pass a `cached: true` tag for SQL query spans that utilized the ActiveRecord QueryCache when using ActiveRecordSubscriber in `sentry-rails` [#1968](https://github.com/getsentry/sentry-ruby/pull/1968)
+- Add `Sentry.add_global_event_processor` API [#1976](https://github.com/getsentry/sentry-ruby/pull/1976)
+
+    Users can now configure global event processors without configuring scope as well.
+
+    ```rb
+    Sentry.add_global_event_processor do |event, hint|
+      event.tags = { foo: 42 }
+      event
+    end
+    ```
+
 
 ### Bug Fixes
 

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -462,6 +462,23 @@ module Sentry
       !!exc.instance_variable_get(CAPTURED_SIGNATURE)
     end
 
+    # Add a global event processor [Proc].
+    # These run before scope event processors.
+    #
+    # @yieldparam event [Event]
+    # @yieldparam hint [Hash, nil]
+    # @return [void]
+    #
+    # @example
+    #   Sentry.add_global_event_processor do |event, hint|
+    #     event.tags = { foo: 42 }
+    #     event
+    #   end
+    #
+    def add_global_event_processor(&block)
+      Scope.add_global_event_processor(&block)
+    end
+
     ##### Helpers #####
 
     # @!visibility private


### PR DESCRIPTION
Other SDKs allow adding global event processors without configuring scope, so this adds the same functionality.

closes #1974 
(need it to implement #1975)
