### PR TITLE
Duplicate `Rails.logger` before assigning it to the SDK

### DIFF
--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -12,7 +12,7 @@ module Sentry
       @excluded_exceptions = @excluded_exceptions.concat(Sentry::Rails::IGNORE_DEFAULT)
 
       if ::Rails.logger
-        @logger = ::Rails.logger
+        @logger = ::Rails.logger.dup
       else
         @logger.warn(Sentry::LOGGER_PROGNAME) do
           <<~MSG

--- a/sentry-rails/spec/dummy/test_rails_app/app.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/app.rb
@@ -53,7 +53,7 @@ def make_basic_app(&block)
   app.config.action_controller.view_paths = "spec/dummy/test_rails_app"
   app.config.hosts = nil
   app.config.secret_key_base = "test"
-  app.config.logger = Logger.new(nil)
+  app.config.logger = ActiveSupport::Logger.new(nil)
   app.config.eager_load = true
   app.config.active_job.queue_adapter = :test
 

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -35,8 +35,12 @@ RSpec.describe Sentry::Rails, type: :request do
     end
 
     describe "logger detection" do
-      it "sets Sentry.configuration.logger correctly" do
-        expect(Sentry.configuration.logger).to eq(Rails.logger)
+      it "sets a duplicated Rails logger as the SDK's logger" do
+        expect(Sentry.configuration.logger).to be_a(ActiveSupport::Logger)
+        Sentry.configuration.logger.level = ::Logger::WARN
+        # Configuring the SDK's logger should not affect the Rails logger
+        expect(Rails.logger.level).to eq(::Logger::DEBUG)
+        expect(Sentry.configuration.logger.level).to eq(::Logger::WARN)
       end
 
       it "respects the logger set by user" do


### PR DESCRIPTION
I discovered this while investigating #2031: If we don't duplicate `Rails.logger`, configurations made to the SDK's logger will be applied to the Rails logger as well.

For example, in an Rails app:

```rb
Sentry.init do |config|
  config.logger.level = Logger::WARN
end
```

Will make the Rails logger's level to be `Logger::WARN` too. I think most users wouldn't expect this and will find it confusing.
