### PR TITLE
Pin loofah for <= ruby 2.4 since they removed support in a patch release

### DIFF
--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -37,6 +37,10 @@ gem 'simplecov'
 gem "simplecov-cobertura", "~> 1.4"
 gem "rexml"
 
+# https://github.com/flavorjones/loofah/pull/267
+# loofah changed the required ruby version in a patch so we need to explicitly pin it
+gem "loofah", "2.20.0" if RUBY_VERSION.to_f < 2.5
+
 gem "rake", "~> 12.0"
 
 gem "object_tracer"

--- a/sentry-sidekiq/Gemfile
+++ b/sentry-sidekiq/Gemfile
@@ -16,6 +16,10 @@ sidekiq_version = "6.0" if sidekiq_version.nil?
 gem "rails", "< 7.0"
 gem "sidekiq", "~> #{sidekiq_version}"
 
+# https://github.com/flavorjones/loofah/pull/267
+# loofah changed the required ruby version in a patch so we need to explicitly pin it
+gem "loofah", "2.20.0" if RUBY_VERSION.to_f < 2.5
+
 gem "sentry-ruby", path: "../sentry-ruby"
 gem "sentry-rails", path: "../sentry-rails"
 


### PR DESCRIPTION
see https://github.com/flavorjones/loofah/pull/267
and https://github.com/flavorjones/loofah/issues/266


#skip-changelog