### PR TITLE
Support capturing low-level errors propagated to Puma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   Sentry.capture_exception(ignored_exception) # won't be sent to Sentry
   Sentry.capture_exception(ignored_exception, hint: { ignore_exclusions: true }) # will be sent to Sentry
   ```
+- Support capturing low-level errors propagated to Puma [#2026](https://github.com/getsentry/sentry-ruby/pull/2026)
 
 - Add `spec` to `Backtrace::APP_DIRS_PATTERN` [#2029](https://github.com/getsentry/sentry-ruby/pull/2029)
 - Forward all `baggage` header items that are prefixed with `sentry-` [#2025](https://github.com/getsentry/sentry-ruby/pull/2025)

--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -10,6 +10,8 @@ gem "rack", "~> #{Gem::Version.new(rack_version)}" unless rack_version == "0"
 redis_rb_version = ENV.fetch("REDIS_RB_VERSION", "5.0")
 gem "redis", "~> #{redis_rb_version}"
 
+gem "puma"
+
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
 gem "rspec-retry"

--- a/sentry-ruby/Rakefile
+++ b/sentry-ruby/Rakefile
@@ -8,6 +8,13 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec).tap do |task|
   task.rspec_opts = "--order rand"
+  task.exclude_pattern = "spec/isolated/**/*_spec.rb"
 end
 
-task :default => :spec
+task :isolated_specs do
+  Dir["spec/isolated/*"].each do |file|
+    sh "bundle exec rspec #{file}"
+  end
+end
+
+task :default => [:spec, :isolated_specs]

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -519,3 +519,4 @@ end
 # patches
 require "sentry/net/http"
 require "sentry/redis"
+require "sentry/puma"

--- a/sentry-ruby/lib/sentry/puma.rb
+++ b/sentry-ruby/lib/sentry/puma.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Sentry
+  module Puma
+    module Server
+      def lowlevel_error(e, env, status=500)
+        result = super
+
+        begin
+          Sentry.capture_exception(e) do |scope|
+            scope.set_rack_env(env)
+          end
+        rescue
+          # if anything happens, we don't want to break the app
+        end
+
+        result
+      end
+    end
+  end
+end
+
+if defined?(Puma::Server)
+  Sentry.register_patch(Sentry::Puma::Server, Puma::Server)
+end

--- a/sentry-ruby/spec/isolated/puma_spec.rb
+++ b/sentry-ruby/spec/isolated/puma_spec.rb
@@ -1,0 +1,91 @@
+require "puma"
+require_relative "../spec_helper"
+
+# Because puma doesn't have any dependency, if Rack is not installed the entire test won't work
+return if ENV["RACK_VERSION"] == "0"
+
+RSpec.describe Puma::Server do
+  class TestServer
+    def initialize(app, options)
+      @host = "127.0.0.1"
+      @ios = []
+      @server = Puma::Server.new(app, nil, options)
+      @port = (@server.add_tcp_listener @host, 0).addr[1]
+      @server.run
+    end
+
+    def send_http_and_read(req)
+      (new_connection << req).read
+    end
+
+    def new_connection
+      TCPSocket.new(@host, @port).tap {|sock| @ios << sock}
+    end
+
+    def close
+      @ios.each { |io| io.close }
+    end
+  end
+
+  let(:app) do
+    proc { raise "foo" }
+  end
+
+  def server_run(app, lowlevel_error_handler: nil, &block)
+    server = TestServer.new(app, lowlevel_error_handler: lowlevel_error_handler)
+    yield server
+  ensure
+    server.close
+  end
+
+  before do
+    perform_basic_setup
+  end
+
+  it "captures low-level errors" do
+    res = server_run(app) do |server|
+      server.send_http_and_read("GET / HTTP/1.0\r\n\r\n")
+    end
+    expect(res).to match(/500 Internal Server Error/)
+    events = sentry_events
+    expect(events.count).to eq(1)
+    event = events.first
+    expect(event.exception.values.first.value).to match("foo")
+  end
+
+  context "when user defines lowlevel_error_handler" do
+    it "captures low-level errors" do
+      handler_executed = false
+
+      lowlevel_error_handler = ->(e, env) do
+        handler_executed = true
+        # Due to the way we test Puma::Server, we won't be verify this response
+        [500, {}, ["Error is handled"]]
+      end
+
+      res = server_run(app, lowlevel_error_handler: lowlevel_error_handler) do |server|
+        server.send_http_and_read("GET / HTTP/1.0\r\n\r\n")
+      end
+
+      expect(res).to match(/500 Internal Server Error/)
+      expect(handler_executed).to eq(true)
+      events = sentry_events
+      expect(events.count).to eq(1)
+      event = events.first
+      expect(event.exception.values.first.value).to match("foo")
+    end
+  end
+
+  context "when Sentry.capture_exception causes error" do
+    it "doesn't affect the response" do
+      expect(Sentry).to receive(:capture_exception).and_raise("bar")
+
+      res = server_run(app) do |server|
+        server.send_http_and_read("GET / HTTP/1.0\r\n\r\n")
+      end
+
+      expect(res).to match(/500 Internal Server Error/)
+      expect(sentry_events).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
This PR implements Puma's error reporting by patching `Puma::Server#lowlevel_error`.

I thought about using the `lowlevel_error_handler` API to add a Sentry error handler, but it's not possible to do that after `puma.rb` is loaded (which is extremely early in a normal app setup, way before the SDK is loaded). There is also no good ways to fetch and update the server's `lowlevel_error_handler` option. So the only option left is to patch the method.

Notes:

- The `lowlevel_error` patch is compatible with [Puma 3.0+](https://github.com/puma/puma/blob/v3.0.0/lib/puma/server.rb#L808) (current latest is 6.1). So it's pretty stable and I'm not sure if it'd be worth introducing another test matrix for Puma versions.
- I think for patches like this it's better to NOT require the related library in `spec_helper` as the nonappearance of the library should also be tested. This is why I added the spec under `isolated` folder.
    - I plan to apply this test pattern to the redis patch in another PR.
- ~~I also want to improve the `Sentry.register_patch` API as we now have 3 patches using it and I've spotted some common boilerplate code.~~

Closes #1511 

