### PR TITLE
Stop Puma::Server after each puma test

### DIFF
--- a/sentry-ruby/spec/isolated/puma_spec.rb
+++ b/sentry-ruby/spec/isolated/puma_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Puma::Server do
     end
 
     def close
+      @server.stop(true)
       @ios.each { |io| io.close }
     end
   end


### PR DESCRIPTION
Otherwise the Puma server threads would linger around and cause problems, especially in JRuby.

#skip-changelog