### PR TITLE
Move http query to span data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Features
+
+- Move `http.query` to span data in net/http integration [#2039](https://github.com/getsentry/sentry-ruby/pull/2039)
+
 ## 5.9.0
 
 ### Features

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -38,7 +38,10 @@ module Sentry
             if sentry_span
               request_info = extract_request_info(req)
               sentry_span.set_description("#{request_info[:method]} #{request_info[:url]}")
-              sentry_span.set_data(:status, res.code.to_i)
+              sentry_span.set_data('url', request_info[:url])
+              sentry_span.set_data('http.method', request_info[:method])
+              sentry_span.set_data('http.query', request_info[:query]) if request_info[:query]
+              sentry_span.set_data('status', res.code.to_i)
             end
           end
         end
@@ -87,7 +90,7 @@ module Sentry
         result = { method: req.method, url: url }
 
         if Sentry.configuration.send_default_pii
-          result[:url] = result[:url] + "?#{uri.query}"
+          result[:query] = uri.query
           result[:body] = req.body
         end
 

--- a/sentry-ruby/spec/sentry/breadcrumb/http_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/http_logger_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe :http_logger do
       expect(response.code).to eq("200")
       crumb = Sentry.get_current_scope.breadcrumbs.peek
       expect(crumb.category).to eq("net.http")
-      expect(crumb.data).to eq({ status: 200, method: "GET", url: "http://example.com/path?foo=bar", body: nil })
+      expect(crumb.data).to eq({ status: 200, method: "GET", url: "http://example.com/path", query: "foo=bar", body: nil })
 
       http = Net::HTTP.new("example.com")
       request = Net::HTTP::Get.new("/path?foo=bar")
@@ -41,7 +41,7 @@ RSpec.describe :http_logger do
       expect(response.code).to eq("200")
       crumb = Sentry.get_current_scope.breadcrumbs.peek
       expect(crumb.category).to eq("net.http")
-      expect(crumb.data).to eq({ status: 200, method: "GET", url: "http://example.com/path?foo=bar", body: nil })
+      expect(crumb.data).to eq({ status: 200, method: "GET", url: "http://example.com/path", query: "foo=bar", body: nil })
 
       request = Net::HTTP::Post.new("/path?foo=bar")
       request.body = 'quz=qux'
@@ -51,7 +51,7 @@ RSpec.describe :http_logger do
       crumb = Sentry.get_current_scope.breadcrumbs.peek
       expect(crumb.category).to eq("net.http")
       expect(crumb.data).to eq(
-        { status: 200, method: "POST", url: "http://example.com/path?foo=bar", body: 'quz=qux' }
+        { status: 200, method: "POST", url: "http://example.com/path", query: "foo=bar", body: 'quz=qux' }
       )
     end
   end

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -25,33 +25,7 @@ RSpec.describe Sentry::Net::HTTP do
         Sentry.configuration.send_default_pii = true
       end
 
-      it "records the request's span with query string" do
-        stub_normal_response
-
-        transaction = Sentry.start_transaction
-        Sentry.get_current_scope.set_span(transaction)
-
-        response = Net::HTTP.get_response(URI("http://example.com/path?foo=bar"))
-
-        expect(response.code).to eq("200")
-        expect(transaction.span_recorder.spans.count).to eq(2)
-
-        request_span = transaction.span_recorder.spans.last
-        expect(request_span.op).to eq("http.client")
-        expect(request_span.start_timestamp).not_to be_nil
-        expect(request_span.timestamp).not_to be_nil
-        expect(request_span.start_timestamp).not_to eq(request_span.timestamp)
-        expect(request_span.description).to eq("GET http://example.com/path?foo=bar")
-        expect(request_span.data).to eq({ status: 200 })
-      end
-    end
-
-    context "with config.send_default_pii = true" do
-      before do
-        Sentry.configuration.send_default_pii = false
-      end
-
-      it "records the request's span with query string" do
+      it "records the request's span with query string in data" do
         stub_normal_response
 
         transaction = Sentry.start_transaction
@@ -68,7 +42,42 @@ RSpec.describe Sentry::Net::HTTP do
         expect(request_span.timestamp).not_to be_nil
         expect(request_span.start_timestamp).not_to eq(request_span.timestamp)
         expect(request_span.description).to eq("GET http://example.com/path")
-        expect(request_span.data).to eq({ status: 200 })
+        expect(request_span.data).to eq({
+          "status" => 200,
+          "url" => "http://example.com/path",
+          "http.method" => "GET",
+          "http.query" => "foo=bar"
+        })
+      end
+    end
+
+    context "with config.send_default_pii = false" do
+      before do
+        Sentry.configuration.send_default_pii = false
+      end
+
+      it "records the request's span without query string" do
+        stub_normal_response
+
+        transaction = Sentry.start_transaction
+        Sentry.get_current_scope.set_span(transaction)
+
+        response = Net::HTTP.get_response(URI("http://example.com/path?foo=bar"))
+
+        expect(response.code).to eq("200")
+        expect(transaction.span_recorder.spans.count).to eq(2)
+
+        request_span = transaction.span_recorder.spans.last
+        expect(request_span.op).to eq("http.client")
+        expect(request_span.start_timestamp).not_to be_nil
+        expect(request_span.timestamp).not_to be_nil
+        expect(request_span.start_timestamp).not_to eq(request_span.timestamp)
+        expect(request_span.description).to eq("GET http://example.com/path")
+        expect(request_span.data).to eq({
+          "status" => 200,
+          "url" => "http://example.com/path",
+          "http.method" => "GET",
+        })
       end
     end
 
@@ -237,7 +246,11 @@ RSpec.describe Sentry::Net::HTTP do
         expect(request_span.timestamp).not_to be_nil
         expect(request_span.start_timestamp).not_to eq(request_span.timestamp)
         expect(request_span.description).to eq("GET http://example.com/path")
-        expect(request_span.data).to eq({ status: 200 })
+        expect(request_span.data).to eq({
+          "status" => 200,
+          "url" => "http://example.com/path",
+          "http.method" => "GET",
+        })
 
         request_span = transaction.span_recorder.spans[2]
         expect(request_span.op).to eq("http.client")
@@ -245,7 +258,11 @@ RSpec.describe Sentry::Net::HTTP do
         expect(request_span.timestamp).not_to be_nil
         expect(request_span.start_timestamp).not_to eq(request_span.timestamp)
         expect(request_span.description).to eq("GET http://example.com/path")
-        expect(request_span.data).to eq({ status: 404 })
+        expect(request_span.data).to eq({
+          "status" => 404,
+          "url" => "http://example.com/path",
+          "http.method" => "GET",
+        })
       end
 
       it "doesn't mess different requests' data together" do


### PR DESCRIPTION
Align with the [query/fragment http spec](https://develop.sentry.dev/sdk/data-handling/#spans).

Notes:
* username/password in the url is not an issue since we already don't expose those
* fragment is currently not extractable from `req` in our net/http patch, so just ignore for now


fixes https://github.com/getsentry/sentry-ruby/issues/1955