### PR TITLE
Expose `:value` in `SingleExceptionInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+
+## 5.11.0
+
+### Features
+
+- Make `:value` in `SingleExceptionInterface` writable, so that it can be modified in `before_send` under `event.exception.values[n].value`
+
 ## 5.10.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
-
-## 5.11.0
+## Unreleased
 
 ### Features
 
-- Make `:value` in `SingleExceptionInterface` writable, so that it can be modified in `before_send` under `event.exception.values[n].value`
+- Make `:value` in `SingleExceptionInterface` writable, so that it can be modified in `before_send` under `event.exception.values[n].value` [#2072](https://github.com/getsentry/sentry-ruby/pull/2072)
 
 ## 5.10.0
 

--- a/sentry-ruby/lib/sentry/interfaces/single_exception.rb
+++ b/sentry-ruby/lib/sentry/interfaces/single_exception.rb
@@ -11,7 +11,8 @@ module Sentry
     OMISSION_MARK = "...".freeze
     MAX_LOCAL_BYTES = 1024
 
-    attr_reader :type, :value, :module, :thread_id, :stacktrace
+    attr_reader :type, :module, :thread_id, :stacktrace
+    attr_accessor :value
 
     def initialize(exception:, stacktrace: nil)
       @type = exception.class.to_s


### PR DESCRIPTION
Expose `:value` in `SingleExceptionInterface` for users wishing to do basic sanitization of the exception message string in `before_send()`.

For example, the :dependabot: project does basic sanitization of `:value` using `sentry-raven`:
https://github.com/dependabot/dependabot-core/blob/65f1c2d24e88ac57ed8df980871446deb5ea2d94/updater/lib/dependabot/sentry.rb#L21

So exposing this makes the migration path easier for those users. And makes it possible for anyone else to do basic redaction of potential secrets, etc.

Fix https://github.com/getsentry/sentry-ruby/issues/2071