### PR TITLE
Deprecate `capture_exception_frame_locals` in favor of `include_local_variables`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@
   - Fixes [#1899](https://github.com/getsentry/sentry-ruby/issues/1899)
 - Do not report exceptions when a Rails runner exits with `exit 0` [#1988](https://github.com/getsentry/sentry-ruby/pull/1988)
 
+### Miscellaneous
+[
+- Deprecate `capture_exception_frame_locals` in favor of `include_local_variables` [#1993](https://github.com/getsentry/sentry-ruby/pull/1993)
+
 ## 5.7.0
 
 ### Features

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -212,7 +212,7 @@ module Sentry
                            nil
                          end
 
-      if config.capture_exception_frame_locals
+      if config.include_local_variables
         exception_locals_tp.enable
       end
 
@@ -234,7 +234,7 @@ module Sentry
         @session_flusher = nil
       end
 
-      if configuration&.capture_exception_frame_locals
+      if configuration&.include_local_variables
         exception_locals_tp.disable
       end
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -97,10 +97,6 @@ module Sentry
     # @return [Array<Symbol>]
     attr_reader :breadcrumbs_logger
 
-    # Whether to capture local variables from the raised exception's frame. Default is false.
-    # @return [Boolean]
-    attr_accessor :capture_exception_frame_locals
-
     # Max number of breadcrumbs a breadcrumb buffer can hold
     # @return [Integer]
     attr_accessor :max_breadcrumbs
@@ -139,6 +135,22 @@ module Sentry
     # @return [Boolean]
     attr_accessor :inspect_exception_causes_for_exclusion
     alias inspect_exception_causes_for_exclusion? inspect_exception_causes_for_exclusion
+
+    # Whether to capture local variables from the raised exception's frame. Default is false.
+    # @return [Boolean]
+    attr_accessor :include_local_variables
+
+    # @deprecated Use {#include_local_variables} instead.
+    alias_method :capture_exception_frame_locals, :include_local_variables
+
+    # @deprecated Use {#include_local_variables=} instead.
+    def capture_exception_frame_locals=(value)
+      log_warn <<~MSG
+        `capture_exception_frame_locals` is now deprecated in favor of `include_local_variables`.
+      MSG
+
+      self.include_local_variables = value
+    end
 
     # You may provide your own LineCache for matching paths with source files.
     # This may be useful if you need to get source code from places other than the disk.
@@ -277,7 +289,7 @@ module Sentry
       self.max_breadcrumbs = BreadcrumbBuffer::DEFAULT_SIZE
       self.breadcrumbs_logger = []
       self.context_lines = 3
-      self.capture_exception_frame_locals = false
+      self.include_local_variables = false
       self.environment = environment_from_env
       self.enabled_environments = []
       self.exclude_loggers = []

--- a/sentry-ruby/lib/sentry/test_helper.rb
+++ b/sentry-ruby/lib/sentry/test_helper.rb
@@ -25,7 +25,7 @@ module Sentry
       copied_config.background_worker_threads = 0
 
       # user can overwrite some of the configs, with a few exceptions like:
-      # - capture_exception_frame_locals
+      # - include_local_variables
       # - auto_session_tracking
       block&.call(copied_config)
 

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -1,6 +1,29 @@
 require 'spec_helper'
 
 RSpec.describe Sentry::Configuration do
+  describe "#capture_exception_frame_locals" do
+    it "passes/received the value to #include_local_variables" do
+      subject.capture_exception_frame_locals = true
+      expect(subject.include_local_variables).to eq(true)
+      expect(subject.capture_exception_frame_locals).to eq(true)
+
+      subject.capture_exception_frame_locals = false
+      expect(subject.include_local_variables).to eq(false)
+      expect(subject.capture_exception_frame_locals).to eq(false)
+    end
+
+    it "prints deprecation message when being assigned" do
+      string_io = StringIO.new
+      subject.logger = Logger.new(string_io)
+
+      subject.capture_exception_frame_locals = true
+
+      expect(string_io.string).to include(
+        "WARN -- sentry: `capture_exception_frame_locals` is now deprecated in favor of `include_local_variables`."
+      )
+    end
+  end
+
   describe "#csp_report_uri" do
     it "returns nil if the dsn is not present" do
       expect(subject.csp_report_uri).to eq(nil)

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -82,10 +82,10 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
       expect(env.key?("sentry.error_event_id")).to eq(false)
     end
 
-    context "with config.capture_exception_frame_locals = true" do
+    context "with config.include_local_variables = true" do
       before do
         perform_basic_setup do |config|
-          config.capture_exception_frame_locals = true
+          config.include_local_variables = true
         end
       end
 

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Sentry do
       expect(result).to eq(nil)
     end
 
-    context "with capture_exception_frame_locals = false (default)" do
+    context "with include_local_variables = false (default)" do
       it "doens't capture local variables" do
         begin
           1/0
@@ -209,10 +209,10 @@ RSpec.describe Sentry do
       end
     end
 
-    context "with capture_exception_frame_locals = true" do
+    context "with include_local_variables = true" do
       before do
         perform_basic_setup do |config|
-          config.capture_exception_frame_locals = true
+          config.include_local_variables = true
         end
       end
 
@@ -273,6 +273,7 @@ RSpec.describe Sentry do
       expect(event).to be_a(Sentry::ErrorEvent)
     end
   end
+
 
   describe ".start_transaction" do
     describe "sampler example" do
@@ -875,7 +876,7 @@ RSpec.describe Sentry do
 
       it "disables Tracepoint" do
         perform_basic_setup do |config|
-          config.capture_exception_frame_locals = true
+          config.include_local_variables = true
         end
 
         expect(described_class.exception_locals_tp).to receive(:disable).and_call_original


### PR DESCRIPTION
Closes #1986 