### PR TITLE
Remove unnecessary character in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
   - Fixes [#1992](https://github.com/getsentry/sentry-ruby/issues/1992)
 
 ### Miscellaneous
-[
+
 - Deprecate `capture_exception_frame_locals` in favor of `include_local_variables` [#1993](https://github.com/getsentry/sentry-ruby/pull/1993)
 
 ## 5.7.0


### PR DESCRIPTION
## Description

I just found a strange character in CHANGELOG and just removed it.

<img width="780" alt="image" src="https://user-images.githubusercontent.com/1811616/218719454-02750e8f-0090-4237-8921-8c5305c42a74.png">
