### PR TITLE
Upgrade yard for Rack 3 compatibility

### DIFF
--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -27,4 +27,5 @@ gem "benchmark_driver"
 gem "benchmark-ipsa"
 gem "benchmark-memory"
 
-gem "yard", "~> 0.9.27"
+gem "yard", github: "lsegal/yard"
+gem "webrick"


### PR DESCRIPTION
Since we have upgraded our default Rack version to 3.0, the yard version we use isn't compatible with it. Therefore, we need to upgrade yard to the unreleased version for its [Rack 3.0 compatibility fix](https://github.com/lsegal/yard/commit/54f177114e182a5231c5821d6b3c2c92bcd9a0f5).

#skip-changelog