### PR TITLE
Adopt Rails 7.1's new BroadcastLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - Record client reports for profiles [#2107](https://github.com/getsentry/sentry-ruby/pull/2107)
+- Adopt Rails 7.1's new BroadcastLogger [#2120](https://github.com/getsentry/sentry-ruby/pull/2120)
 
 ### Bug Fixes
 

--- a/sentry-rails/.gitignore
+++ b/sentry-rails/.gitignore
@@ -5,7 +5,7 @@
 /doc/
 /pkg/
 /spec/reports/
-/spec/dummy/test_rails_app/db
+/spec/dummy/test_rails_app/db*
 /tmp/
 
 # rspec failure tracking

--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -12,7 +12,12 @@ module Sentry
       @excluded_exceptions = @excluded_exceptions.concat(Sentry::Rails::IGNORE_DEFAULT)
 
       if ::Rails.logger
-        @logger = ::Rails.logger.dup
+        if ::Rails.logger.respond_to?(:broadcasts)
+          dupped_broadcasts = ::Rails.logger.broadcasts.map(&:dup)
+          @logger = ::ActiveSupport::BroadcastLogger.new(*dupped_broadcasts)
+        else
+          @logger = ::Rails.logger.dup
+        end
       else
         @logger.warn(Sentry::LOGGER_PROGNAME) do
           <<~MSG


### PR DESCRIPTION
In https://github.com/rails/rails/pull/48615, Rails 7.1 introduced a new `BroadcastLogger` class that allows users to send logs to multiple loggers, which means we need to adjust the SDK's logger assignment for it.