### PR TITLE
Tracing without performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   ```
 - Tracing without Performance
   - Implement `PropagationContext` on `Scope` and add `Sentry.get_trace_propagation_headers` API [#2084](https://github.com/getsentry/sentry-ruby/pull/2084)
+  - Implement `Sentry.continue_trace` API [#2089](https://github.com/getsentry/sentry-ruby/pull/2089)
 
   The SDK now supports connecting arbitrary events (Errors / Transactions / Replays) across distributed services and not just Transactions.  
   To continue an incoming trace starting with this version of the SDK, use `Sentry.continue_trace` as follows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@
   config.trace_propagation_targets = [/.*/]  # default is to all targets
   config.trace_propagation_targets = [/example.com/, 'foobar.org/api/v2']
   ```
+- Tracing without Performance
+  - Implement `PropagationContext` on `Scope` and add `Sentry.get_trace_propagation_headers` API [#2084](https://github.com/getsentry/sentry-ruby/pull/2084)
+
+  The SDK now supports connecting arbitrary events (Errors / Transactions / Replays) across distributed services and not just Transactions.  
+  To continue an incoming trace starting with this version of the SDK, use `Sentry.continue_trace` as follows.
+
+  ```rb
+  # rack application
+  def call(env)
+    transaction = Sentry.continue_trace(env, name: 'transaction', op: 'op')
+    Sentry.start_transaction(transaction: transaction)
+  end
+  ```
+
+  To inject headers into outgoing requests, use `Sentry.get_trace_propagation_headers` to get a hash of headers to add to your request.
 
 ### Bug Fixes
 

--- a/sentry-rails/lib/sentry/rails/action_cable.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable.rb
@@ -33,11 +33,8 @@ module Sentry
           end
 
           def start_transaction(env, scope)
-            sentry_trace = env["HTTP_SENTRY_TRACE"]
-            baggage = env["HTTP_BAGGAGE"]
-
             options = { name: scope.transaction_name, source: scope.transaction_source, op: OP_NAME }
-            transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, baggage: baggage, **options) if sentry_trace
+            transaction = Sentry.continue_trace(env, **options)
             Sentry.start_transaction(transaction: transaction, **options)
           end
 

--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -32,16 +32,13 @@ module Sentry
       end
 
       def start_transaction(env, scope)
-        sentry_trace = env["HTTP_SENTRY_TRACE"]
-        baggage = env["HTTP_BAGGAGE"]
-
         options = { name: scope.transaction_name, source: scope.transaction_source, op: transaction_op }
 
         if @assets_regexp && scope.transaction_name.match?(@assets_regexp)
           options.merge!(sampled: false)
         end
 
-        transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, baggage: baggage, **options) if sentry_trace
+        transaction = Sentry.continue_trace(env, **options)
         Sentry.start_transaction(transaction: transaction, custom_sampling_context: { env: env }, **options)
       end
 

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -489,6 +489,24 @@ module Sentry
       Scope.add_global_event_processor(&block)
     end
 
+    # Returns the traceparent (sentry-trace) header for distributed tracing.
+    # Can be either from the currently active span or the propagation context.
+    #
+    # @return [String, nil]
+    def get_traceparent
+      return nil unless initialized?
+      get_current_hub.get_traceparent
+    end
+
+    # Returns the baggage header for distributed tracing.
+    # Can be either from the currently active span or the propagation context.
+    #
+    # @return [String, nil]
+    def get_baggage
+      return nil unless initialized?
+      get_current_hub.get_baggage
+    end
+
     ##### Helpers #####
 
     # @!visibility private

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -507,6 +507,15 @@ module Sentry
       get_current_hub.get_baggage
     end
 
+    # Returns the a Hash containing sentry-trace and baggage.
+    # Can be either from the currently active span or the propagation context.
+    #
+    # @return [Hash, nil]
+    def get_trace_propagation_headers
+      return nil unless initialized?
+      get_current_hub.get_trace_propagation_headers
+    end
+
     ##### Helpers #####
 
     # @!visibility private

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -516,6 +516,15 @@ module Sentry
       get_current_hub.get_trace_propagation_headers
     end
 
+    # Continue an incoming trace from a rack env like hash.
+    #
+    # @param env [Hash]
+    # @return [Transaction, nil]
+    def continue_trace(env, **options)
+      return nil unless initialized?
+      get_current_hub.continue_trace(env, **options)
+    end
+
     ##### Helpers #####
 
     # @!visibility private

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -148,6 +148,8 @@ module Sentry
       raise
     end
 
+    # @deprecated use Sentry.get_traceparent instead.
+    #
     # Generates a Sentry trace for distribted tracing from the given Span.
     # Returns `nil` if `config.propagate_traces` is `false`.
     # @param span [Span] the span to generate trace from.
@@ -160,7 +162,9 @@ module Sentry
       trace
     end
 
-    # Generates a W3C Baggage header for distribted tracing from the given Span.
+    # @deprecated Use Sentry.get_baggage instead.
+    #
+    # Generates a W3C Baggage header for distributed tracing from the given Span.
     # Returns `nil` if `config.propagate_traces` is `false`.
     # @param span [Span] the span to generate trace from.
     # @return [String, nil]

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -37,6 +37,11 @@ module Sentry
     # @return [RequestInterface]
     attr_reader :request
 
+    # Dynamic Sampling Context (DSC) that gets attached
+    # as the trace envelope header in the transport.
+    # @return [Hash, nil]
+    attr_accessor :dynamic_sampling_context
+
     # @param configuration [Configuration]
     # @param integration_meta [Hash, nil]
     # @param message [String, nil]

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -59,6 +59,7 @@ module Sentry
       @tags          = {}
 
       @fingerprint = []
+      @dynamic_sampling_context = nil
 
       # configuration data that's directly used by events
       @server_name = configuration.server_name

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -246,10 +246,15 @@ module Sentry
     def get_trace_propagation_headers
       return nil unless configuration.propagate_traces
 
-      {
-        SENTRY_TRACE_HEADER_NAME => get_traceparent,
-        BAGGAGE_HEADER_NAME => get_baggage
-      }.compact
+      headers = {}
+
+      traceparent = get_traceparent
+      headers[SENTRY_TRACE_HEADER_NAME] = traceparent if traceparent
+
+      baggage = get_baggage
+      headers[BAGGAGE_HEADER_NAME] = baggage if baggage && !baggage.empty?
+
+      headers
     end
 
     private

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -243,6 +243,15 @@ module Sentry
         current_scope.propagation_context&.get_baggage&.serialize
     end
 
+    def get_trace_propagation_headers
+      return nil unless configuration.propagate_traces
+
+      {
+        SENTRY_TRACE_HEADER_NAME => get_traceparent,
+        BAGGAGE_HEADER_NAME => get_baggage
+      }.compact
+    end
+
     private
 
     def current_layer

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -229,6 +229,20 @@ module Sentry
       end_session
     end
 
+    def get_traceparent
+      return nil unless current_scope
+
+      current_scope.get_span&.to_sentry_trace ||
+        current_scope.propagation_context&.get_traceparent
+    end
+
+    def get_baggage
+      return nil unless current_scope
+
+      current_scope.get_span&.to_baggage ||
+        current_scope.propagation_context&.get_baggage&.serialize
+    end
+
     private
 
     def current_layer

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -233,14 +233,14 @@ module Sentry
       return nil unless current_scope
 
       current_scope.get_span&.to_sentry_trace ||
-        current_scope.propagation_context&.get_traceparent
+        current_scope.propagation_context.get_traceparent
     end
 
     def get_baggage
       return nil unless current_scope
 
       current_scope.get_span&.to_baggage ||
-        current_scope.propagation_context&.get_baggage&.serialize
+        current_scope.propagation_context.get_baggage&.serialize
     end
 
     def get_trace_propagation_headers

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -244,8 +244,6 @@ module Sentry
     end
 
     def get_trace_propagation_headers
-      return nil unless configuration.propagate_traces
-
       headers = {}
 
       traceparent = get_traceparent

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -32,7 +32,7 @@ module Sentry
         Sentry.with_child_span(op: OP_NAME, start_timestamp: Sentry.utc_now.to_f) do |sentry_span|
           request_info = extract_request_info(req)
 
-          if propagate_trace?(request_info[:url], Sentry.configuration.trace_propagation_targets)
+          if propagate_trace?(request_info[:url], Sentry.configuration)
             set_propagation_headers(req)
           end
 
@@ -90,8 +90,10 @@ module Sentry
         result
       end
 
-      def propagate_trace?(url, trace_propagation_targets)
-        url && trace_propagation_targets.any? { |target| url.match?(target) }
+      def propagate_trace?(url, configuration)
+        url &&
+          configuration.propagate_traces &&
+          configuration.trace_propagation_targets.any? { |target| url.match?(target) }
       end
     end
   end

--- a/sentry-ruby/lib/sentry/propagation_context.rb
+++ b/sentry-ruby/lib/sentry/propagation_context.rb
@@ -62,7 +62,7 @@ module Sentry
 
       items = {
         "trace_id" => trace_id,
-        "sample_rate" => configuration.traces_sample_rate,
+        "sample_rate" => configuration.traces_sample_rate&.to_s,
         "environment" => configuration.environment,
         "release" => configuration.release,
         "public_key" => configuration.dsn&.public_key

--- a/sentry-ruby/lib/sentry/propagation_context.rb
+++ b/sentry-ruby/lib/sentry/propagation_context.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+module Sentry
+  class PropagationContext
+    def initialize
+      @trace_id = SecureRandom.uuid.delete("-")
+      @span_id = SecureRandom.uuid.delete("-").slice(0, 16)
+      @parent_span_id = nil
+      @dynamic_sampling_context = nil
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/propagation_context.rb
+++ b/sentry-ruby/lib/sentry/propagation_context.rb
@@ -10,5 +10,15 @@ module Sentry
       @parent_span_id = nil
       @dynamic_sampling_context = nil
     end
+
+    # Returns the trace context that can be used to embed in an Event.
+    # @return [Hash]
+    def get_trace_context
+      {
+        trace_id: @trace_id,
+        span_id: @span_id,
+        parent_span_id: @parent_span_id
+      }
+    end
   end
 end

--- a/sentry-ruby/lib/sentry/propagation_context.rb
+++ b/sentry-ruby/lib/sentry/propagation_context.rb
@@ -1,24 +1,78 @@
 # frozen_string_literal: true
 
 require "securerandom"
+require "sentry/baggage"
 
 module Sentry
   class PropagationContext
-    def initialize
+
+    # An uuid that can be used to identify a trace.
+    # @return [String]
+    attr_reader :trace_id
+    # An uuid that can be used to identify the span.
+    # @return [String]
+    attr_reader :span_id
+    # Span parent's span_id.
+    # @return [String]
+    attr_reader :parent_span_id
+
+    def initialize(scope)
+      @scope = scope
       @trace_id = SecureRandom.uuid.delete("-")
       @span_id = SecureRandom.uuid.delete("-").slice(0, 16)
       @parent_span_id = nil
-      @dynamic_sampling_context = nil
+      @baggage = nil
     end
 
     # Returns the trace context that can be used to embed in an Event.
     # @return [Hash]
     def get_trace_context
       {
-        trace_id: @trace_id,
-        span_id: @span_id,
-        parent_span_id: @parent_span_id
+        trace_id: trace_id,
+        span_id: span_id,
+        parent_span_id: parent_span_id
       }
+    end
+
+    # Returns the sentry-trace header from the propagation context.
+    # @return [String]
+    def get_traceparent
+      "#{trace_id}-#{span_id}"
+    end
+
+    # Returns the W3C baggage header from the propagation context.
+    # @return [String, nil]
+    def get_baggage
+      populate_head_baggage if @baggage.nil? || @baggage.mutable
+      @baggage
+    end
+
+    # Returns the Dynamic Sampling Context from the baggage.
+    # @return [String, nil]
+    def get_dynamic_sampling_context
+      get_baggage&.dynamic_sampling_context
+    end
+
+    private
+
+    def populate_head_baggage
+      return unless Sentry.initialized?
+
+      configuration = Sentry.configuration
+
+      items = {
+        "trace_id" => trace_id,
+        "sample_rate" => configuration.traces_sample_rate,
+        "environment" => configuration.environment,
+        "release" => configuration.release,
+        "public_key" => configuration.dsn&.public_key
+      }
+
+      user = @scope&.user
+      items["user_segment"] = user["segment"] if user && user["segment"]
+
+      items.compact!
+      @baggage = Baggage.new(items, mutable: false)
     end
   end
 end

--- a/sentry-ruby/lib/sentry/propagation_context.rb
+++ b/sentry-ruby/lib/sentry/propagation_context.rb
@@ -5,6 +5,13 @@ require "sentry/baggage"
 
 module Sentry
   class PropagationContext
+    SENTRY_TRACE_REGEXP = Regexp.new(
+      "^[ \t]*" +  # whitespace
+      "([0-9a-f]{32})?" +  # trace_id
+      "-?([0-9a-f]{16})?" +  # span_id
+      "-?([01])?" +  # sampled
+      "[ \t]*$"  # whitespace
+    )
 
     # An uuid that can be used to identify a trace.
     # @return [String]
@@ -13,15 +20,67 @@ module Sentry
     # @return [String]
     attr_reader :span_id
     # Span parent's span_id.
-    # @return [String]
+    # @return [String, nil]
     attr_reader :parent_span_id
+    # The sampling decision of the parent transaction.
+    # @return [Boolean, nil]
+    attr_reader :parent_sampled
+    # Is there an incoming trace or not?
+    # @return [Boolean]
+    attr_reader :incoming_trace
+    # This is only for accessing the current baggage variable.
+    # Please use the #get_baggage method for interfacing outside this class.
+    # @return [Baggage, nil]
+    attr_reader :baggage
 
-    def initialize(scope)
+    def initialize(scope, env = nil)
       @scope = scope
-      @trace_id = SecureRandom.uuid.delete("-")
-      @span_id = SecureRandom.uuid.delete("-").slice(0, 16)
       @parent_span_id = nil
+      @parent_sampled = nil
       @baggage = nil
+      @incoming_trace = false
+
+      if env
+        sentry_trace_header = env["HTTP_SENTRY_TRACE"] || env[SENTRY_TRACE_HEADER_NAME]
+        baggage_header = env["HTTP_BAGGAGE"] || env[BAGGAGE_HEADER_NAME]
+
+        if sentry_trace_header
+          sentry_trace_data = self.class.extract_sentry_trace(sentry_trace_header)
+
+          if sentry_trace_data
+            @trace_id, @parent_span_id, @parent_sampled = sentry_trace_data
+
+            @baggage = if baggage_header && !baggage_header.empty?
+                        Baggage.from_incoming_header(baggage_header)
+                      else
+                        # If there's an incoming sentry-trace but no incoming baggage header,
+                        # for instance in traces coming from older SDKs,
+                        # baggage will be empty and frozen and won't be populated as head SDK.
+                        Baggage.new({})
+                      end
+
+            @baggage.freeze!
+            @incoming_trace = true
+          end
+        end
+      end
+
+      @trace_id ||= SecureRandom.uuid.delete("-")
+      @span_id = SecureRandom.uuid.delete("-").slice(0, 16)
+    end
+
+    # Extract the trace_id, parent_span_id and parent_sampled values from a sentry-trace header.
+    #
+    # @param sentry_trace [String] the sentry-trace header value from the previous transaction.
+    # @return [Array, nil]
+    def self.extract_sentry_trace(sentry_trace)
+      match = SENTRY_TRACE_REGEXP.match(sentry_trace)
+      return nil if match.nil?
+
+      trace_id, parent_span_id, sampled_flag = match[1..3]
+      parent_sampled = sampled_flag.nil? ? nil : sampled_flag != "0"
+
+      [trace_id, parent_span_id, parent_sampled]
     end
 
     # Returns the trace context that can be used to embed in an Event.
@@ -40,8 +99,8 @@ module Sentry
       "#{trace_id}-#{span_id}"
     end
 
-    # Returns the W3C baggage header from the propagation context.
-    # @return [String, nil]
+    # Returns the Baggage from the propagation context or populates as head SDK if empty.
+    # @return [Baggage, nil]
     def get_baggage
       populate_head_baggage if @baggage.nil? || @baggage.mutable
       @baggage

--- a/sentry-ruby/lib/sentry/propagation_context.rb
+++ b/sentry-ruby/lib/sentry/propagation_context.rb
@@ -65,11 +65,9 @@ module Sentry
         "sample_rate" => configuration.traces_sample_rate&.to_s,
         "environment" => configuration.environment,
         "release" => configuration.release,
-        "public_key" => configuration.dsn&.public_key
+        "public_key" => configuration.dsn&.public_key,
+        "user_segment" => @scope.user && @scope.user["segment"]
       }
-
-      user = @scope&.user
-      items["user_segment"] = user["segment"] if user && user["segment"]
 
       items.compact!
       @baggage = Baggage.new(items, mutable: false)

--- a/sentry-ruby/lib/sentry/propagation_context.rb
+++ b/sentry-ruby/lib/sentry/propagation_context.rb
@@ -121,7 +121,6 @@ module Sentry
 
       items = {
         "trace_id" => trace_id,
-        "sample_rate" => configuration.traces_sample_rate&.to_s,
         "environment" => configuration.environment,
         "release" => configuration.release,
         "public_key" => configuration.dsn&.public_key,

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -62,11 +62,8 @@ module Sentry
       end
 
       def start_transaction(env, scope)
-        sentry_trace = env["HTTP_SENTRY_TRACE"]
-        baggage = env["HTTP_BAGGAGE"]
-
         options = { name: scope.transaction_name, source: scope.transaction_source, op: transaction_op }
-        transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, baggage: baggage, **options) if sentry_trace
+        transaction = Sentry.continue_trace(env, **options)
         Sentry.start_transaction(transaction: transaction, custom_sampling_context: { env: env }, **options)
       end
 

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -292,11 +292,16 @@ module Sentry
       @rack_env = {}
       @span = nil
       @session = nil
+      generate_propagation_context
       set_new_breadcrumb_buffer
     end
 
     def set_new_breadcrumb_buffer
       @breadcrumbs = BreadcrumbBuffer.new(@max_breadcrumbs)
+    end
+
+    def generate_propagation_context
+      @propagation_context = PropagationContext.new
     end
 
     class << self

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -279,6 +279,13 @@ module Sentry
       @event_processors << block
     end
 
+    # Generate a new propagation context either from the incoming env headers or from scratch.
+    # @param env [Hash, nil]
+    # @return [void]
+    def generate_propagation_context(env = nil)
+      @propagation_context = PropagationContext.new(self, env)
+    end
+
     protected
 
     # for duplicating scopes internally
@@ -305,10 +312,6 @@ module Sentry
 
     def set_new_breadcrumb_buffer
       @breadcrumbs = BreadcrumbBuffer.new(@max_breadcrumbs)
-    end
-
-    def generate_propagation_context
-      @propagation_context = PropagationContext.new(self)
     end
 
     class << self

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -55,6 +55,7 @@ module Sentry
         event.contexts[:trace] ||= span.get_trace_context
       else
         event.contexts[:trace] ||= propagation_context.get_trace_context
+        event.dynamic_sampling_context ||= propagation_context.get_dynamic_sampling_context
       end
 
       event.fingerprint = fingerprint
@@ -307,7 +308,7 @@ module Sentry
     end
 
     def generate_propagation_context
-      @propagation_context = PropagationContext.new
+      @propagation_context = PropagationContext.new(self)
     end
 
     class << self

--- a/sentry-ruby/lib/sentry/span.rb
+++ b/sentry-ruby/lib/sentry/span.rb
@@ -75,7 +75,7 @@ module Sentry
       timestamp: nil
     )
       @trace_id = trace_id || SecureRandom.uuid.delete("-")
-      @span_id = span_id || SecureRandom.hex(8)
+      @span_id = span_id || SecureRandom.uuid.delete("-").slice(0, 16)
       @parent_span_id = parent_span_id
       @sampled = sampled
       @start_timestamp = start_timestamp || Sentry.utc_now.to_f

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -2,16 +2,13 @@
 
 require "sentry/baggage"
 require "sentry/profiler"
+require "sentry/propagation_context"
 
 module Sentry
   class Transaction < Span
-    SENTRY_TRACE_REGEXP = Regexp.new(
-      "^[ \t]*" +  # whitespace
-      "([0-9a-f]{32})?" +  # trace_id
-      "-?([0-9a-f]{16})?" +  # span_id
-      "-?([01])?" +  # sampled
-      "[ \t]*$"  # whitespace
-    )
+    # @deprecated Use Sentry::PropagationContext::SENTRY_TRACE_REGEXP instead.
+    SENTRY_TRACE_REGEXP = PropagationContext::SENTRY_TRACE_REGEXP
+
     UNLABELD_NAME = "<unlabeled transaction>".freeze
     MESSAGE_PREFIX = "[Tracing]"
 
@@ -92,6 +89,8 @@ module Sentry
       init_span_recorder
     end
 
+    # @deprecated use Sentry.continue_trace instead.
+    #
     # Initalizes a Transaction instance with a Sentry trace string from another transaction (usually from an external request).
     #
     # The original transaction will become the parent of the new Transaction instance. And they will share the same `trace_id`.
@@ -132,18 +131,10 @@ module Sentry
       )
     end
 
-    # Extract the trace_id, parent_span_id and parent_sampled values from a sentry-trace header.
-    #
-    # @param sentry_trace [String] the sentry-trace header value from the previous transaction.
+    # @deprecated Use Sentry::PropagationContext.extract_sentry_trace instead.
     # @return [Array, nil]
     def self.extract_sentry_trace(sentry_trace)
-      match = SENTRY_TRACE_REGEXP.match(sentry_trace)
-      return nil if match.nil?
-
-      trace_id, parent_span_id, sampled_flag = match[1..3]
-      parent_sampled = sampled_flag.nil? ? nil : sampled_flag != "0"
-
-      [trace_id, parent_span_id, parent_sampled]
+      PropagationContext.extract_sentry_trace(sentry_trace)
     end
 
     # @return [Hash]

--- a/sentry-ruby/lib/sentry/transaction_event.rb
+++ b/sentry-ruby/lib/sentry/transaction_event.rb
@@ -8,9 +8,6 @@ module Sentry
     # @return [<Array[Span]>]
     attr_accessor :spans
 
-    # @return [Hash, nil]
-    attr_accessor :dynamic_sampling_context
-
     # @return [Hash]
     attr_accessor :measurements
 

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Sentry::Event do
       expect(event.environment).to eq("test")
       expect(event.release).to eq("721e41770371db95eee98ca2707686226b993eda")
       expect(event.sdk).to eq("name" => "sentry.ruby", "version" => Sentry::VERSION)
+      expect(event.dynamic_sampling_context).to eq(nil)
     end
   end
 

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -97,9 +97,6 @@ RSpec.describe Sentry::Net::HTTP do
       response = http.request(request)
 
       expect(response.code).to eq("200")
-      expect(string_io.string).to match(
-        /\[Tracing\] Adding sentry-trace header to outgoing request:/
-      )
     end
 
     it "adds baggage header to the request header as head SDK when no incoming trace" do
@@ -115,10 +112,6 @@ RSpec.describe Sentry::Net::HTTP do
       response = http.request(request)
 
       expect(response.code).to eq("200")
-      expect(string_io.string).to match(
-        /\[Tracing\] Adding baggage header to outgoing request:/
-      )
-
       request_span = transaction.span_recorder.spans.last
       expect(request["baggage"]).to eq(request_span.to_baggage)
       expect(request["baggage"]).to eq(
@@ -151,10 +144,6 @@ RSpec.describe Sentry::Net::HTTP do
       response = http.request(request)
 
       expect(response.code).to eq("200")
-      expect(string_io.string).to match(
-        /\[Tracing\] Adding baggage header to outgoing request:/
-      )
-
       request_span = transaction.span_recorder.spans.last
       expect(request["baggage"]).to eq(request_span.to_baggage)
       expect(request["baggage"]).to eq(
@@ -165,7 +154,7 @@ RSpec.describe Sentry::Net::HTTP do
       )
     end
 
-    context "with config.propagate_trace = false" do
+    context "with config.propagate_traces = false" do
       before do
         Sentry.configuration.propagate_traces = false
       end
@@ -183,9 +172,6 @@ RSpec.describe Sentry::Net::HTTP do
         response = http.request(request)
 
         expect(response.code).to eq("200")
-        expect(string_io.string).not_to match(
-          /Adding sentry-trace header to outgoing request:/
-        )
         expect(request.key?("sentry-trace")).to eq(false)
       end
 
@@ -210,9 +196,6 @@ RSpec.describe Sentry::Net::HTTP do
         response = http.request(request)
 
         expect(response.code).to eq("200")
-        expect(string_io.string).not_to match(
-          /Adding baggage header to outgoing request:/
-        )
         expect(request.key?("baggage")).to eq(false)
       end
     end

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Sentry::Net::HTTP do
         "sentry-user_id=Am%C3%A9lie,  "\
         "other-vendor-value-2=foo;bar;"
 
-      transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, baggage: baggage)
+      transaction = Sentry.continue_trace({ "sentry-trace" => sentry_trace, "baggage" => baggage })
       Sentry.get_current_scope.set_span(transaction)
 
       response = http.request(request)
@@ -190,7 +190,7 @@ RSpec.describe Sentry::Net::HTTP do
           "sentry-user_id=Am%C3%A9lie,  "\
           "other-vendor-value-2=foo;bar;"
 
-        transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, baggage: baggage)
+        transaction = Sentry.continue_trace({ "sentry-trace" => sentry_trace, "baggage" => baggage })
         Sentry.get_current_scope.set_span(transaction)
 
         response = http.request(request)

--- a/sentry-ruby/spec/sentry/propagation_context_spec.rb
+++ b/sentry-ruby/spec/sentry/propagation_context_spec.rb
@@ -110,7 +110,6 @@ RSpec.describe Sentry::PropagationContext do
       perform_basic_setup do |config|
         config.environment = "test"
         config.release = "foobar"
-        config.traces_sample_rate = 0.5
       end
     end
 
@@ -120,7 +119,6 @@ RSpec.describe Sentry::PropagationContext do
       expect(baggage.mutable).to eq(false)
       expect(baggage.items).to eq({
         "trace_id" => subject.trace_id,
-        "sample_rate" => "0.5",
         "environment" => "test",
         "release" => "foobar",
         "public_key" => Sentry.configuration.dsn.public_key

--- a/sentry-ruby/spec/sentry/propagation_context_spec.rb
+++ b/sentry-ruby/spec/sentry/propagation_context_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+
+RSpec.describe Sentry::PropagationContext do
+  before do
+    perform_basic_setup
+  end
+
+  let(:scope) { Sentry.get_current_scope }
+  let(:subject) { described_class.new(scope) }
+
+  describe "#initialize" do
+    it "generates correct attributes" do
+      expect(subject.trace_id.length).to eq(32)
+      expect(subject.span_id.length).to eq(16)
+      expect(subject.parent_span_id).to be_nil
+    end
+  end
+
+  describe "#get_trace_context" do
+    it "generates correct trace context" do
+      expect(subject.get_trace_context).to eq({
+        trace_id: subject.trace_id,
+        span_id: subject.span_id,
+        parent_span_id: subject.parent_span_id
+      })
+    end
+  end
+
+  describe "#get_traceparent" do
+    it "generates correct traceparent" do
+      expect(subject.get_traceparent).to eq("#{subject.trace_id}-#{subject.span_id}")
+    end
+  end
+
+  describe "#get_baggage" do
+    before do
+      perform_basic_setup do |config|
+        config.environment = "test"
+        config.release = "foobar"
+        config.traces_sample_rate = 0.5
+      end
+    end
+
+    it "populates head baggage" do
+      baggage = subject.get_baggage
+
+      expect(baggage.mutable).to eq(false)
+      expect(baggage.items).to eq({
+        "trace_id" => subject.trace_id,
+        "sample_rate" => "0.5",
+        "environment" => "test",
+        "release" => "foobar",
+        "public_key" => Sentry.configuration.dsn.public_key
+      })
+    end
+  end
+
+  describe "#get_dynamic_sampling_context" do
+    it "generates DSC from baggage" do
+      expect(subject.get_dynamic_sampling_context).to eq(subject.get_baggage.dynamic_sampling_context)
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/propagation_context_spec.rb
+++ b/sentry-ruby/spec/sentry/propagation_context_spec.rb
@@ -9,10 +9,83 @@ RSpec.describe Sentry::PropagationContext do
   let(:subject) { described_class.new(scope) }
 
   describe "#initialize" do
-    it "generates correct attributes" do
+    it "generates correct attributes without env" do
       expect(subject.trace_id.length).to eq(32)
       expect(subject.span_id.length).to eq(16)
       expect(subject.parent_span_id).to be_nil
+      expect(subject.parent_sampled).to be_nil
+      expect(subject.baggage).to be_nil
+      expect(subject.incoming_trace).to eq(false)
+    end
+
+    it "generates correct attributes when incoming sentry-trace and baggage" do
+      env = {
+        "sentry-trace" => "771a43a4192642f0b136d5159a501700-7c51afd529da4a2a",
+        "baggage" => "other-vendor-value-1=foo;bar;baz, "\
+                      "sentry-trace_id=771a43a4192642f0b136d5159a501700, "\
+                      "sentry-public_key=49d0f7386ad645858ae85020e393bef3, "\
+                      "sentry-sample_rate=0.01337, "\
+                      "sentry-user_id=Am%C3%A9lie,  "\
+                      "other-vendor-value-2=foo;bar;"
+      }
+
+      subject = described_class.new(scope, env)
+      expect(subject.trace_id).to eq("771a43a4192642f0b136d5159a501700")
+      expect(subject.span_id.length).to eq(16)
+      expect(subject.parent_span_id).to eq("7c51afd529da4a2a")
+      expect(subject.parent_sampled).to eq(nil)
+      expect(subject.incoming_trace).to eq(true)
+      expect(subject.baggage).to be_a(Sentry::Baggage)
+      expect(subject.baggage.mutable).to eq(false)
+      expect(subject.baggage.items).to eq({
+        "public_key"=>"49d0f7386ad645858ae85020e393bef3",
+        "sample_rate"=>"0.01337",
+        "trace_id"=>"771a43a4192642f0b136d5159a501700",
+        "user_id"=>"Amélie"
+      })
+    end
+
+    it "generates correct attributes when incoming HTTP_SENTRY_TRACE and HTTP_BAGGAGE" do
+      env = {
+        "HTTP_SENTRY_TRACE" => "771a43a4192642f0b136d5159a501700-7c51afd529da4a2a",
+        "HTTP_BAGGAGE" => "other-vendor-value-1=foo;bar;baz, "\
+                      "sentry-trace_id=771a43a4192642f0b136d5159a501700, "\
+                      "sentry-public_key=49d0f7386ad645858ae85020e393bef3, "\
+                      "sentry-sample_rate=0.01337, "\
+                      "sentry-user_id=Am%C3%A9lie,  "\
+                      "other-vendor-value-2=foo;bar;"
+      }
+
+      subject = described_class.new(scope, env)
+      expect(subject.trace_id).to eq("771a43a4192642f0b136d5159a501700")
+      expect(subject.span_id.length).to eq(16)
+      expect(subject.parent_span_id).to eq("7c51afd529da4a2a")
+      expect(subject.parent_sampled).to eq(nil)
+      expect(subject.incoming_trace).to eq(true)
+      expect(subject.baggage).to be_a(Sentry::Baggage)
+      expect(subject.baggage.mutable).to eq(false)
+      expect(subject.baggage.items).to eq({
+        "public_key"=>"49d0f7386ad645858ae85020e393bef3",
+        "sample_rate"=>"0.01337",
+        "trace_id"=>"771a43a4192642f0b136d5159a501700",
+        "user_id"=>"Amélie"
+      })
+    end
+
+    it "generates correct attributes when incoming sentry-trace only (from older SDKs)" do
+      env = {
+        "sentry-trace" => "771a43a4192642f0b136d5159a501700-7c51afd529da4a2a"
+      }
+
+      subject = described_class.new(scope, env)
+      expect(subject.trace_id).to eq("771a43a4192642f0b136d5159a501700")
+      expect(subject.span_id.length).to eq(16)
+      expect(subject.parent_span_id).to eq("7c51afd529da4a2a")
+      expect(subject.parent_sampled).to eq(nil)
+      expect(subject.incoming_trace).to eq(true)
+      expect(subject.baggage).to be_a(Sentry::Baggage)
+      expect(subject.baggage.mutable).to eq(false)
+      expect(subject.baggage.items).to eq({})
     end
   end
 

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -579,6 +579,8 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
       described_class.new(app)
     end
 
+    before { perform_basic_setup }
+
     it "captures exception with correct DSC and trace context" do
       expect { stack.call(env) }.to raise_error(ZeroDivisionError)
 

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -311,4 +311,17 @@ RSpec.describe Sentry::Scope do
       end
     end
   end
+
+  describe "#generate_propagation_context" do
+    it "initializes new propagation context without env" do
+      expect(Sentry::PropagationContext).to receive(:new).with(subject, nil)
+      subject.generate_propagation_context
+    end
+
+    it "initializes new propagation context without env" do
+      env = { foo: 42 }
+      expect(Sentry::PropagationContext).to receive(:new).with(subject, env)
+      subject.generate_propagation_context(env)
+    end
+  end
 end

--- a/sentry-ruby/spec/sentry/span_spec.rb
+++ b/sentry-ruby/spec/sentry/span_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Sentry::Span do
       sentry_trace = subject.to_sentry_trace
 
       expect(sentry_trace).to eq("#{subject.trace_id}-#{subject.span_id}-1")
-      expect(sentry_trace).to match(Sentry::Transaction::SENTRY_TRACE_REGEXP)
+      expect(sentry_trace).to match(Sentry::PropagationContext::SENTRY_TRACE_REGEXP)
     end
 
     context "without sampled value" do
@@ -87,7 +87,7 @@ RSpec.describe Sentry::Span do
         sentry_trace = subject.to_sentry_trace
 
         expect(sentry_trace).to eq("#{subject.trace_id}-#{subject.span_id}-")
-        expect(sentry_trace).to match(Sentry::Transaction::SENTRY_TRACE_REGEXP)
+        expect(sentry_trace).to match(Sentry::PropagationContext::SENTRY_TRACE_REGEXP)
       end
     end
   end

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -331,18 +331,18 @@ RSpec.describe Sentry do
         unsampled_trace = "d298e6b033f84659928a2267c3879aaa-2a35b8e9a1b974f4-0"
         not_sampled_trace = "d298e6b033f84659928a2267c3879aaa-2a35b8e9a1b974f4-"
 
-        transaction = Sentry::Transaction.from_sentry_trace(sampled_trace, op: "rack.request", name: "/payment")
+        transaction = Sentry.continue_trace({ "sentry-trace" => sampled_trace }, op: "rack.request", name: "/payment")
         described_class.start_transaction(transaction: transaction)
 
         expect(transaction.sampled).to eq(true)
 
-        transaction = Sentry::Transaction.from_sentry_trace(unsampled_trace, op: "rack.request", name: "/payment")
+        transaction = Sentry.continue_trace({ "sentry-trace" => unsampled_trace }, op: "rack.request", name: "/payment")
         described_class.start_transaction(transaction: transaction)
 
         expect(transaction.sampled).to eq(false)
 
         allow(Random).to receive(:rand).and_return(0.4)
-        transaction = Sentry::Transaction.from_sentry_trace(not_sampled_trace, op: "rack.request", name: "/payment")
+        transaction = Sentry.continue_trace({ "sentry-trace" => not_sampled_trace }, op: "rack.request", name: "/payment")
         described_class.start_transaction(transaction: transaction)
 
         expect(transaction.sampled).to eq(true)
@@ -672,7 +672,7 @@ RSpec.describe Sentry do
       traceparent = described_class.get_traceparent
       propagation_context = described_class.get_current_scope.propagation_context
 
-      expect(traceparent).to match(Sentry::Transaction::SENTRY_TRACE_REGEXP)
+      expect(traceparent).to match(Sentry::PropagationContext::SENTRY_TRACE_REGEXP)
       expect(traceparent).to eq("#{propagation_context.trace_id}-#{propagation_context.span_id}")
     end
 
@@ -683,7 +683,7 @@ RSpec.describe Sentry do
 
       traceparent = described_class.get_traceparent
 
-      expect(traceparent).to match(Sentry::Transaction::SENTRY_TRACE_REGEXP)
+      expect(traceparent).to match(Sentry::PropagationContext::SENTRY_TRACE_REGEXP)
       expect(traceparent).to eq("#{span.trace_id}-#{span.span_id}-1")
     end
   end
@@ -713,6 +713,69 @@ RSpec.describe Sentry do
         "sentry-trace" => described_class.get_traceparent,
         "baggage" => described_class.get_baggage
       })
+    end
+  end
+
+  describe ".continue_trace" do
+
+    context "without incoming sentry trace" do
+      let(:env) { { "HTTP_FOO" => "bar" } }
+
+      it "returns nil with tracing disabled" do
+        expect(described_class.continue_trace(env)).to eq(nil)
+      end
+
+      it "returns nil with tracing enabled" do
+        Sentry.configuration.traces_sample_rate = 1.0
+        expect(described_class.continue_trace(env)).to eq(nil)
+      end
+
+      it "sets new propagation context on scope" do
+        expect(Sentry.get_current_scope).to receive(:generate_propagation_context).and_call_original
+        described_class.continue_trace(env)
+
+        propagation_context = Sentry.get_current_scope.propagation_context
+        expect(propagation_context.incoming_trace).to eq(false)
+      end
+    end
+
+    context "with incoming sentry trace" do
+      let(:incoming_prop_context) { Sentry::PropagationContext.new(Sentry::Scope.new) }
+      let(:env) do
+        {
+          "HTTP_SENTRY_TRACE" => incoming_prop_context.get_traceparent,
+          "HTTP_BAGGAGE" => incoming_prop_context.get_baggage.serialize
+        }
+      end
+
+      it "returns nil with tracing disabled" do
+        expect(described_class.continue_trace(env)).to eq(nil)
+      end
+
+      it "sets new propagation context from env on scope" do
+        expect(Sentry.get_current_scope).to receive(:generate_propagation_context).and_call_original
+        described_class.continue_trace(env)
+
+        propagation_context = Sentry.get_current_scope.propagation_context
+        expect(propagation_context.incoming_trace).to eq(true)
+        expect(propagation_context.trace_id).to eq(incoming_prop_context.trace_id)
+        expect(propagation_context.parent_span_id).to eq(incoming_prop_context.span_id)
+        expect(propagation_context.parent_sampled).to eq(nil)
+        expect(propagation_context.baggage.items).to eq(incoming_prop_context.get_baggage.items)
+        expect(propagation_context.baggage.mutable).to eq(false)
+      end
+
+      it "returns new Transaction with tracing enabled" do
+        Sentry.configuration.traces_sample_rate = 1.0
+
+        transaction = described_class.continue_trace(env, name: "foobar")
+        expect(transaction).to be_a(Sentry::Transaction)
+        expect(transaction.name).to eq("foobar")
+        expect(transaction.trace_id).to eq(incoming_prop_context.trace_id)
+        expect(transaction.parent_span_id).to eq(incoming_prop_context.span_id)
+        expect(transaction.baggage.items).to eq(incoming_prop_context.get_baggage.items)
+        expect(transaction.baggage.mutable).to eq(false)
+      end
     end
   end
 

--- a/sentry-sidekiq/lib/sentry/sidekiq/sentry_context_middleware.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/sentry_context_middleware.rb
@@ -19,7 +19,7 @@ module Sentry
         scope.set_tags(build_tags(job["tags"]))
         scope.set_contexts(sidekiq: job.merge("queue" => queue))
         scope.set_transaction_name(context_filter.transaction_name, source: :task)
-        transaction = start_transaction(scope, job["sentry_trace"])
+        transaction = start_transaction(scope, job["trace_propagation_headers"])
         scope.set_span(transaction) if transaction
 
         begin
@@ -39,9 +39,9 @@ module Sentry
         Array(tags).each_with_object({}) { |name, tags_hash| tags_hash[:"sidekiq.#{name}"] = true }
       end
 
-      def start_transaction(scope, sentry_trace)
+      def start_transaction(scope, env)
         options = { name: scope.transaction_name, source: scope.transaction_source, op: OP_NAME }
-        transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, **options) if sentry_trace
+        transaction = Sentry.continue_trace(env, **options)
         Sentry.start_transaction(transaction: transaction, **options)
       end
 
@@ -58,9 +58,8 @@ module Sentry
         return yield unless Sentry.initialized?
 
         user = Sentry.get_current_scope.user
-        transaction = Sentry.get_current_scope.get_transaction
         job["sentry_user"] = user unless user.empty?
-        job["sentry_trace"] = transaction.to_sentry_trace if transaction
+        job["trace_propagation_headers"] = Sentry.get_trace_propagation_headers
         yield
       end
     end


### PR DESCRIPTION
This PR is 1/2 to enable **Tracing without Performance**, i.e. make sure all our events are connected even if they are not Transactions.

This enables use cases such as Errors / Transactions / Replays etc all being connected across services and not just Transactions.

### Summary of changes

* new `PropagationContext` class that generates trace/span ids and baggage irrespective of whether there are transactions/spans active or not
* this lives on the `Scope`
* three new top level methods that first check the span and fallback on the scope's propagation context
  * `Sentry.get_traceparent`
  * `Sentry.get_baggage`
  * `Sentry.get_trace_propagation_headers`
* move `dynamic_sampling_context` to `Event` from `TransactionEvent` since all events will now have this info
* use the new top level helpers in `net/http` patch to set propagation headers

closes #2056 
also see #2089 