### PR TITLE
Fix Sidekiq tracing headers not being overwritten in case of schedules and retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Always send envelope trace header from dynamic sampling context [#2113](https://github.com/getsentry/sentry-ruby/pull/2113)
 - Improve `TestHelper`'s setup/teardown helpers ([#2116](https://github.com/getsentry/sentry-ruby/pull/2116))
   - Fixes [#2103](https://github.com/getsentry/sentry-ruby/issues/2103)
+- Fix Sidekiq tracing headers not being overwritten in case of schedules and retries [#2118](https://github.com/getsentry/sentry-ruby/pull/2118)
 
 ## 5.11.0
 

--- a/sentry-sidekiq/lib/sentry/sidekiq/sentry_context_middleware.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/sentry_context_middleware.rb
@@ -59,7 +59,7 @@ module Sentry
 
         user = Sentry.get_current_scope.user
         job["sentry_user"] = user unless user.empty?
-        job["trace_propagation_headers"] = Sentry.get_trace_propagation_headers
+        job["trace_propagation_headers"] ||= Sentry.get_trace_propagation_headers
         yield
       end
     end


### PR DESCRIPTION
https://github.com/getsentry/sentry-ruby/pull/1774 added `SentryContextClientMiddleware` to the server middleware chain too.

Sidekiq's [scheduler pushes to the client on the server again for schedules and retries](https://github.com/sidekiq/sidekiq/blob/aadc77a172f1490fb141c7936d2801ca3af925ef/lib/sidekiq/scheduled.rb#L39) which causes our trace propagation to be broken for this case.


Prioritize taking the trace propagation headers from the job whenever they exist.
