### PR TITLE
Add event processor in OpenTelemetry SpanProcessor to link errors and transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
     end
     ```
 
+- Add global event processor in OpenTelemetry `SpanProcessor` to link errors with transactions [#1983](https://github.com/getsentry/sentry-ruby/pull/1983)
+
 
 ### Bug Fixes
 


### PR DESCRIPTION
closes #1975 