### PR TITLE
Fix comment on Raven::Configuration#encoding

### DIFF
--- a/sentry-raven/lib/raven/configuration.rb
+++ b/sentry-raven/lib/raven/configuration.rb
@@ -23,7 +23,7 @@ module Raven
     # RACK_ENV by default.
     attr_reader :current_environment
 
-    # Encoding type for event bodies. Must be :json or :gzip.
+    # Encoding type for event bodies. Must be "json" or "gzip".
     attr_reader :encoding
 
     # Whitelist of environments that will send notifications to Sentry. Array of Strings.


### PR DESCRIPTION
The encoding= method accepts a `String`, not a `Symbol`: https://github.com/getsentry/sentry-ruby/blob/master/sentry-raven/lib/raven/configuration.rb#L312