### PR TITLE
Add minimum VSCode setup for the project

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "shopify.ruby-lsp",
+        "koichisasada.vscode-rdbg"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "[ruby]": {
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true,
+    // ruby-lsp's formatOnSave uses syntax-tree's rules, which may not be the rules we want
+    "editor.formatOnSave": false,
+  },
+}

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+git_source(:github) { |name| "https://github.com/#{name}.git" }
+
+gem "ruby-lsp", require: false


### PR DESCRIPTION
These settings are mostly for my convenience using VS Code, which should have no impact on non-VS Code developers. However, if you do use VS Code when working on this/other Ruby project, I think the 2 extensions are worth installing 😉 