### PR TITLE
Improve ActiveSupport breadcrumb logger's data filtering

### DIFF
--- a/sentry-rails/lib/sentry/rails/instrument_payload_cleanup_helper.rb
+++ b/sentry-rails/lib/sentry/rails/instrument_payload_cleanup_helper.rb
@@ -1,11 +1,12 @@
 module Sentry
   module Rails
     module InstrumentPayloadCleanupHelper
-      IGNORED_DATA_TYPES = [:connection, :binds, :request, :response, :headers, :exception, :exception_object, Tracing::START_TIMESTAMP_NAME]
+      IGNORED_KEYS = [:connection, :binds, :request, :response, :headers, :exception, :exception_object, Tracing::START_TIMESTAMP_NAME]
+      ACCEPTABLE_DATA_TYPES = [String, Symbol, Numeric, TrueClass, FalseClass, NilClass, Array, Hash]
 
       def cleanup_data(data)
-        IGNORED_DATA_TYPES.each do |key|
-          data.delete(key) if data.key?(key)
+        data.delete_if do |key, value|
+          IGNORED_KEYS.include?(key) || ACCEPTABLE_DATA_TYPES.none? { |type| value.is_a?(type) }
         end
       end
     end

--- a/sentry-rails/lib/sentry/rails/instrument_payload_cleanup_helper.rb
+++ b/sentry-rails/lib/sentry/rails/instrument_payload_cleanup_helper.rb
@@ -1,7 +1,7 @@
 module Sentry
   module Rails
     module InstrumentPayloadCleanupHelper
-      IGNORED_DATA_TYPES = [:request, :response, :headers, :exception, :exception_object, Tracing::START_TIMESTAMP_NAME]
+      IGNORED_DATA_TYPES = [:connection, :binds, :request, :response, :headers, :exception, :exception_object, Tracing::START_TIMESTAMP_NAME]
 
       def cleanup_data(data)
         IGNORED_DATA_TYPES.each do |key|

--- a/sentry-rails/spec/sentry/rails/breadcrumbs/active_support_logger_spec.rb
+++ b/sentry-rails/spec/sentry/rails/breadcrumbs/active_support_logger_spec.rb
@@ -117,6 +117,17 @@ RSpec.describe "Sentry::Breadcrumbs::ActiveSupportLogger", type: :request do
       expect(breadcrumb["data"].keys).not_to include("binds")
     end
 
+    it "doesn't capture non-primitive objects" do
+      ActiveSupport::Notifications.instrument "my.custom.event", foo: Object.new, bar: 123
+
+      breadcrumbs = Sentry.get_current_scope.breadcrumbs
+
+      expect(breadcrumbs.count).to eq(1)
+
+      breadcrumb = breadcrumbs.first
+      expect(breadcrumb.data).to eq({ bar: 123 })
+    end
+
     it "doesn't add internal start timestamp payload to breadcrumbs data" do
       p = Post.create!
 


### PR DESCRIPTION
1. Exclude `sql.active_record` payload's `connection` and `binds` because they could cause problems when being serialised.
2. Exclude non-primitive type objects because at this stage they're likely added by the user or other libraries, which could also be problematic to serialise.

I know 2) also excludes most data declared in `IGNORED_KEYS`, but I think it's still worth keeping that list to make it explicit on what we try to exclude.