### PR TITLE
Add option to notify Sentry only after the last retry on resque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Record client reports for profiles [#2107](https://github.com/getsentry/sentry-ruby/pull/2107)
 - Adopt Rails 7.1's new BroadcastLogger [#2120](https://github.com/getsentry/sentry-ruby/pull/2120)
+- Support sending events after all retries were performed (sentry-resque) [#2087](https://github.com/getsentry/sentry-ruby/pull/2087)
 - Add [Cron Monitoring](https://docs.sentry.io/product/crons/) support
   - Add `Sentry.capture_check_in` API for Cron Monitoring [#2117](https://github.com/getsentry/sentry-ruby/pull/2117)
 

--- a/sentry-resque/Gemfile
+++ b/sentry-resque/Gemfile
@@ -14,6 +14,8 @@ gem 'simplecov'
 gem "simplecov-cobertura", "~> 1.4"
 gem "rexml"
 
+gem "resque-retry", "~> 1.8"
+
 if RUBY_VERSION.to_f >= 2.6
   gem "debug", github: "ruby/debug", platform: :ruby
   gem "irb"

--- a/sentry-resque/lib/sentry/resque.rb
+++ b/sentry-resque/lib/sentry/resque.rb
@@ -34,13 +34,11 @@ module Sentry
             rescue Exception => exception
               klass = payload['class'].constantize
 
-              if Sentry.configuration.resque.report_after_job_retries && defined?(::Resque::Plugins::Retry) == 'constant' && klass.is_a?(::Resque::Plugins::Retry)
-                retry_key = klass.redis_retry_key(payload['args'])
-                retry_attempt = ::Resque.redis.get(retry_key)
+              raise if Sentry.configuration.resque.report_after_job_retries &&
+                       defined?(::Resque::Plugins::Retry) == 'constant' &&
+                       klass.is_a?(::Resque::Plugins::Retry) &&
+                       !klass.retry_limit_reached?
 
-                # If retry_attempt is nil, it means the resque-retry has already called the #clean_retry_key no retries are left
-                raise unless retry_attempt.nil?
-              end
               ::Sentry::Resque.capture_exception(exception, hint: { background: false })
               finish_transaction(transaction, 500)
               raise

--- a/sentry-resque/sentry-resque.gemspec
+++ b/sentry-resque/sentry-resque.gemspec
@@ -24,6 +24,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "sentry-ruby", "~> 5.11.0"
   spec.add_dependency "resque", ">= 1.24"
-
-  spec.add_development_dependency "resque-retry", "~> 1.8"
 end

--- a/sentry-resque/sentry-resque.gemspec
+++ b/sentry-resque/sentry-resque.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "sentry-ruby", "~> 5.11.0"
   spec.add_dependency "resque", ">= 1.24"
+
+  spec.add_development_dependency "resque-retry", "~> 1.8"
 end

--- a/sentry-resque/spec/sentry/resque_spec.rb
+++ b/sentry-resque/spec/sentry/resque_spec.rb
@@ -7,7 +7,6 @@ end
 RSpec.describe Sentry::Resque do
   before do
     perform_basic_setup
-    Resque.redis.flushall
   end
 
   class FailedJob

--- a/sentry-resque/spec/sentry/resque_spec.rb
+++ b/sentry-resque/spec/sentry/resque_spec.rb
@@ -7,12 +7,28 @@ end
 RSpec.describe Sentry::Resque do
   before do
     perform_basic_setup
+    Resque.redis.flushall
   end
 
   class FailedJob
     def self.perform
       1/0
     end
+  end
+
+  class FailedRetriableJob
+    extend Resque::Plugins::Retry
+
+    @queue = :default
+    @retry_limit = 3
+
+    def self.perform
+      1/0
+    end
+  end
+
+  class FailedZeroRetriesJob < FailedRetriableJob
+    @retry_limit = 0
   end
 
   class TaggedFailedJob
@@ -122,6 +138,74 @@ RSpec.describe Sentry::Resque do
       expect(event[:tags]).to eq({ "resque.queue" => "default" })
       expect(Sentry.get_current_scope.extra).to eq({})
       expect(Sentry.get_current_scope.tags).to eq({})
+    end
+  end
+
+  context "with ResqueRetry" do
+    context "when report_after_job_retries is true" do
+      before do
+        Sentry.configuration.resque.report_after_job_retries = true
+      end
+
+      it "reports exception only on the last run" do
+        expect do
+          Resque::Job.create(:default, FailedRetriableJob)
+          process_job(worker)
+        end.to change { Resque::Stat.get("failed") }.by(1)
+           .and change { transport.events.count }.by(0)
+
+        expect do
+          3.times do
+            process_job(worker)
+          end
+        end.to change { transport.events.count }.by(1)
+
+        event = transport.events.last.to_hash
+
+        expect(event[:sdk]).to eq({ name: "sentry.ruby.resque", version: described_class::VERSION })
+        expect(event.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
+        expect(event[:tags]).to eq({ "resque.queue" => "default" })
+      end
+
+      it "reports exception on first run when retry_count is 0" do
+        expect do
+          Resque::Job.create(:default, FailedZeroRetriesJob)
+          process_job(worker)
+        end.to change { Resque::Stat.get("failed") }.by(1)
+           .and change { transport.events.count }.by(1)
+
+        event = transport.events.last.to_hash
+
+        expect(event[:sdk]).to eq({ name: "sentry.ruby.resque", version: described_class::VERSION })
+        expect(event.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
+        expect(event[:tags]).to eq({ "resque.queue" => "default" })
+      end
+    end
+
+    context "when report_after_job_retries is false" do
+      before do
+        Sentry.configuration.resque.report_after_job_retries = false
+      end
+
+      it "reports exeception all the runs" do
+        expect do
+          Resque::Job.create(:default, FailedRetriableJob)
+          process_job(worker)
+        end.to change { Resque::Stat.get("failed") }.by(1)
+           .and change { transport.events.count }.by(1)
+
+        expect do
+          3.times do
+            process_job(worker)
+          end
+        end.to change { transport.events.count }.by(3)
+
+        event = transport.events.last.to_hash
+
+        expect(event[:sdk]).to eq({ name: "sentry.ruby.resque", version: described_class::VERSION })
+        expect(event.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
+        expect(event[:tags]).to eq({ "resque.queue" => "default" })
+      end
     end
   end
 

--- a/sentry-resque/spec/spec_helper.rb
+++ b/sentry-resque/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require "pry"
 require "debug" if RUBY_VERSION.to_f >= 2.6 && RUBY_ENGINE == "ruby"
 
 require "resque"
+require "resque-retry"
 
 # To workaround https://github.com/steveklabnik/mono_logger/issues/13
 # Note: mono_logger is resque's default logger


### PR DESCRIPTION
`sentry-sidekiq` and `sentry-delayed_job` have the option to report the failure only after the retry process has finished.

With `sentry-resque` we can do the same when using the `resque-retry` gem. The implementation is not as clean as `Sidekiq` and `DelayedJob`, which expose the attempts in a better way, but still, I was able to make it work.
I noticed the configuration option was there but not implemented. I added a conditional inside the exception block to check if the job is an instance of `Resque::Plugins::Retry` and if so, it checks the retry key.

An odd behavior: `resque-retry` cleans the key on the last try, before being caught on the exception block. Thus, when the key no longer exists on Redis, it means the retries were exhausted.

I understand this change implies using the `resque-retry` gem, but I'm unaware of a similar gem widely used as `resque-retry`.