### PR TITLE
`Span#with_child_span` should finish the span even with exception raised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Skip private _config context in Sidekiq 7+ [#1967](https://github.com/getsentry/sentry-ruby/pull/1967)
   - Fixes [#1956](https://github.com/getsentry/sentry-ruby/issues/1956)
 - Return value from `perform_action` in ActionCable::Channel instances when initialized [#1966](https://github.com/getsentry/sentry-ruby/pull/1966)
+- `Span#with_child_span` should finish the span even with exception raised [#1982](https://github.com/getsentry/sentry-ruby/pull/1982)
 
 ## 5.7.0
 

--- a/sentry-ruby/lib/sentry/span.rb
+++ b/sentry-ruby/lib/sentry/span.rb
@@ -169,6 +169,10 @@ module Sentry
       yield(child_span)
 
       child_span.finish
+    rescue
+      child_span.set_http_status(500)
+      child_span.finish
+      raise
     end
 
     def deep_dup

--- a/sentry-ruby/spec/sentry/span_spec.rb
+++ b/sentry-ruby/spec/sentry/span_spec.rb
@@ -198,6 +198,20 @@ RSpec.describe Sentry::Span do
       expect(new_span.start_timestamp).not_to eq(subject.start_timestamp)
       expect(new_span.timestamp).not_to be(nil)
     end
+
+    it "finishes the span even when exception occurs" do
+      child_span = nil
+
+      expect do
+        subject.with_child_span(op: "sql.query") do |span|
+          child_span = span
+          1/0
+        end
+      end.to raise_error(ZeroDivisionError)
+
+      expect(child_span.timestamp).to be_a(Float)
+      expect(child_span.status).to eq("internal_error")
+    end
   end
 
   describe "#set_status" do


### PR DESCRIPTION
This saves users from doing complicated exception handling logic inside their operation block to save the span data, such as

```rb
span.with_child_span do |child_span|
  begin
    do_something
  rescue
    child_span.finish
    raise
  end
end
```

Now users only need:

```rb
span.with_child_span do |child_span|
  do_something
end
```

I consider this a bug fix because I thought it's already working this way 😅 