### PR TITLE
Ignore specs for codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,4 @@
 codecov:
   disable_default_path_fixes: true
+ignore:
+  - **/spec


### PR DESCRIPTION
some org-wide codecov changes were made recently, ignore the `spec` folders because it's a lot of noise on every PR

#skip-changelog