### PR TITLE
Fix unknown status code for Rails 6.0.6

### DIFF
--- a/sentry-rails/lib/sentry/rails/tracing/abstract_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/abstract_subscriber.rb
@@ -14,7 +14,7 @@ module Sentry
             end
           end
 
-          if ::Rails.version.to_i == 5
+          if ::Rails.version.to_f < 6.1
             def subscribe_to_event(event_names)
               event_names.each do |event_name|
                 ActiveSupport::Notifications.subscribe(event_name) do |*args|


### PR DESCRIPTION
Thanks for your Pull Request 🎉 

**Please keep these instructions in mind so we can review it more efficiently:**

- Add the references of all the related issues/PRs in the description
- Whether it's a new feature or a bug fix, make sure they're covered by new test cases
- If this PR contains any refactoring work, please give it its own commit(s)
- Finally, please add an entry to the corresponding changelog


**Other Notes**
- We squash all commits before merging
- We generally review new PRs within a week
- If you have any question, you can ask for feedback in our [discord community](https://discord.gg/Ww9hbqr) first

## Description
Describe your changes:

This closes #1984. I tested with other Rails versions and it seems that in version 6.0.6 we should also be using the `ActiveSupport::Notifications.subscribe` the same way as in Rails 5.x, with the `*args` to get the status code in the payload, so I changed the clause that creates the `subscribe_to_event` function to also include versions before 6.1.

