### PR TITLE
Do not capture exception in Rails runner at_exit if the exit code is 0 / success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - `Span#with_child_span` should finish the span even with exception raised [#1982](https://github.com/getsentry/sentry-ruby/pull/1982)
 - Fix sentry-rails' controller span nesting [#1973](https://github.com/getsentry/sentry-ruby/pull/1973)
   - Fixes [#1899](https://github.com/getsentry/sentry-ruby/issues/1899)
+- Do not report exceptions when a Rails runner exits with `exit 0` [#1988](https://github.com/getsentry/sentry-ruby/pull/1988)
 
 ## 5.7.0
 

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -56,7 +56,9 @@ module Sentry
 
       at_exit do
         # TODO: Add a condition for Rails 7.1 to avoid confliction with https://github.com/rails/rails/pull/44999
-        Sentry::Rails.capture_exception($ERROR_INFO, tags: { source: "runner" }) if $ERROR_INFO
+        if $ERROR_INFO && !($ERROR_INFO.is_a?(SystemExit) && $ERROR_INFO.success?)
+          Sentry::Rails.capture_exception($ERROR_INFO, tags: { source: "runner" })
+        end
       end
     end
 

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -104,7 +104,6 @@ RSpec.describe Sentry::Rails, type: :request do
         pipe_in.close
 
         allow(Sentry::Rails).to receive(:capture_exception) do |event|
-          # raise "hello"
           pipe_out.puts event
         end
 


### PR DESCRIPTION

## Description
Do not capture exception in Rails runner at_exit if the exit code is 0 / success.

## Why
Recently a change went in to start capturing a Rails runner exceptions in `at_exit` https://github.com/getsentry/sentry-ruby/pull/1820

Unfortunately this captures a Sentry alert if a Rails script finishes with `exit 0`.  

Our application has existing scripts that exit with `exit 0` and we started seeing Sentry alerts when we upgraded.
