### PR TITLE
Allow java exceptions as capture type in JRuby (#2043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Move `http.query` to span data in net/http integration [#2039](https://github.com/getsentry/sentry-ruby/pull/2039)
 - Validate `release` is a `String` during configuration [#2040](https://github.com/getsentry/sentry-ruby/pull/2040)
+- Allow JRuby Java exceptions to be captured [#2043](https://github.com/getsentry/sentry-ruby/pull/2043)
 
 ### Bug Fixes
 

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -116,7 +116,11 @@ module Sentry
     end
 
     def capture_exception(exception, **options, &block)
-      check_argument_type!(exception, ::Exception)
+      if RUBY_PLATFORM == "java"
+        check_argument_type!(exception, ::Exception, ::Java::JavaLang::Throwable)
+      else
+        check_argument_type!(exception, ::Exception)
+      end
 
       return if Sentry.exception_captured?(exception)
 


### PR DESCRIPTION
This should fix the problems described in #2043. It should now be possible to directly capture exceptions originating in Java when running in JRuby.

I'm not entirely sure, if the implementation is clean enough, and am open for feedback. I based it on [something similar in sentry/raven](https://github.com/getsentry/sentry-ruby/blob/fea18fee3dabd9c7af47a7811bc432df96a58799/sentry-raven/spec/raven/event_spec.rb#L721).