### PR TITLE
handle sample rate type incompatibilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Move `http.query` to span data in net/http integration [#2039](https://github.com/getsentry/sentry-ruby/pull/2039)
 - Validate `release` is a `String` during configuration [#2040](https://github.com/getsentry/sentry-ruby/pull/2040)
 - Allow JRuby Java exceptions to be captured [#2043](https://github.com/getsentry/sentry-ruby/pull/2043)
+- Improved error handling around `traces_sample_rate`/`profiles_sample_rate` [#2036](https://github.com/getsentry/sentry-ruby/pull/2036)
 
 ### Bug Fixes
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -216,8 +216,8 @@ module Sentry
     attr_reader :transport
 
     # Take a float between 0.0 and 1.0 as the sample rate for tracing events (transactions).
-    # @return [Float]
-    attr_accessor :traces_sample_rate
+    # @return [Float, nil]
+    attr_reader :traces_sample_rate
 
     # Take a Proc that controls the sample rate for every tracing event, e.g.
     # @example
@@ -327,7 +327,6 @@ module Sentry
       self.before_send = nil
       self.before_send_transaction = nil
       self.rack_env_whitelist = RACK_ENV_WHITELIST_DEFAULT
-      self.traces_sample_rate = nil
       self.traces_sampler = nil
       self.enable_tracing = nil
 
@@ -409,9 +408,13 @@ module Sentry
       @traces_sample_rate ||= 1.0 if enable_tracing
     end
 
+    def traces_sample_rate=(traces_sample_rate)
+      @traces_sample_rate = traces_sample_rate&.to_f
+    end
+
     def profiles_sample_rate=(profiles_sample_rate)
       log_info("Please make sure to include the 'stackprof' gem in your Gemfile to use Profiling with Sentry.") unless defined?(StackProf)
-      @profiles_sample_rate = profiles_sample_rate
+      @profiles_sample_rate = profiles_sample_rate&.to_f
     end
 
     def sending_allowed?

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -446,19 +446,22 @@ module Sentry
       enabled_environments.empty? || enabled_environments.include?(environment)
     end
 
+    def valid_sample_rate?(sample_rate)
+      sample_rate &&
+      sample_rate.respond_to?(:>=) &&
+      sample_rate >= 0.0 &&
+      sample_rate.respond_to?(:<=) &&
+      sample_rate <= 1.0
+    end
+
     def tracing_enabled?
-      valid_sampler = !!((@traces_sample_rate &&
-                          @traces_sample_rate >= 0.0 &&
-                          @traces_sample_rate <= 1.0) ||
-                         @traces_sampler)
+      valid_sampler = !!((valid_sample_rate?(@traces_sample_rate)) || @traces_sampler)
 
       (@enable_tracing != false) && valid_sampler && sending_allowed?
     end
 
     def profiling_enabled?
-      valid_sampler = !!(@profiles_sample_rate &&
-                         @profiles_sample_rate >= 0.0 &&
-                         @profiles_sample_rate <= 1.0)
+      valid_sampler = !!(valid_sample_rate?(@profiles_sample_rate))
 
       tracing_enabled? && valid_sampler && sending_allowed?
     end

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -447,11 +447,8 @@ module Sentry
     end
 
     def valid_sample_rate?(sample_rate)
-      sample_rate &&
-      sample_rate.respond_to?(:>=) &&
-      sample_rate >= 0.0 &&
-      sample_rate.respond_to?(:<=) &&
-      sample_rate <= 1.0
+      return false unless sample_rate.is_a?(Numeric)
+      sample_rate >= 0.0 && sample_rate <= 1.0
     end
 
     def tracing_enabled?

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -408,13 +408,19 @@ module Sentry
       @traces_sample_rate ||= 1.0 if enable_tracing
     end
 
+    def is_numeric_or_nil?(value)
+      value.is_a?(Numeric) || value.nil?
+    end
+
     def traces_sample_rate=(traces_sample_rate)
-      @traces_sample_rate = traces_sample_rate&.to_f
+      raise ArgumentError, "traces_sample_rate must be a Numeric or nil" unless is_numeric_or_nil?(traces_sample_rate)
+      @traces_sample_rate = traces_sample_rate
     end
 
     def profiles_sample_rate=(profiles_sample_rate)
+      raise ArgumentError, "profiles_sample_rate must be a Numeric or nil" unless is_numeric_or_nil?(profiles_sample_rate)
       log_info("Please make sure to include the 'stackprof' gem in your Gemfile to use Profiling with Sentry.") unless defined?(StackProf)
-      @profiles_sample_rate = profiles_sample_rate&.to_f
+      @profiles_sample_rate = profiles_sample_rate
     end
 
     def sending_allowed?

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -63,22 +63,15 @@ RSpec.describe Sentry::Configuration do
           expect(subject.traces_sample_rate).to eq(nil)
         end
 
-      it "returns 0.0 when passed a non-numeric String" do
-        subject.traces_sample_rate = "foobar"
-        expect(subject.traces_sample_rate).to eq(0.0)
-      end
-
-      it "returns 0.5 when passed a numeric String" do
-        subject.traces_sample_rate = "0.5"
-        expect(subject.traces_sample_rate).to eq(0.5)
+      it "is non-Numeric and results in an ArgumentError" do
+        expect { subject.traces_sample_rate = "foobar" }.to raise_error(ArgumentError)
       end
     end
 
     context "when enable_tracing is true" do
-      it "returns 0.0 when given a non-numeric String" do
+      it "is non-Numeric and results in an ArgumentError" do
         subject.enable_tracing = true
-        subject.traces_sample_rate = "foobar"
-        expect(subject.traces_sample_rate).to eq(0.0)
+        expect { subject.traces_sample_rate = "foobar" }.to raise_error(ArgumentError)
       end
     end
   end
@@ -147,13 +140,6 @@ RSpec.describe Sentry::Configuration do
         end
       end
 
-      context "when traces_sample_rate is a String" do
-        it "returns true without any exceptions" do
-          expect { subject.traces_sample_rate = "0.1" }.not_to raise_error(ArgumentError)
-          expect(subject.tracing_enabled?).to eq(true)
-        end
-      end
-
       context "when traces_sampler is set" do
         it "returns true" do
           subject.traces_sampler = proc { true }
@@ -192,14 +178,8 @@ RSpec.describe Sentry::Configuration do
       expect(subject.profiles_sample_rate).to eq(nil)
     end
 
-    it "returns 0.0 when given as non-numeric String" do
-      subject.profiles_sample_rate = "foobar"
-      expect(subject.profiles_sample_rate).to eq(0.0)
-    end
-
-    it "returns 0.5 when given a numeric String" do
-      subject.profiles_sample_rate = "0.5"
-      expect(subject.profiles_sample_rate).to eq(0.5)
+    it "is non-Numeric and results in an ArgumentError" do
+      expect { subject.profiles_sample_rate = "foobar" }.to raise_error(ArgumentError)
     end
   end
 

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -57,6 +57,32 @@ RSpec.describe Sentry::Configuration do
     end
   end
 
+  describe "#traces_sample_rate" do
+    context "when enable_tracing is unset" do
+      it "returns nil by default" do
+          expect(subject.traces_sample_rate).to eq(nil)
+        end
+
+      it "returns 0.0 when passed a non-numeric String" do
+        subject.traces_sample_rate = "foobar"
+        expect(subject.traces_sample_rate).to eq(0.0)
+      end
+
+      it "returns 0.5 when passed a numeric String" do
+        subject.traces_sample_rate = "0.5"
+        expect(subject.traces_sample_rate).to eq(0.5)
+      end
+    end
+
+    context "when enable_tracing is true" do
+      it "returns 0.0 when given a non-numeric String" do
+        subject.enable_tracing = true
+        subject.traces_sample_rate = "foobar"
+        expect(subject.traces_sample_rate).to eq(0.0)
+      end
+    end
+  end
+
   describe "#tracing_enabled?" do
     context "when sending not allowed" do
       before do
@@ -121,6 +147,13 @@ RSpec.describe Sentry::Configuration do
         end
       end
 
+      context "when traces_sample_rate is a String" do
+        it "returns true without any exceptions" do
+          expect { subject.traces_sample_rate = "0.1" }.not_to raise_error(ArgumentError)
+          expect(subject.tracing_enabled?).to eq(true)
+        end
+      end
+
       context "when traces_sampler is set" do
         it "returns true" do
           subject.traces_sampler = proc { true }
@@ -151,6 +184,22 @@ RSpec.describe Sentry::Configuration do
           expect(subject.tracing_enabled?).to eq(false)
         end
       end
+    end
+  end
+
+  describe "#profiles_sample_rate" do
+    it "returns nil by default" do
+      expect(subject.profiles_sample_rate).to eq(nil)
+    end
+
+    it "returns 0.0 when given as non-numeric String" do
+      subject.profiles_sample_rate = "foobar"
+      expect(subject.profiles_sample_rate).to eq(0.0)
+    end
+
+    it "returns 0.5 when given a numeric String" do
+      subject.profiles_sample_rate = "0.5"
+      expect(subject.profiles_sample_rate).to eq(0.5)
     end
   end
 

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -58,21 +58,25 @@ RSpec.describe Sentry::Configuration do
   end
 
   describe "#traces_sample_rate" do
-    context "when enable_tracing is unset" do
-      it "returns nil by default" do
-          expect(subject.traces_sample_rate).to eq(nil)
-        end
-
-      it "is non-Numeric and results in an ArgumentError" do
-        expect { subject.traces_sample_rate = "foobar" }.to raise_error(ArgumentError)
-      end
+    it "returns nil by default" do
+      expect(subject.traces_sample_rate).to eq(nil)
     end
 
-    context "when enable_tracing is true" do
-      it "is non-Numeric and results in an ArgumentError" do
-        subject.enable_tracing = true
-        expect { subject.traces_sample_rate = "foobar" }.to raise_error(ArgumentError)
-      end
+    it "accepts Numeric values" do
+      subject.traces_sample_rate = 1
+      expect(subject.traces_sample_rate).to eq(1)
+      subject.traces_sample_rate = 1.0
+      expect(subject.traces_sample_rate).to eq(1.0)
+    end
+
+    it "accepts nil value" do
+      subject.traces_sample_rate = 1
+      subject.traces_sample_rate = nil
+      expect(subject.traces_sample_rate).to eq(nil)
+    end
+
+    it "raises ArgumentError when the value is not Numeric nor nil" do
+      expect { subject.traces_sample_rate = "foobar" }.to raise_error(ArgumentError)
     end
   end
 

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -182,7 +182,20 @@ RSpec.describe Sentry::Configuration do
       expect(subject.profiles_sample_rate).to eq(nil)
     end
 
-    it "is non-Numeric and results in an ArgumentError" do
+    it "accepts Numeric values" do
+      subject.profiles_sample_rate = 1
+      expect(subject.profiles_sample_rate).to eq(1)
+      subject.profiles_sample_rate = 1.0
+      expect(subject.profiles_sample_rate).to eq(1.0)
+    end
+
+    it "accepts nil value" do
+      subject.profiles_sample_rate = 1
+      subject.profiles_sample_rate = nil
+      expect(subject.profiles_sample_rate).to eq(nil)
+    end
+
+    it "raises ArgumentError when the value is not Numeric nor nil" do
       expect { subject.profiles_sample_rate = "foobar" }.to raise_error(ArgumentError)
     end
   end


### PR DESCRIPTION
## Description

The suggested workaround in https://github.com/getsentry/sentry-ruby/issues/2035 results in an `ArgumentError`, since we aren't casting to `Float`. This PR will allow us to fail earlier and with a more specific error message.