### PR TITLE
Use allowlist to filter ActiveSupport breadcrumbs' data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Support Rails 7.1's show exception check [#2049](https://github.com/getsentry/sentry-ruby/pull/2049)
 - Ignore low-level Puma exceptions by default [#2055](https://github.com/getsentry/sentry-ruby/pull/2055)
+- Use allowlist to filter `ActiveSupport` breadcrumbs' data [#2048](https://github.com/getsentry/sentry-ruby/pull/2048)
 
 ## 5.9.0
 

--- a/sentry-rails/lib/sentry/rails/breadcrumb/active_support_logger.rb
+++ b/sentry-rails/lib/sentry/rails/breadcrumb/active_support_logger.rb
@@ -1,20 +1,76 @@
-require "sentry/rails/instrument_payload_cleanup_helper"
-
 module Sentry
   module Rails
     module Breadcrumb
       module ActiveSupportLogger
-        class << self
-          include InstrumentPayloadCleanupHelper
+        ALLOWED_LIST = {
+          # action_controller
+          "write_fragment.action_controller" => %i[key],
+          "read_fragment.action_controller" => %i[key],
+          "exist_fragment?.action_controller" => %i[key],
+          "expire_fragment.action_controller" => %i[key],
+          "start_processing.action_controller" => %i[controller action params format method path],
+          "process_action.action_controller" => %i[controller action params format method path status view_runtime db_runtime],
+          "send_file.action_controller" => %i[path],
+          "redirect_to.action_controller" => %i[status location],
+          "halted_callback.action_controller" => %i[filter],
+          # action_dispatch
+          "process_middleware.action_dispatch" => %i[middleware],
+          # action_view
+          "render_template.action_view" => %i[identifier layout],
+          "render_partial.action_view" => %i[identifier],
+          "render_collection.action_view" => %i[identifier count cache_hits],
+          "render_layout.action_view" => %i[identifier],
+          # active_record
+          "sql.active_record" => %i[sql name statement_name cached],
+          "instantiation.active_record" => %i[record_count class_name],
+          # action_mailer
+          # not including to, from, or subject..etc. because of PII concern
+          "deliver.action_mailer" => %i[mailer date perform_deliveries],
+          "process.action_mailer" => %i[mailer action params],
+          # active_support
+          "cache_read.active_support" => %i[key store hit],
+          "cache_generate.active_support" => %i[key store],
+          "cache_fetch_hit.active_support" => %i[key store],
+          "cache_write.active_support" => %i[key store],
+          "cache_delete.active_support" => %i[key store],
+          "cache_exist?.active_support" => %i[key store],
+          # active_job
+          "enqueue_at.active_job" => %i[],
+          "enqueue.active_job" => %i[],
+          "enqueue_retry.active_job" => %i[],
+          "perform_start.active_job" => %i[],
+          "perform.active_job" => %i[],
+          "retry_stopped.active_job" => %i[],
+          "discard.active_job" => %i[],
+          # action_cable
+          "perform_action.action_cable" => %i[channel_class action],
+          "transmit.action_cable" => %i[channel_class],
+          "transmit_subscription_confirmation.action_cable" => %i[channel_class],
+          "transmit_subscription_rejection.action_cable" => %i[channel_class],
+          "broadcast.action_cable" => %i[broadcasting],
+          # active_storage
+          "service_upload.active_storage" => %i[service key checksum],
+          "service_streaming_download.active_storage" => %i[service key],
+          "service_download_chunk.active_storage" => %i[service key],
+          "service_download.active_storage" => %i[service key],
+          "service_delete.active_storage" => %i[service key],
+          "service_delete_prefixed.active_storage" => %i[service prefix],
+          "service_exist.active_storage" => %i[service key exist],
+          "service_url.active_storage" => %i[service key url],
+          "service_update_metadata.active_storage" => %i[service key],
+          "preview.active_storage" => %i[key],
+          "analyze.active_storage" => %i[analyzer],
+        }.freeze
 
+        class << self
           def add(name, started, _finished, _unique_id, data)
             # skip Rails' internal events
             return if name.start_with?("!")
 
+            allowed_keys = ALLOWED_LIST[name]
+
             if data.is_a?(Hash)
-              # we should only mutate the copy of the data
-              data = data.dup
-              cleanup_data(data)
+              data = data.slice(*allowed_keys)
             end
 
             crumb = Sentry::Breadcrumb.new(


### PR DESCRIPTION
Since the number of potentially hard-to-serialise data is growing, we should use allowlist to filter the data.

This should properly resolve #1183
