### PR TITLE
Pin irb to 1.7.4 for ruby 2.7 / rails 6.0.0

### DIFF
--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -47,7 +47,12 @@ gem "rake", "~> 12.0"
 
 if RUBY_VERSION.to_f >= 2.6
   gem "debug", github: "ruby/debug", platform: :ruby
-  gem "irb"
+
+  if rails_version == Gem::Version.new("6.0.0") && RUBY_VERSION.to_f == 2.7
+    gem "irb", "~> 1.7.4"   # irb 1.8 adds psych via rdoc that causes CI to fail
+  else
+    gem "irb"
+  end
 end
 
 gem "pry"


### PR DESCRIPTION
irb 1.8.0 adds rdoc which adds psych which breaks on rails 6.0.0 with
```
      Psych::AliasesNotEnabled:
        Cannot load database configuration:
        Alias parsing was not enabled. To enable it, pass `aliases: true` to `Psych::load` or `Psych::safe_load`.
      # ./spec/dummy/test_rails_app/app.rb:90:in `make_basic_app'
      # ./spec/sentry/rails_spec.rb:184:in `block (3 levels) in <top (required)>'
      # ------------------
      # --- Caused by: ---
      # Psych::AliasesNotEnabled:
      #   Alias parsing was not enabled. To enable it, pass `aliases: true` to `Psych::load` or `Psych::safe_load`.
      #   ./spec/dummy/test_rails_app/app.rb:90:in `make_basic_app'
```

#skip-changelog