### PR TITLE
Delete deprecated `configuration` method

### DIFF
--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -98,12 +98,6 @@ module Sentry
       end
     end
 
-    # @deprecated This method will be removed in v5.0.0. Please just use Sentry.configuration
-    # @return [Configuration]
-    def configuration
-      Sentry.configuration
-    end
-
     # Sets the event's timestamp.
     # @param time [Time, Float]
     # @return [void]


### PR DESCRIPTION
Use `Sentry.configuration` instead.

This was slated for removal in `v5.0.0` but was accidentally left in, so removing as part of `v6.0.0`.

Related:
* https://github.com/getsentry/sentry-ruby/issues/1279