### PR TITLE
Fix uninitialized race condition in Redis integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Bug Fixes
 
 - Support Rails 7.1's show exception check [#2049](https://github.com/getsentry/sentry-ruby/pull/2049)
+- Fix uninitialzed race condition in Redis integration [#2057](https://github.com/getsentry/sentry-ruby/pull/2057)
+  - Fixes [#2054](https://github.com/getsentry/sentry-ruby/issues/2054)
 
 ## 5.9.0
 

--- a/sentry-ruby/lib/sentry/redis.rb
+++ b/sentry-ruby/lib/sentry/redis.rb
@@ -30,6 +30,7 @@ module Sentry
     attr_reader :commands, :host, :port, :db
 
     def record_breadcrumb
+      return unless Sentry.initialized?
       return unless Sentry.configuration.breadcrumbs_logger.include?(LOGGER_NAME)
 
       Sentry.add_breadcrumb(


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-ruby/issues/2054
