### PR TITLE
Support Rails 7.1's show exception check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Move `http.query` to span data in net/http integration [#2039](https://github.com/getsentry/sentry-ruby/pull/2039)
 - Validate `release` is a `String` during configuration [#2040](https://github.com/getsentry/sentry-ruby/pull/2040)
 
+### Bug Fixes
+
+- Support Rails 7.1's show exception check [#2049](https://github.com/getsentry/sentry-ruby/pull/2049)
+
 ## 5.9.0
 
 ### Features

--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -1,6 +1,8 @@
 module Sentry
   module Rails
     class CaptureExceptions < Sentry::Rack::CaptureExceptions
+      RAILS_7_1 = Gem::Version.new(::Rails.version) >= Gem::Version.new("7.1.0.alpha")
+
       def initialize(_)
         super
 
@@ -21,10 +23,9 @@ module Sentry
       end
 
       def capture_exception(exception, env)
-        request = ActionDispatch::Request.new(env)
-
         # the exception will be swallowed by ShowExceptions middleware
-        return if request.show_exceptions? && !Sentry.configuration.rails.report_rescued_exceptions
+        return if show_exceptions?(exception, env) && !Sentry.configuration.rails.report_rescued_exceptions
+
         Sentry::Rails.capture_exception(exception).tap do |event|
           env[ERROR_EVENT_ID_KEY] = event.event_id if event
         end
@@ -42,6 +43,16 @@ module Sentry
 
         transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, baggage: baggage, **options) if sentry_trace
         Sentry.start_transaction(transaction: transaction, custom_sampling_context: { env: env }, **options)
+      end
+
+      def show_exceptions?(exception, env)
+        request = ActionDispatch::Request.new(env)
+
+        if RAILS_7_1
+          ActionDispatch::ExceptionWrapper.new(nil, exception).show?(request)
+        else
+          request.show_exceptions?
+        end
       end
     end
   end


### PR DESCRIPTION
The `request.show_exceptions?` method will be removed in Raiils 7.1 (https://github.com/rails/rails/pull/45867)

So this PR adopts the new API to check whether to show exception if the Rails version is 7.1 or later.

