### PR TITLE
Ignore low-level Puma exceptions by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 - Support Rails 7.1's show exception check [#2049](https://github.com/getsentry/sentry-ruby/pull/2049)
+- Ignore low-level Puma exceptions by default [#2055](https://github.com/getsentry/sentry-ruby/pull/2055)
 
 ## 5.9.0
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -257,6 +257,15 @@ module Sentry
     # @!visibility private
     attr_reader :errors, :gem_specs
 
+    # These exceptions could enter Puma's `lowlevel_error_handler` callback and the SDK's Puma integration
+    # But they are mostly considered as noise and should be ignored by default
+    # Please see https://github.com/getsentry/sentry-ruby/pull/2026 for more information
+    PUMA_IGNORE_DEFAULT = [
+      'Puma::MiniSSL::SSLError',
+      'Puma::HttpParserError',
+      'Puma::HttpParserError501'
+    ].freeze
+
     # Most of these errors generate 4XX responses. In general, Sentry clients
     # only automatically report 5xx responses.
     IGNORE_DEFAULT = [
@@ -306,7 +315,7 @@ module Sentry
       self.environment = environment_from_env
       self.enabled_environments = []
       self.exclude_loggers = []
-      self.excluded_exceptions = IGNORE_DEFAULT.dup
+      self.excluded_exceptions = IGNORE_DEFAULT + PUMA_IGNORE_DEFAULT
       self.inspect_exception_causes_for_exclusion = true
       self.linecache = ::Sentry::LineCache.new
       self.logger = ::Sentry::Logger.new(STDOUT)


### PR DESCRIPTION
This is a follow-up to #2026. The idea is to ignore low-level Puma exceptions by default, but allow users to opt-in to capturing them.

Please see comments in https://github.com/getsentry/sentry-ruby/pull/2026 for more details.