### PR TITLE
Tracing without performance: new continue_trace api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   ```
 - Tracing without Performance
   - Implement `PropagationContext` on `Scope` and add `Sentry.get_trace_propagation_headers` API [#2084](https://github.com/getsentry/sentry-ruby/pull/2084)
+  - Implement `Sentry.continue_trace` API [#2089](https://github.com/getsentry/sentry-ruby/pull/2089)
 
   The SDK now supports connecting arbitrary events (Errors / Transactions / Replays) across distributed services and not just Transactions.  
   To continue an incoming trace starting with this version of the SDK, use `Sentry.continue_trace` as follows.

--- a/sentry-rails/lib/sentry/rails/action_cable.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable.rb
@@ -33,11 +33,8 @@ module Sentry
           end
 
           def start_transaction(env, scope)
-            sentry_trace = env["HTTP_SENTRY_TRACE"]
-            baggage = env["HTTP_BAGGAGE"]
-
             options = { name: scope.transaction_name, source: scope.transaction_source, op: OP_NAME }
-            transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, baggage: baggage, **options) if sentry_trace
+            transaction = Sentry.continue_trace(env, **options)
             Sentry.start_transaction(transaction: transaction, **options)
           end
 

--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -32,16 +32,13 @@ module Sentry
       end
 
       def start_transaction(env, scope)
-        sentry_trace = env["HTTP_SENTRY_TRACE"]
-        baggage = env["HTTP_BAGGAGE"]
-
         options = { name: scope.transaction_name, source: scope.transaction_source, op: transaction_op }
 
         if @assets_regexp && scope.transaction_name.match?(@assets_regexp)
           options.merge!(sampled: false)
         end
 
-        transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, baggage: baggage, **options) if sentry_trace
+        transaction = Sentry.continue_trace(env, **options)
         Sentry.start_transaction(transaction: transaction, custom_sampling_context: { env: env }, **options)
       end
 

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -516,6 +516,15 @@ module Sentry
       get_current_hub.get_trace_propagation_headers
     end
 
+    # Continue an incoming trace from a rack env like hash.
+    #
+    # @param env [Hash]
+    # @return [Transaction, nil]
+    def continue_trace(env, **options)
+      return nil unless initialized?
+      get_current_hub.continue_trace(env, **options)
+    end
+
     ##### Helpers #####
 
     # @!visibility private

--- a/sentry-ruby/lib/sentry/propagation_context.rb
+++ b/sentry-ruby/lib/sentry/propagation_context.rb
@@ -20,23 +20,35 @@ module Sentry
     # @return [String]
     attr_reader :span_id
     # Span parent's span_id.
-    # @return [String]
+    # @return [String, nil]
     attr_reader :parent_span_id
+    # The sampling decision of the parent transaction.
+    # @return [Boolean, nil]
+    attr_reader :parent_sampled
+    # Is there an incoming trace or not?
+    # @return [Boolean]
+    attr_reader :incoming_trace
+    # This is only for accessing the current baggage variable.
+    # Please use the #get_baggage method for interfacing outside this class.
+    # @return [Baggage, nil]
+    attr_reader :baggage
 
     def initialize(scope, env = nil)
       @scope = scope
       @parent_span_id = nil
+      @parent_sampled = nil
       @baggage = nil
+      @incoming_trace = false
 
       if env
         sentry_trace_header = env["HTTP_SENTRY_TRACE"]
         baggage_header = env["HTTP_BAGGAGE"]
 
         if sentry_trace_header
-          sentry_trace_data = extract_sentry_trace(sentry_trace_header)
+          sentry_trace_data = self.class.extract_sentry_trace(sentry_trace_header)
 
           if sentry_trace_data
-            @trace_id, @parent_span_id, _ = sentry_trace_data
+            @trace_id, @parent_span_id, @parent_sampled = sentry_trace_data
 
             @baggage = if baggage_header && !baggage_header.empty?
                         Baggage.from_incoming_header(baggage_header)
@@ -48,6 +60,7 @@ module Sentry
                       end
 
             @baggage.freeze!
+            @incoming_trace = true
           end
         end
       end
@@ -70,7 +83,6 @@ module Sentry
       [trace_id, parent_span_id, parent_sampled]
     end
 
-
     # Returns the trace context that can be used to embed in an Event.
     # @return [Hash]
     def get_trace_context
@@ -87,7 +99,7 @@ module Sentry
       "#{trace_id}-#{span_id}"
     end
 
-    # Returns the Baggage from the propagation context.
+    # Returns the Baggage from the propagation context or populates as head SDK if empty.
     # @return [Baggage, nil]
     def get_baggage
       populate_head_baggage if @baggage.nil? || @baggage.mutable

--- a/sentry-ruby/lib/sentry/propagation_context.rb
+++ b/sentry-ruby/lib/sentry/propagation_context.rb
@@ -41,8 +41,8 @@ module Sentry
       @incoming_trace = false
 
       if env
-        sentry_trace_header = env["HTTP_SENTRY_TRACE"]
-        baggage_header = env["HTTP_BAGGAGE"]
+        sentry_trace_header = env["HTTP_SENTRY_TRACE"] || env[SENTRY_TRACE_HEADER_NAME]
+        baggage_header = env["HTTP_BAGGAGE"] || env[BAGGAGE_HEADER_NAME]
 
         if sentry_trace_header
           sentry_trace_data = self.class.extract_sentry_trace(sentry_trace_header)

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -62,11 +62,8 @@ module Sentry
       end
 
       def start_transaction(env, scope)
-        sentry_trace = env["HTTP_SENTRY_TRACE"]
-        baggage = env["HTTP_BAGGAGE"]
-
         options = { name: scope.transaction_name, source: scope.transaction_source, op: transaction_op }
-        transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, baggage: baggage, **options) if sentry_trace
+        transaction = Sentry.continue_trace(env, **options)
         Sentry.start_transaction(transaction: transaction, custom_sampling_context: { env: env }, **options)
       end
 

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -279,6 +279,13 @@ module Sentry
       @event_processors << block
     end
 
+    # Generate a new propagation context either from the incoming env headers or from scratch.
+    # @param env [Hash, nil]
+    # @return [void]
+    def generate_propagation_context(env = nil)
+      @propagation_context = PropagationContext.new(self, env)
+    end
+
     protected
 
     # for duplicating scopes internally
@@ -305,10 +312,6 @@ module Sentry
 
     def set_new_breadcrumb_buffer
       @breadcrumbs = BreadcrumbBuffer.new(@max_breadcrumbs)
-    end
-
-    def generate_propagation_context
-      @propagation_context = PropagationContext.new(self)
     end
 
     class << self

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -2,16 +2,13 @@
 
 require "sentry/baggage"
 require "sentry/profiler"
+require "sentry/propagation_context"
 
 module Sentry
   class Transaction < Span
-    SENTRY_TRACE_REGEXP = Regexp.new(
-      "^[ \t]*" +  # whitespace
-      "([0-9a-f]{32})?" +  # trace_id
-      "-?([0-9a-f]{16})?" +  # span_id
-      "-?([01])?" +  # sampled
-      "[ \t]*$"  # whitespace
-    )
+    # @deprecated Use Sentry::PropagationContext::SENTRY_TRACE_REGEXP instead.
+    SENTRY_TRACE_REGEXP = PropagationContext::SENTRY_TRACE_REGEXP
+
     UNLABELD_NAME = "<unlabeled transaction>".freeze
     MESSAGE_PREFIX = "[Tracing]"
 
@@ -132,18 +129,10 @@ module Sentry
       )
     end
 
-    # Extract the trace_id, parent_span_id and parent_sampled values from a sentry-trace header.
-    #
-    # @param sentry_trace [String] the sentry-trace header value from the previous transaction.
+    # @deprecated Use Sentry::PropagationContext.extract_sentry_trace instead.
     # @return [Array, nil]
     def self.extract_sentry_trace(sentry_trace)
-      match = SENTRY_TRACE_REGEXP.match(sentry_trace)
-      return nil if match.nil?
-
-      trace_id, parent_span_id, sampled_flag = match[1..3]
-      parent_sampled = sampled_flag.nil? ? nil : sampled_flag != "0"
-
-      [trace_id, parent_span_id, parent_sampled]
+      PropagationContext.extract_sentry_trace(sentry_trace)
     end
 
     # @return [Hash]

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -89,6 +89,8 @@ module Sentry
       init_span_recorder
     end
 
+    # @deprecated use Sentry.continue_trace instead.
+    #
     # Initalizes a Transaction instance with a Sentry trace string from another transaction (usually from an external request).
     #
     # The original transaction will become the parent of the new Transaction instance. And they will share the same `trace_id`.

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Sentry::Net::HTTP do
         "sentry-user_id=Am%C3%A9lie,  "\
         "other-vendor-value-2=foo;bar;"
 
-      transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, baggage: baggage)
+      transaction = Sentry.continue_trace({ "sentry-trace" => sentry_trace, "baggage" => baggage })
       Sentry.get_current_scope.set_span(transaction)
 
       response = http.request(request)
@@ -190,7 +190,7 @@ RSpec.describe Sentry::Net::HTTP do
           "sentry-user_id=Am%C3%A9lie,  "\
           "other-vendor-value-2=foo;bar;"
 
-        transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, baggage: baggage)
+        transaction = Sentry.continue_trace({ "sentry-trace" => sentry_trace, "baggage" => baggage })
         Sentry.get_current_scope.set_span(transaction)
 
         response = http.request(request)

--- a/sentry-ruby/spec/sentry/propagation_context_spec.rb
+++ b/sentry-ruby/spec/sentry/propagation_context_spec.rb
@@ -9,10 +9,83 @@ RSpec.describe Sentry::PropagationContext do
   let(:subject) { described_class.new(scope) }
 
   describe "#initialize" do
-    it "generates correct attributes" do
+    it "generates correct attributes without env" do
       expect(subject.trace_id.length).to eq(32)
       expect(subject.span_id.length).to eq(16)
       expect(subject.parent_span_id).to be_nil
+      expect(subject.parent_sampled).to be_nil
+      expect(subject.baggage).to be_nil
+      expect(subject.incoming_trace).to eq(false)
+    end
+
+    it "generates correct attributes when incoming sentry-trace and baggage" do
+      env = {
+        "sentry-trace" => "771a43a4192642f0b136d5159a501700-7c51afd529da4a2a",
+        "baggage" => "other-vendor-value-1=foo;bar;baz, "\
+                      "sentry-trace_id=771a43a4192642f0b136d5159a501700, "\
+                      "sentry-public_key=49d0f7386ad645858ae85020e393bef3, "\
+                      "sentry-sample_rate=0.01337, "\
+                      "sentry-user_id=Am%C3%A9lie,  "\
+                      "other-vendor-value-2=foo;bar;"
+      }
+
+      subject = described_class.new(scope, env)
+      expect(subject.trace_id).to eq("771a43a4192642f0b136d5159a501700")
+      expect(subject.span_id.length).to eq(16)
+      expect(subject.parent_span_id).to eq("7c51afd529da4a2a")
+      expect(subject.parent_sampled).to eq(nil)
+      expect(subject.incoming_trace).to eq(true)
+      expect(subject.baggage).to be_a(Sentry::Baggage)
+      expect(subject.baggage.mutable).to eq(false)
+      expect(subject.baggage.items).to eq({
+        "public_key"=>"49d0f7386ad645858ae85020e393bef3",
+        "sample_rate"=>"0.01337",
+        "trace_id"=>"771a43a4192642f0b136d5159a501700",
+        "user_id"=>"Amélie"
+      })
+    end
+
+    it "generates correct attributes when incoming HTTP_SENTRY_TRACE and HTTP_BAGGAGE" do
+      env = {
+        "HTTP_SENTRY_TRACE" => "771a43a4192642f0b136d5159a501700-7c51afd529da4a2a",
+        "HTTP_BAGGAGE" => "other-vendor-value-1=foo;bar;baz, "\
+                      "sentry-trace_id=771a43a4192642f0b136d5159a501700, "\
+                      "sentry-public_key=49d0f7386ad645858ae85020e393bef3, "\
+                      "sentry-sample_rate=0.01337, "\
+                      "sentry-user_id=Am%C3%A9lie,  "\
+                      "other-vendor-value-2=foo;bar;"
+      }
+
+      subject = described_class.new(scope, env)
+      expect(subject.trace_id).to eq("771a43a4192642f0b136d5159a501700")
+      expect(subject.span_id.length).to eq(16)
+      expect(subject.parent_span_id).to eq("7c51afd529da4a2a")
+      expect(subject.parent_sampled).to eq(nil)
+      expect(subject.incoming_trace).to eq(true)
+      expect(subject.baggage).to be_a(Sentry::Baggage)
+      expect(subject.baggage.mutable).to eq(false)
+      expect(subject.baggage.items).to eq({
+        "public_key"=>"49d0f7386ad645858ae85020e393bef3",
+        "sample_rate"=>"0.01337",
+        "trace_id"=>"771a43a4192642f0b136d5159a501700",
+        "user_id"=>"Amélie"
+      })
+    end
+
+    it "generates correct attributes when incoming sentry-trace only (from older SDKs)" do
+      env = {
+        "sentry-trace" => "771a43a4192642f0b136d5159a501700-7c51afd529da4a2a"
+      }
+
+      subject = described_class.new(scope, env)
+      expect(subject.trace_id).to eq("771a43a4192642f0b136d5159a501700")
+      expect(subject.span_id.length).to eq(16)
+      expect(subject.parent_span_id).to eq("7c51afd529da4a2a")
+      expect(subject.parent_sampled).to eq(nil)
+      expect(subject.incoming_trace).to eq(true)
+      expect(subject.baggage).to be_a(Sentry::Baggage)
+      expect(subject.baggage.mutable).to eq(false)
+      expect(subject.baggage.items).to eq({})
     end
   end
 

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -311,4 +311,17 @@ RSpec.describe Sentry::Scope do
       end
     end
   end
+
+  describe "#generate_propagation_context" do
+    it "initializes new propagation context without env" do
+      expect(Sentry::PropagationContext).to receive(:new).with(subject, nil)
+      subject.generate_propagation_context
+    end
+
+    it "initializes new propagation context without env" do
+      env = { foo: 42 }
+      expect(Sentry::PropagationContext).to receive(:new).with(subject, env)
+      subject.generate_propagation_context(env)
+    end
+  end
 end

--- a/sentry-ruby/spec/sentry/span_spec.rb
+++ b/sentry-ruby/spec/sentry/span_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Sentry::Span do
       sentry_trace = subject.to_sentry_trace
 
       expect(sentry_trace).to eq("#{subject.trace_id}-#{subject.span_id}-1")
-      expect(sentry_trace).to match(Sentry::Transaction::SENTRY_TRACE_REGEXP)
+      expect(sentry_trace).to match(Sentry::PropagationContext::SENTRY_TRACE_REGEXP)
     end
 
     context "without sampled value" do
@@ -87,7 +87,7 @@ RSpec.describe Sentry::Span do
         sentry_trace = subject.to_sentry_trace
 
         expect(sentry_trace).to eq("#{subject.trace_id}-#{subject.span_id}-")
-        expect(sentry_trace).to match(Sentry::Transaction::SENTRY_TRACE_REGEXP)
+        expect(sentry_trace).to match(Sentry::PropagationContext::SENTRY_TRACE_REGEXP)
       end
     end
   end

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -331,18 +331,18 @@ RSpec.describe Sentry do
         unsampled_trace = "d298e6b033f84659928a2267c3879aaa-2a35b8e9a1b974f4-0"
         not_sampled_trace = "d298e6b033f84659928a2267c3879aaa-2a35b8e9a1b974f4-"
 
-        transaction = Sentry::Transaction.from_sentry_trace(sampled_trace, op: "rack.request", name: "/payment")
+        transaction = Sentry.continue_trace({ "sentry-trace" => sampled_trace }, op: "rack.request", name: "/payment")
         described_class.start_transaction(transaction: transaction)
 
         expect(transaction.sampled).to eq(true)
 
-        transaction = Sentry::Transaction.from_sentry_trace(unsampled_trace, op: "rack.request", name: "/payment")
+        transaction = Sentry.continue_trace({ "sentry-trace" => unsampled_trace }, op: "rack.request", name: "/payment")
         described_class.start_transaction(transaction: transaction)
 
         expect(transaction.sampled).to eq(false)
 
         allow(Random).to receive(:rand).and_return(0.4)
-        transaction = Sentry::Transaction.from_sentry_trace(not_sampled_trace, op: "rack.request", name: "/payment")
+        transaction = Sentry.continue_trace({ "sentry-trace" => not_sampled_trace }, op: "rack.request", name: "/payment")
         described_class.start_transaction(transaction: transaction)
 
         expect(transaction.sampled).to eq(true)
@@ -672,7 +672,7 @@ RSpec.describe Sentry do
       traceparent = described_class.get_traceparent
       propagation_context = described_class.get_current_scope.propagation_context
 
-      expect(traceparent).to match(Sentry::Transaction::SENTRY_TRACE_REGEXP)
+      expect(traceparent).to match(Sentry::PropagationContext::SENTRY_TRACE_REGEXP)
       expect(traceparent).to eq("#{propagation_context.trace_id}-#{propagation_context.span_id}")
     end
 
@@ -683,7 +683,7 @@ RSpec.describe Sentry do
 
       traceparent = described_class.get_traceparent
 
-      expect(traceparent).to match(Sentry::Transaction::SENTRY_TRACE_REGEXP)
+      expect(traceparent).to match(Sentry::PropagationContext::SENTRY_TRACE_REGEXP)
       expect(traceparent).to eq("#{span.trace_id}-#{span.span_id}-1")
     end
   end
@@ -713,6 +713,69 @@ RSpec.describe Sentry do
         "sentry-trace" => described_class.get_traceparent,
         "baggage" => described_class.get_baggage
       })
+    end
+  end
+
+  describe ".continue_trace" do
+
+    context "without incoming sentry trace" do
+      let(:env) { { "HTTP_FOO" => "bar" } }
+
+      it "returns nil with tracing disabled" do
+        expect(described_class.continue_trace(env)).to eq(nil)
+      end
+
+      it "returns nil with tracing enabled" do
+        Sentry.configuration.traces_sample_rate = 1.0
+        expect(described_class.continue_trace(env)).to eq(nil)
+      end
+
+      it "sets new propagation context on scope" do
+        expect(Sentry.get_current_scope).to receive(:generate_propagation_context).and_call_original
+        described_class.continue_trace(env)
+
+        propagation_context = Sentry.get_current_scope.propagation_context
+        expect(propagation_context.incoming_trace).to eq(false)
+      end
+    end
+
+    context "with incoming sentry trace" do
+      let(:incoming_prop_context) { Sentry::PropagationContext.new(Sentry::Scope.new) }
+      let(:env) do
+        {
+          "HTTP_SENTRY_TRACE" => incoming_prop_context.get_traceparent,
+          "HTTP_BAGGAGE" => incoming_prop_context.get_baggage.serialize
+        }
+      end
+
+      it "returns nil with tracing disabled" do
+        expect(described_class.continue_trace(env)).to eq(nil)
+      end
+
+      it "sets new propagation context from env on scope" do
+        expect(Sentry.get_current_scope).to receive(:generate_propagation_context).and_call_original
+        described_class.continue_trace(env)
+
+        propagation_context = Sentry.get_current_scope.propagation_context
+        expect(propagation_context.incoming_trace).to eq(true)
+        expect(propagation_context.trace_id).to eq(incoming_prop_context.trace_id)
+        expect(propagation_context.parent_span_id).to eq(incoming_prop_context.span_id)
+        expect(propagation_context.parent_sampled).to eq(nil)
+        expect(propagation_context.baggage.items).to eq(incoming_prop_context.get_baggage.items)
+        expect(propagation_context.baggage.mutable).to eq(false)
+      end
+
+      it "returns new Transaction with tracing enabled" do
+        Sentry.configuration.traces_sample_rate = 1.0
+
+        transaction = described_class.continue_trace(env, name: "foobar")
+        expect(transaction).to be_a(Sentry::Transaction)
+        expect(transaction.name).to eq("foobar")
+        expect(transaction.trace_id).to eq(incoming_prop_context.trace_id)
+        expect(transaction.parent_span_id).to eq(incoming_prop_context.span_id)
+        expect(transaction.baggage.items).to eq(incoming_prop_context.get_baggage.items)
+        expect(transaction.baggage.mutable).to eq(false)
+      end
     end
   end
 

--- a/sentry-sidekiq/lib/sentry/sidekiq/sentry_context_middleware.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/sentry_context_middleware.rb
@@ -19,7 +19,7 @@ module Sentry
         scope.set_tags(build_tags(job["tags"]))
         scope.set_contexts(sidekiq: job.merge("queue" => queue))
         scope.set_transaction_name(context_filter.transaction_name, source: :task)
-        transaction = start_transaction(scope, job["sentry_trace"])
+        transaction = start_transaction(scope, job["trace_propagation_headers"])
         scope.set_span(transaction) if transaction
 
         begin
@@ -39,9 +39,9 @@ module Sentry
         Array(tags).each_with_object({}) { |name, tags_hash| tags_hash[:"sidekiq.#{name}"] = true }
       end
 
-      def start_transaction(scope, sentry_trace)
+      def start_transaction(scope, env)
         options = { name: scope.transaction_name, source: scope.transaction_source, op: OP_NAME }
-        transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, **options) if sentry_trace
+        transaction = Sentry.continue_trace(env, **options)
         Sentry.start_transaction(transaction: transaction, **options)
       end
 
@@ -58,9 +58,8 @@ module Sentry
         return yield unless Sentry.initialized?
 
         user = Sentry.get_current_scope.user
-        transaction = Sentry.get_current_scope.get_transaction
         job["sentry_user"] = user unless user.empty?
-        job["sentry_trace"] = transaction.to_sentry_trace if transaction
+        job["trace_propagation_headers"] = Sentry.get_trace_propagation_headers
         yield
       end
     end


### PR DESCRIPTION
This PR is 2/2 to enable Tracing without Performance, i.e. make sure all our events are connected even if they are not Transactions.

### Summary of changes
* Implement new top level `Sentry.continue_trace(env, **options)` API that standardizes continuing an incoming trace from a rack env like hash.
* Use this new API in rack/rails/sidekiq

part of #2056 
linked to #2084