### PR TITLE
Update setup for Rails 7.1

### DIFF
--- a/sentry-delayed_job/Gemfile
+++ b/sentry-delayed_job/Gemfile
@@ -14,7 +14,7 @@ gem "rexml"
 
 gem "delayed_job"
 gem "delayed_job_active_record"
-gem "rails"
+gem "rails", "> 5.0.0", "< 7.1.0"
 
 platform :jruby do
   gem "activerecord-jdbcmysql-adapter"

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -11,7 +11,7 @@ platform :jruby do
 end
 
 rails_version = ENV["RAILS_VERSION"]
-rails_version = "7.0.0" if rails_version.nil?
+rails_version = "7.1.0" if rails_version.nil?
 rails_version = Gem::Version.new(rails_version)
 
 if rails_version < Gem::Version.new("6.0.0")
@@ -20,8 +20,10 @@ else
   gem "sqlite3", platform: :ruby
 end
 
-if rails_version > Gem::Version.new("7.0.0")
+if rails_version >= Gem::Version.new("7.2.0.alpha")
   gem "rails", github: "rails/rails"
+elsif rails_version >= Gem::Version.new("7.1.0")
+  gem "rails", "~> #{rails_version}"
 else
   gem "rails", "~> #{rails_version}"
   gem "psych", "~> 3.0.0"

--- a/sentry-rails/spec/dummy/test_rails_app/configs/7-2.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/7-2.rb
@@ -1,0 +1,36 @@
+require "active_storage/engine"
+require "action_cable/engine"
+require "sentry/rails/error_subscriber"
+
+def run_pre_initialize_cleanup
+  # Zeitwerk checks if registered loaders load paths repeatedly and raises error if that happens.
+  # And because every new Rails::Application instance registers its own loader, we need to clear previously registered ones from Zeitwerk.
+  Zeitwerk::Registry.loaders.clear
+
+  # Rails removes the support of multiple instances, which includes freezing some setting values.
+  # This is the workaround to avoid FrozenError. Related issue: https://github.com/rails/rails/issues/42319
+  ActiveSupport::Dependencies.autoload_once_paths = []
+  ActiveSupport::Dependencies.autoload_paths = []
+
+  # there are a few Rails initializers/finializers that register hook to the executor
+  # because the callbacks are stored inside the `ActiveSupport::Executor` class instead of an instance
+  # the callbacks duplicate after each time we initialize the application and cause issues when they're executed
+  ActiveSupport::Executor.reset_callbacks(:run)
+  ActiveSupport::Executor.reset_callbacks(:complete)
+
+  # Rails uses this module to set a global context for its ErrorReporter feature.
+  # this needs to be cleared so previously set context won't pollute later reportings (see ErrorSubscriber).
+  ActiveSupport::ExecutionContext.clear
+
+  ActionCable::Channel::Base.reset_callbacks(:subscribe)
+  ActionCable::Channel::Base.reset_callbacks(:unsubscribe)
+
+  # Rails 7.1 stores the error reporter directly under the ActiveSupport class.
+  # So we need to make sure the subscriber is not subscribed unexpectedly before any tests
+  ActiveSupport.error_reporter.unsubscribe(Sentry::Rails::ErrorSubscriber)
+end
+
+def configure_app(app)
+  app.config.active_storage.service = :test
+  app.config.enable_reloading = false
+end

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -14,12 +14,6 @@ RSpec.describe Sentry::Rails, type: :request do
       make_basic_app
     end
 
-    after do
-      # We need to cleanup Rails.logger because after https://github.com/rails/rails/pull/49417
-      # Rails.logger could get recreated with the previous logger value and become deeply nested broadcast logger
-      Rails.logger = nil
-    end
-
     it "has version set" do
       expect(described_class::VERSION).to be_a(String)
     end

--- a/sentry-sidekiq/Gemfile
+++ b/sentry-sidekiq/Gemfile
@@ -17,9 +17,16 @@ gem "loofah", "2.20.0" if RUBY_VERSION.to_f < 2.5
 
 sidekiq_version = ENV["SIDEKIQ_VERSION"]
 sidekiq_version = "6.0" if sidekiq_version.nil?
+sidekiq_version = Gem::Version.new(sidekiq_version)
 
-gem "sidekiq", "~> #{sidekiq_version}"
-gem "rails"
+if sidekiq_version >= Gem::Version.new("7.0")
+  # This is for a unreleased fix for sidekiq 7
+  # https://github.com/sidekiq/sidekiq/commit/b7236f814ccb61d3b1e6fc5251ed3d3ac7428eb3
+  gem "sidekiq", github: "sidekiq/sidekiq"
+else
+  gem "sidekiq", "~> #{sidekiq_version}"
+end
+gem "rails", "> 5.0.0", "< 7.1.0"
 
 if RUBY_VERSION.to_f >= 2.6
   gem "debug", github: "ruby/debug", platform: :ruby
@@ -27,4 +34,3 @@ if RUBY_VERSION.to_f >= 2.6
 end
 
 gem "pry"
-

--- a/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
     execute_worker(processor, SadWorker)
 
     expect(transport.events.count).to eq(1)
-    event = transport.events.first
+    event = transport.events[0]
     expect(event.user).to eq(user)
   end
 
@@ -36,7 +36,7 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
       execute_worker(processor, HappyWorker)
 
       expect(transport.events.count).to eq(1)
-      transaction = transport.events.first
+      transaction = transport.events[0]
       expect(transaction).not_to be_nil
       expect(transaction.user).to eq(user)
     end
@@ -45,7 +45,7 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
       execute_worker(processor, SadWorker)
 
       expect(transport.events.count).to eq(2)
-      transaction = transport.events.first
+      transaction = transport.events[0]
       expect(transaction.user).to eq(user)
       event = transport.events.last
       expect(event.user).to eq(user)
@@ -65,7 +65,7 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
         execute_worker(processor, HappyWorker, trace_propagation_headers: trace_propagation_headers)
 
         expect(transport.events.count).to eq(1)
-        transaction = transport.events.first
+        transaction = transport.events[0]
         expect(transaction).not_to be_nil
         expect(transaction.contexts.dig(:trace, :trace_id)).to eq(parent_transaction.trace_id)
       end
@@ -140,11 +140,11 @@ RSpec.describe Sentry::Sidekiq::SentryContextClientMiddleware do
 
       q = queue.to_a
       expect(q.size).to be(2)
-      first_headers = q.first["trace_propagation_headers"]
+      first_headers = q[0]["trace_propagation_headers"]
       expect(first_headers["sentry-trace"]).to eq(transaction.to_sentry_trace)
       expect(first_headers["baggage"]).to eq(transaction.to_baggage)
 
-      second_headers = q.second["trace_propagation_headers"]
+      second_headers = q[1]["trace_propagation_headers"]
       expect(second_headers["sentry-trace"]).to eq(transaction.to_sentry_trace)
       expect(second_headers["baggage"]).to eq(transaction.to_baggage)
     end


### PR DESCRIPTION
Since Rails 7.1 has been officially released, we update `sentry-rails`' setup for it.

This also addresses build failures in `sentry-delayed_job` and `sentry-sidekiq`.

#skip-changelog