### PR TITLE
Drop IRB's patch

### DIFF
--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -24,6 +24,7 @@ if rails_version > Gem::Version.new("7.0.0")
   gem "rails", github: "rails/rails"
 else
   gem "rails", "~> #{rails_version}"
+  gem "psych", "~> 3.0.0"
 end
 
 gem "mini_magick"

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -47,12 +47,7 @@ gem "rake", "~> 12.0"
 
 if RUBY_VERSION.to_f >= 2.6
   gem "debug", github: "ruby/debug", platform: :ruby
-
-  if rails_version == Gem::Version.new("6.0.0") && RUBY_VERSION.to_f == 2.7
-    gem "irb", "~> 1.7.4"   # irb 1.8 adds psych via rdoc that causes CI to fail
-  else
-    gem "irb"
-  end
+  gem "irb"
 end
 
 gem "pry"


### PR DESCRIPTION
I've fixed the issue in https://github.com/ruby/irb/pull/704 and released it in v1.8.1, so this patch is no longer needed 😄 

#skip-changelog
