### PR TITLE
ErrorHandler should cleanup the scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - Fixes [#2054](https://github.com/getsentry/sentry-ruby/issues/2054)
 - Ignore low-level Puma exceptions by default [#2055](https://github.com/getsentry/sentry-ruby/pull/2055)
 - Use allowlist to filter `ActiveSupport` breadcrumbs' data [#2048](https://github.com/getsentry/sentry-ruby/pull/2048)
+- ErrorHandler should cleanup the scope ([#2059](https://github.com/getsentry/sentry-ruby/pull/2059))
 
 
 ## 5.9.0

--- a/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
@@ -25,6 +25,8 @@ module Sentry
           contexts: { sidekiq: context_filter.filtered },
           hint: { background: false }
         )
+      ensure
+        scope&.clear
       end
 
       private

--- a/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe Sentry::Sidekiq do
       expect(event["tags"]).to eq("queue" => "default", "jid" => "123123", "mood" => "sad")
       expect(event["transaction"]).to eq("Sidekiq/SadWorker")
       expect(event["breadcrumbs"]["values"][0]["message"]).to eq("I'm sad!")
+      expect(Sentry.get_current_scope.tags).to be_empty
     end
 
     it "cleans up context from failed jobs" do
@@ -86,6 +87,7 @@ RSpec.describe Sentry::Sidekiq do
 
       expect(event["tags"]).to eq("queue" => "default", "jid" => "123123", "mood" => "very sad")
       expect(event["breadcrumbs"]["values"][0]["message"]).to eq("I'm very sad!")
+      expect(Sentry.get_current_scope.tags).to be_empty
     end
   end
 


### PR DESCRIPTION
Because ErrorHandler is called outside of context middlewares, we don't clean the scope when an exception occurs. This makes sure ErrorHandler can have the context data set by middlewares. However, this also means that those states would be left uncleaned after the exception is captured.

This commit makes sure that the scope is cleaned up after the exception is captured.

Closes #2012 