### PR TITLE
Avoid testing Redis integration with detailed information

### DIFF
--- a/sentry-ruby/spec/sentry/breadcrumb/redis_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/redis_logger_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe :redis_logger do
     let(:result) { redis.info }
 
     it "doesn't cause an error" do
-      expect(result["uptime_in_days"].to_s).to eq("0")
+      expect(result.key?("uptime_in_days")).to eq(true)
       expect(Sentry.get_current_scope.breadcrumbs.peek).to have_attributes(
         category: "db.redis",
         data: { commands: [{ command: "INFO", key: nil }], server: "127.0.0.1:6379/0" }


### PR DESCRIPTION
In this test case we only need to know the info command works and don't care about specific information.

The current expectation breaks when the redis instance is up for more than a day.

#skip-changelog