### PR TITLE
Improve `TestHelper`'s setup/teardown helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Fix `db_config` begin `nil` in `ActiveRecordSubscriber` [#2111](https://github.com/getsentry/sentry-ruby/pull/2111)
   - Fixes [#2109](https://github.com/getsentry/sentry-ruby/issues/2109)
 - Always send envelope trace header from dynamic sampling context [#2113](https://github.com/getsentry/sentry-ruby/pull/2113)
+- Improve `TestHelper`'s setup/teardown helpers ([#2116](https://github.com/getsentry/sentry-ruby/pull/2116))
+  - Fixes [#2103](https://github.com/getsentry/sentry-ruby/issues/2103)
 
 ## 5.11.0
 
@@ -31,7 +33,7 @@
   - Implement `PropagationContext` on `Scope` and add `Sentry.get_trace_propagation_headers` API [#2084](https://github.com/getsentry/sentry-ruby/pull/2084)
   - Implement `Sentry.continue_trace` API [#2089](https://github.com/getsentry/sentry-ruby/pull/2089)
 
-  The SDK now supports connecting arbitrary events (Errors / Transactions / Replays) across distributed services and not just Transactions.  
+  The SDK now supports connecting arbitrary events (Errors / Transactions / Replays) across distributed services and not just Transactions.
   To continue an incoming trace starting with this version of the SDK, use `Sentry.continue_trace` as follows.
 
   ```rb

--- a/sentry-ruby/lib/sentry/test_helper.rb
+++ b/sentry-ruby/lib/sentry/test_helper.rb
@@ -14,24 +14,28 @@ module Sentry
     # @return [void]
     def setup_sentry_test(&block)
       raise "please make sure the SDK is initialized for testing" unless Sentry.initialized?
-      copied_config = Sentry.configuration.dup
+      dummy_config = Sentry.configuration.dup
       # configure dummy DSN, so the events will not be sent to the actual service
-      copied_config.dsn = DUMMY_DSN
+      dummy_config.dsn = DUMMY_DSN
       # set transport to DummyTransport, so we can easily intercept the captured events
-      copied_config.transport.transport_class = Sentry::DummyTransport
+      dummy_config.transport.transport_class = Sentry::DummyTransport
       # make sure SDK allows sending under the current environment
-      copied_config.enabled_environments << copied_config.environment unless copied_config.enabled_environments.include?(copied_config.environment)
+      dummy_config.enabled_environments << dummy_config.environment unless dummy_config.enabled_environments.include?(dummy_config.environment)
       # disble async event sending
-      copied_config.background_worker_threads = 0
+      dummy_config.background_worker_threads = 0
 
       # user can overwrite some of the configs, with a few exceptions like:
       # - include_local_variables
       # - auto_session_tracking
-      block&.call(copied_config)
+      block&.call(dummy_config)
 
-      test_client = Sentry::Client.new(copied_config)
+      # the base layer's client should already use the dummy config so nothing will be sent by accident
+      base_client = Sentry::Client.new(dummy_config)
+      Sentry.get_current_hub.bind_client(base_client)
+      # create a new layer so mutations made to the testing scope or configuration could be simply popped later
+      Sentry.get_current_hub.push_scope
+      test_client = Sentry::Client.new(dummy_config.dup)
       Sentry.get_current_hub.bind_client(test_client)
-      Sentry.get_current_scope.clear
     end
 
     # Clears all stored events and envelopes.
@@ -40,9 +44,12 @@ module Sentry
     def teardown_sentry_test
       return unless Sentry.initialized?
 
-      sentry_transport.events = []
-      sentry_transport.envelopes = []
-      Sentry.get_current_scope.clear
+      # pop testing layer created by `setup_sentry_test`
+      # but keep the base layer to avoid nil-pointer errors
+      # TODO: find a way to notify users if they somehow popped the test layer before calling this method
+      if Sentry.get_current_hub.instance_variable_get(:@stack).size > 1
+        Sentry.get_current_hub.pop_scope
+      end
     end
 
     # @return [Transport]
@@ -75,4 +82,3 @@ module Sentry
     end
   end
 end
-

--- a/sentry-ruby/spec/sentry/test_helper_spec.rb
+++ b/sentry-ruby/spec/sentry/test_helper_spec.rb
@@ -118,5 +118,16 @@ RSpec.describe Sentry::TestHelper do
 
       expect(Sentry.get_current_scope.tags).to eq({})
     end
+
+    context "when the configuration is mutated" do
+      it "rolls back client changes" do
+        Sentry.configuration.environment = "quack"
+        expect(Sentry.configuration.environment).to eq("quack")
+
+        teardown_sentry_test
+
+        expect(Sentry.configuration.environment).to eq("test")
+      end
+    end
   end
 end

--- a/sentry-ruby/spec/sentry/test_helper_spec.rb
+++ b/sentry-ruby/spec/sentry/test_helper_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe Sentry::TestHelper do
     expect(Sentry.get_current_client.transport).to be_a(Sentry::HTTPTransport)
   end
 
-  after do
-    teardown_sentry_test
-  end
-
   describe "#setup_sentry_test" do
+    after do
+      teardown_sentry_test
+    end
+
     it "raises error when the SDK is not initialized" do
       allow(Sentry).to receive(:initialized?).and_return(false)
 
@@ -51,6 +51,10 @@ RSpec.describe Sentry::TestHelper do
       setup_sentry_test
     end
 
+    after do
+      teardown_sentry_test
+    end
+
     it "returns the last sent event" do
       Sentry.capture_message("foobar")
       Sentry.capture_message("barbaz")
@@ -64,6 +68,10 @@ RSpec.describe Sentry::TestHelper do
   describe "#extract_sentry_exceptions" do
     before do
       setup_sentry_test
+    end
+
+    after do
+      teardown_sentry_test
     end
 
     it "extracts exceptions from an ErrorEvent" do


### PR DESCRIPTION
Fixes #2103 

Currently, `TestHelper` sets up / tears down tests by mutating the objects on the same layer. With this design, fixing #2103 would require storing the previous values of config and assigning them back after tests, which is error-prone.

So in this PR, I decided to utilise the SDK's layer design in `setup_sentry_test`:

1. We make sure the base layer's configuration uses dummy values.
2. And then we push another layer to the stack, which has a copied dummy configuration as well as a blank scope.
3. When `teardown_sentry_test` is called, we can simply pop the layer from 2.

If anything unexpected happens (e.g. users popped the stack themselves), having the base layer created in 1) will make sure no `NoMethodError` will be thrown or having any data being sent by accident.