### PR TITLE
Add config.enable_tracing for easier performance tracing setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+### Features
+
+- Add new boolean option `config.enable_tracing` to simplify enabling performance tracing [#2005](https://github.com/getsentry/sentry-ruby/pull/2005)
+  - `config.enable_tracing = true` will set `traces_sample_rate` to `1.0` if not set already
+  - `config.enable_tracing = false` will turn off tracing even if `traces_sample_rate/traces_sampler` is set
+  - `config.enable_tracing = nil` (default) will keep the current behaviour
+
 ## 5.8.0
 
 ### Features

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -78,7 +78,16 @@ RSpec.describe Sentry::Configuration do
           expect(subject.tracing_enabled?).to eq(false)
         end
       end
+
+      context "when enable_tracing is set" do
+        it "returns false" do
+          subject.enable_tracing = true
+
+          expect(subject.tracing_enabled?).to eq(false)
+        end
+      end
     end
+
     context "when sending allowed" do
       before do
         allow(subject).to receive(:sending_allowed?).and_return(true)
@@ -119,6 +128,42 @@ RSpec.describe Sentry::Configuration do
           expect(subject.tracing_enabled?).to eq(true)
         end
       end
+
+      context "when enable_tracing is true" do
+        it "returns true" do
+          subject.enable_tracing = true
+
+          expect(subject.tracing_enabled?).to eq(true)
+        end
+      end
+
+      context "when enable_tracing is false" do
+        it "returns false" do
+          subject.enable_tracing = false
+
+          expect(subject.tracing_enabled?).to eq(false)
+        end
+
+        it "returns false even with explicit traces_sample_rate" do
+          subject.traces_sample_rate = 1.0
+          subject.enable_tracing = false
+
+          expect(subject.tracing_enabled?).to eq(false)
+        end
+      end
+    end
+  end
+
+  describe "#enable_tracing=" do
+    it "sets traces_sample_rate to 1.0 automatically" do
+      subject.enable_tracing = true
+      expect(subject.traces_sample_rate).to eq(1.0)
+    end
+
+    it "doesn't override existing traces_sample_rate" do
+      subject.traces_sample_rate = 0.5
+      subject.enable_tracing = true
+      expect(subject.traces_sample_rate).to eq(0.5)
     end
   end
 


### PR DESCRIPTION
The new optional boolean will set traces_sample_rate to 1.0
automatically if not set yet. If false, this will also disable tracing
even if a sample rate or sampler is set.

closes #1996 