### PR TITLE
Update CI Rubies

### DIFF
--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -24,8 +24,8 @@ jobs:
         ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', '3.1', '3.2', head, jruby]
         os: [ubuntu-latest]
         include:
-          - { os: ubuntu-latest, ruby_version: '3.1', options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
-          - { os: ubuntu-latest, ruby_version: '3.1', options: { codecov: 1 } }
+          - { os: ubuntu-latest, ruby_version: '3.2', options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
+          - { os: ubuntu-latest, ruby_version: '3.2', options: { codecov: 1 } }
     steps:
     - uses: actions/checkout@v1
     - name: Install sqlite

--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', '3.1', '3.2', head, jruby]
+        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', '3.1', '3.2', jruby]
         os: [ubuntu-latest]
         include:
           - { os: ubuntu-latest, ruby_version: '3.2', options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }

--- a/.github/workflows/sentry_opentelemetry_test.yml
+++ b/.github/workflows/sentry_opentelemetry_test.yml
@@ -25,8 +25,8 @@ jobs:
         # opentelemetry_version: [1.2.0]
         os: [ubuntu-latest]
         include:
-          - { os: ubuntu-latest, ruby_version: 3.1, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
-          - { os: ubuntu-latest, ruby_version: 3.1, options: { codecov: 1 } }
+          - { os: ubuntu-latest, ruby_version: 3.2, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
+          - { os: ubuntu-latest, ruby_version: 3.2, options: { codecov: 1 } }
     steps:
     - uses: actions/checkout@v1
 

--- a/.github/workflows/sentry_opentelemetry_test.yml
+++ b/.github/workflows/sentry_opentelemetry_test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.6, 2.7, '3.0', '3.1', '3.2', head, jruby]
+        ruby_version: [2.6, 2.7, '3.0', '3.1', '3.2', jruby]
         # opentelemetry_version: [1.2.0]
         os: [ubuntu-latest]
         include:

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         rails_version: [6.1.0, 7.0.0, 7.1.0]
-        ruby_version: [2.7, '3.0', '3.1', '3.2', head]
+        ruby_version: [2.7, '3.0', '3.1', '3.2']
         os: [ubuntu-latest]
         include:
           - { os: ubuntu-latest, ruby_version: "2.4", rails_version: 5.0.0 }

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -47,7 +47,7 @@ jobs:
           - { os: ubuntu-latest, ruby_version: "jruby", rails_version: 6.1.0 }
           - {
               os: ubuntu-latest,
-              ruby_version: "3.1",
+              ruby_version: "3.2",
               rails_version: 7.1.0,
               options:
                 {
@@ -56,7 +56,7 @@ jobs:
             }
           - {
               os: ubuntu-latest,
-              ruby_version: "3.1",
+              ruby_version: "3.2",
               rails_version: 7.1.0,
               options: { codecov: 1 },
             }

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -24,8 +24,8 @@ jobs:
         ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', '3.1', '3.2', head, jruby]
         os: [ubuntu-latest]
         include:
-          - { os: ubuntu-latest, ruby_version: '3.1', options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
-          - { os: ubuntu-latest, ruby_version: '3.1', options: { codecov: 1 } }
+          - { os: ubuntu-latest, ruby_version: '3.2', options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
+          - { os: ubuntu-latest, ruby_version: '3.2', options: { codecov: 1 } }
     steps:
     - uses: actions/checkout@v1
     - name: Set up Ruby ${{ matrix.ruby_version }}

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', '3.1', '3.2', head, jruby]
+        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', '3.1', '3.2', jruby]
         os: [ubuntu-latest]
         include:
           - { os: ubuntu-latest, ruby_version: '3.2', options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -28,19 +28,19 @@ jobs:
         include:
           - {
               os: ubuntu-latest,
-              ruby_version: 3.1,
+              ruby_version: 3.2,
               rack_version: 0,
               redis_rb_version: 5.0,
             }
           - {
               os: ubuntu-latest,
-              ruby_version: 3.1,
+              ruby_version: 3.2,
               rack_version: 2.0,
               redis_rb_version: 5.0,
             }
           - {
               os: ubuntu-latest,
-              ruby_version: 3.1,
+              ruby_version: 3.2,
               rack_version: 3.0,
               redis_rb_version: 5.0,
               options:
@@ -50,7 +50,7 @@ jobs:
             }
           - {
               os: ubuntu-latest,
-              ruby_version: 3.1,
+              ruby_version: 3.2,
               rack_version: 3.0,
               redis_rb_version: 5.0,
               options: { codecov: 1 },

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', '3.1', '3.2', head, jruby]
+        ruby_version: [2.4, 2.5, 2.6, 2.7, '3.0', '3.1', '3.2', jruby]
         rack_version: [2.0, 3.0]
         redis_rb_version: [4.0]
         os: [ubuntu-latest]

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         sidekiq_version: ['5.0', '6.0', '7.0']
-        ruby_version: ['2.7', '3.0', '3.1', '3.2', head, jruby]
+        ruby_version: ['2.7', '3.0', '3.1', '3.2', jruby]
         os: [ubuntu-latest]
         include:
           - { os: ubuntu-latest, ruby_version: 2.4, sidekiq_version: 5.0 }

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -32,8 +32,9 @@ jobs:
           - { os: ubuntu-latest, ruby_version: 2.6, sidekiq_version: 6.0 }
           - { os: ubuntu-latest, ruby_version: jruby, sidekiq_version: 5.0 }
           - { os: ubuntu-latest, ruby_version: jruby, sidekiq_version: 6.0 }
-          - { os: ubuntu-latest, ruby_version: '3.1', sidekiq_version: 6.0, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
-          - { os: ubuntu-latest, ruby_version: '3.1', sidekiq_version: 6.0, options: { codecov: 1 } }
+          - { os: ubuntu-latest, ruby_version: jruby, sidekiq_version: 7.0 }
+          - { os: ubuntu-latest, ruby_version: '3.2', sidekiq_version: 7.0, options: { rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal" } }
+          - { os: ubuntu-latest, ruby_version: '3.2', sidekiq_version: 7.0, options: { codecov: 1 } }
     steps:
     - uses: actions/checkout@v1
 


### PR DESCRIPTION
1. Since Ruby 3.2 has gone out for almost half of year, we should be able to use it for special suites like generating coverage or with `--enable-frozen-string-literal` falg
2. Given that we rarely adopt the latest Ruby features and Ruby has strong emphasise on backward-compatibility, I think testing against head just increases the chance of broken build unnecessarily. So I'm stopping testing against Ruby head now.

#skip-changelog