### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -20,6 +20,7 @@ jobs:
     name: Ruby ${{ matrix.ruby_version }} & Rails ${{ matrix.rails_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         rails_version: [6.1.0, 7.0.0, 7.1.0]
         ruby_version: [2.7, '3.0', '3.1', '3.2', head]

--- a/sentry-rails/spec/dummy/test_rails_app/configs/7-1.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/7-1.rb
@@ -32,4 +32,5 @@ end
 
 def configure_app(app)
   app.config.active_storage.service = :test
+  app.config.enable_reloading = false
 end

--- a/sentry-resque/spec/spec_helper.rb
+++ b/sentry-resque/spec/spec_helper.rb
@@ -4,6 +4,10 @@ require "debug" if RUBY_VERSION.to_f >= 2.6 && RUBY_ENGINE == "ruby"
 
 require "resque"
 
+# To workaround https://github.com/steveklabnik/mono_logger/issues/13
+# Note: mono_logger is resque's default logger
+Resque.logger = ::Logger.new(nil)
+
 require "sentry-ruby"
 
 require 'simplecov'

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -191,11 +191,16 @@ RSpec.describe Sentry::Client do
       it "sets correct exception message based on Ruby version" do
         version = Gem::Version.new(RUBY_VERSION)
 
-        if version >= Gem::Version.new("3.2.0-dev")
+        case
+        when version >= Gem::Version.new("3.3.0-dev")
+          expect(hash[:exception][:values][0][:value]).to eq(
+            "undefined method `[]' for nil (NoMethodError)\n\n          {}[:foo][:bar]\n                  ^^^^^^"
+          )
+        when version >= Gem::Version.new("3.2")
           expect(hash[:exception][:values][0][:value]).to eq(
             "undefined method `[]' for nil:NilClass (NoMethodError)\n\n          {}[:foo][:bar]\n                  ^^^^^^"
           )
-        elsif version >= Gem::Version.new("3.1") && RUBY_ENGINE == "ruby"
+        when version >= Gem::Version.new("3.1") && RUBY_ENGINE == "ruby"
           expect(hash[:exception][:values][0][:value]).to eq(
             "undefined method `[]' for nil:NilClass\n\n          {}[:foo][:bar]\n                  ^^^^^^"
           )


### PR DESCRIPTION
There are several issues causing the CI to fail:

### Fix sentry-rails' test failures caused by Zeitwerk exception

1. By default, Rails eager loads the app through Zeitwerk and registers
    future eager load calls with the `after_class_unload` hook. This hook
    makes sure the app would be eagerly reloaded after the app is unloaded.
    ([code](https://github.com/rails/rails/blob/64962266e38817e025de53234accc1e54ed2b32e/railties/lib/rails/application/finisher.rb#L77-L81))

2. Since version 2.6.5, Zeitwerk raises an error when the app is being
    eager loaded without a proper setup.
3. Our test app is not properly setup for being reloaded. So when the app
    is unloaded, it's not ready for the next eager load call, which means
    it'd trigger the error mentioned in 2.

So this PR simply marks the app as not reloadable, which means it doesn't register the callback mentioned in 1 and avoids the later errors.

### Fix sentry-resque's test failure caused by `mono_logger`

It's caused by `mono_logger` (a resque dependency)'s conflict with Ruby 3.3's `Logger`. I've opened an [issue](https://github.com/steveklabnik/mono_logger/issues/13) and worked around it by changing Resque's logger in our tests.

### Fix sentry-ruby's test failure caused by error message change

#skip-changelog