### PR TITLE
Allow Sentry.register_patch to take patch and target directly

### DIFF
--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -73,8 +73,18 @@ module Sentry
     ##### Patch Registration #####
 
     # @!visibility private
-    def register_patch(&block)
-      registered_patches << block
+    def register_patch(patch = nil, target = nil, &block)
+      if patch && block
+        raise ArgumentError.new("Please provide either a patch and its target OR a block, but not both")
+      end
+
+      if block
+        registered_patches << block
+      else
+        registered_patches << proc do
+          target.send(:prepend, patch) unless target.ancestors.include?(patch)
+        end
+      end
     end
 
     # @!visibility private

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -97,7 +97,4 @@ module Sentry
   end
 end
 
-Sentry.register_patch do
-  patch = Sentry::Net::HTTP
-  Net::HTTP.send(:prepend, patch) unless Net::HTTP.ancestors.include?(patch)
-end
+Sentry.register_patch(Sentry::Net::HTTP, Net::HTTP)

--- a/sentry-ruby/lib/sentry/redis.rb
+++ b/sentry-ruby/lib/sentry/redis.rb
@@ -95,12 +95,7 @@ end
 
 if defined?(::Redis::Client)
   if Gem::Version.new(::Redis::VERSION) < Gem::Version.new("5.0")
-    Sentry.register_patch do
-      patch = Sentry::Redis::OldClientPatch
-      unless Redis::Client.ancestors.include?(patch)
-        Redis::Client.prepend(patch)
-      end
-    end
+    Sentry.register_patch(Sentry::Redis::OldClientPatch, ::Redis::Client)
   elsif defined?(RedisClient)
     RedisClient.register(Sentry::Redis::GlobalRedisInstrumentation)
   end


### PR DESCRIPTION
This will reduce the boilerplate code we need when registering new patches.

And even though we're not using the block form anymore, I don't see an immediate need to drop it. I'm also aware that some gems are using this API ([example](https://github.com/HoneyryderChuck/httpx/blob/5532d8eb7365b0ec54306e976b8ceaa5b4d09ef8/lib/httpx/adapters/sentry.rb#L111-L116)). But since it's private as indicated by a comment, I'm not adding this to changelog.

#skip-changelog

I'll apply this to https://github.com/getsentry/sentry-ruby/pull/2026 if this is merged first and vice versa.

