### PR TITLE
Validate contexts when setting multiple contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,9 @@
 - Do not report exceptions when a Rails runner exits with `exit 0` [#1988](https://github.com/getsentry/sentry-ruby/pull/1988)
 - Ignore redis key if not UTF8 [#1997](https://github.com/getsentry/sentry-ruby/pull/1997)
   - Fixes [#1992](https://github.com/getsentry/sentry-ruby/issues/1992)
-
+- Validate that contexts set in set_contexts method are a Hash instances [#2022](https://github.com/getsentry/sentry-ruby/pull/2022/files)
+  - Fixes [#2021](https://github.com/getsentry/sentry-ruby/issues/2021)
+  
 ### Miscellaneous
 
 - Deprecate `capture_exception_frame_locals` in favor of `include_local_variables` [#1993](https://github.com/getsentry/sentry-ruby/pull/1993)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 - Do not report exceptions when a Rails runner exits with `exit 0` [#1988](https://github.com/getsentry/sentry-ruby/pull/1988)
 - Ignore redis key if not UTF8 [#1997](https://github.com/getsentry/sentry-ruby/pull/1997)
   - Fixes [#1992](https://github.com/getsentry/sentry-ruby/issues/1992)
-- Validate that contexts set in set_contexts method are a Hash instances [#2022](https://github.com/getsentry/sentry-ruby/pull/2022/files)
+- Validate that contexts set in `set_contexts` are also Hash instances [#2022](https://github.com/getsentry/sentry-ruby/pull/2022/files)
   - Fixes [#2021](https://github.com/getsentry/sentry-ruby/issues/2021)
   
 ### Miscellaneous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 - Do not report exceptions when a Rails runner exits with `exit 0` [#1988](https://github.com/getsentry/sentry-ruby/pull/1988)
 - Ignore redis key if not UTF8 [#1997](https://github.com/getsentry/sentry-ruby/pull/1997)
   - Fixes [#1992](https://github.com/getsentry/sentry-ruby/issues/1992)
-  
+
 ### Miscellaneous
 
 - Deprecate `capture_exception_frame_locals` in favor of `include_local_variables` [#1993](https://github.com/getsentry/sentry-ruby/pull/1993)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   - `config.enable_tracing = false` will turn off tracing even if `traces_sample_rate/traces_sampler` is set
   - `config.enable_tracing = nil` (default) will keep the current behaviour
 
+### Bug Fixes
+
+- Validate that contexts set in `set_contexts` are also Hash instances [#2022](https://github.com/getsentry/sentry-ruby/pull/2022/files)
+  - Fixes [#2021](https://github.com/getsentry/sentry-ruby/issues/2021)
+
 ## 5.8.0
 
 ### Features
@@ -63,8 +68,6 @@
 - Do not report exceptions when a Rails runner exits with `exit 0` [#1988](https://github.com/getsentry/sentry-ruby/pull/1988)
 - Ignore redis key if not UTF8 [#1997](https://github.com/getsentry/sentry-ruby/pull/1997)
   - Fixes [#1992](https://github.com/getsentry/sentry-ruby/issues/1992)
-- Validate that contexts set in `set_contexts` are also Hash instances [#2022](https://github.com/getsentry/sentry-ruby/pull/2022/files)
-  - Fixes [#2021](https://github.com/getsentry/sentry-ruby/issues/2021)
   
 ### Miscellaneous
 

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -192,6 +192,10 @@ module Sentry
     # @return [Hash]
     def set_contexts(contexts_hash)
       check_argument_type!(contexts_hash, Hash)
+      contexts_hash.values.each do |val|
+        check_argument_type!(val, Hash)
+      end
+
       @contexts.merge!(contexts_hash) do |key, old, new|
         old.merge(new)
       end

--- a/sentry-ruby/spec/sentry/scope/setters_spec.rb
+++ b/sentry-ruby/spec/sentry/scope/setters_spec.rb
@@ -106,6 +106,12 @@ RSpec.describe Sentry::Scope do
       end.to raise_error(ArgumentError)
     end
 
+    it "raises error when passed non-hash context value" do
+      expect do
+        subject.set_contexts({ character: "John" })
+      end.to raise_error(ArgumentError)
+    end
+
     it "merges the context hash" do
       subject.set_contexts({ character: { name: "John" }})
       expect(subject.contexts).to include({ character: { name: "John" }})


### PR DESCRIPTION
## Description
Adds validation for contexts set by `set_contexts` method
Fixes https://github.com/getsentry/sentry-ruby/issues/2021

