### PR TITLE
Allow ignoring excluded_exceptions when manually capturing exceptions

### DIFF
--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -74,9 +74,14 @@ module Sentry
     # Initializes an Event object with the given exception. Returns `nil` if the exception's class is excluded from reporting.
     # @param exception [Exception] the exception to be reported.
     # @param hint [Hash] the hint data that'll be passed to `before_send` callback and the scope's event processors.
+    # @param ignore_exclusions [Boolean] override checking whether exceptions should be excluded based on configuration.
     # @return [Event, nil]
-    def event_from_exception(exception, hint = {})
-      return unless @configuration.sending_allowed? && @configuration.exception_class_allowed?(exception)
+    def event_from_exception(exception, hint = {}, ignore_exclusions: false)
+      return unless @configuration.sending_allowed?
+
+      if !ignore_exclusions
+        return unless @configuration.exception_class_allowed?(exception)
+      end
 
       integration_meta = Sentry.integrations[hint[:integration]]
 

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -122,7 +122,9 @@ module Sentry
 
       options[:hint] ||= {}
       options[:hint][:exception] = exception
-      event = current_client.event_from_exception(exception, options[:hint])
+      ignore_exclusions = options.delete(:ignore_exclusions) { false }
+
+      event = current_client.event_from_exception(exception, options[:hint], ignore_exclusions: ignore_exclusions)
 
       return unless event
 

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -328,6 +328,54 @@ RSpec.describe Sentry::Client do
             expect(subject.event_from_exception(Sentry::Test::SubExc.new.tap { |x| x.extend(Sentry::Test::ExcTag) })).to be_nil
           end
         end
+
+        context "when exclusions overridden" do
+          context "defined by string type" do
+            it 'returns nil for a class match' do
+              config.excluded_exceptions << 'Sentry::Test::BaseExc'
+              expect(subject.event_from_exception(Sentry::Test::BaseExc.new, ignore_exclusions: true)).to be_a(Sentry::ErrorEvent)
+            end
+  
+            it 'returns nil for a top class match' do
+              config.excluded_exceptions << '::Sentry::Test::BaseExc'
+              expect(subject.event_from_exception(Sentry::Test::BaseExc.new, ignore_exclusions: true)).to be_a(Sentry::ErrorEvent)
+            end
+  
+            it 'returns nil for a sub class match' do
+              config.excluded_exceptions << 'Sentry::Test::BaseExc'
+              expect(subject.event_from_exception(Sentry::Test::SubExc.new, ignore_exclusions: true)).to be_a(Sentry::ErrorEvent)
+            end
+  
+            it 'returns nil for a tagged class match' do
+              config.excluded_exceptions << 'Sentry::Test::ExcTag'
+              expect(
+                subject.event_from_exception(Sentry::Test::SubExc.new, ignore_exclusions: true).tap { |x| x.extend(Sentry::Test::ExcTag) }
+              ).to be_a(Sentry::ErrorEvent)
+            end
+  
+            it 'returns Sentry::ErrorEvent for an undefined exception class' do
+              config.excluded_exceptions << 'Sentry::Test::NonExistentExc'
+              expect(subject.event_from_exception(Sentry::Test::BaseExc.new, ignore_exclusions: true)).to be_a(Sentry::ErrorEvent)
+            end
+          end
+  
+          context "defined by class type" do
+            it 'returns nil for a class match' do
+              config.excluded_exceptions << Sentry::Test::BaseExc
+              expect(subject.event_from_exception(Sentry::Test::BaseExc.new, ignore_exclusions: true)).to be_a(Sentry::ErrorEvent)
+            end
+  
+            it 'returns nil for a sub class match' do
+              config.excluded_exceptions << Sentry::Test::BaseExc
+              expect(subject.event_from_exception(Sentry::Test::SubExc.new, ignore_exclusions: true)).to be_a(Sentry::ErrorEvent)
+            end
+  
+            it 'returns nil for a tagged class match' do
+              config.excluded_exceptions << Sentry::Test::ExcTag
+              expect(subject.event_from_exception(Sentry::Test::SubExc.new, ignore_exclusions: true).tap { |x| x.extend(Sentry::Test::ExcTag) }).to be_a(Sentry::ErrorEvent)
+            end
+          end
+        end
       end
 
       context 'when the exception has a cause' do

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -195,6 +195,11 @@ RSpec.describe Sentry::Hub do
       end.to change { transport.events.count }.by(1)
     end
 
+    it "takes ignore_exclusions option" do
+      event = subject.capture_exception(exception, ignore_exclusions: true)
+      expect(event).to be_a(Sentry::ErrorEvent)
+    end
+
     it_behaves_like "capture_helper" do
       let(:capture_helper) { :capture_exception }
       let(:capture_subject) { exception }


### PR DESCRIPTION
## Description
Addresses #2006 and allows manually bypassing `excluded_exceptions` array from Sentry config.
