### PR TITLE
Update sentry-sidekiq for Sidekiq 7.1.5

### DIFF
--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -20,6 +20,7 @@ jobs:
     name: Ruby ${{ matrix.ruby_version }} & Sidekiq ${{ matrix.sidekiq_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         sidekiq_version: ['5.0', '6.0', '7.0']
         ruby_version: ['2.7', '3.0', '3.1', '3.2', jruby]

--- a/sentry-sidekiq/Gemfile
+++ b/sentry-sidekiq/Gemfile
@@ -16,15 +16,20 @@ gem "rexml"
 gem "loofah", "2.20.0" if RUBY_VERSION.to_f < 2.5
 
 sidekiq_version = ENV["SIDEKIQ_VERSION"]
-sidekiq_version = "6.0" if sidekiq_version.nil?
+sidekiq_version = "7.0" if sidekiq_version.nil?
 
 gem "sidekiq", "~> #{sidekiq_version}"
 gem "rails"
 
-if RUBY_VERSION.to_f >= 2.6
+ruby_version = Gem::Version.new(RUBY_VERSION)
+
+if ruby_version >= Gem::Version.new("2.6.0")
   gem "debug", github: "ruby/debug", platform: :ruby
   gem "irb"
+
+  if ruby_version >= Gem::Version.new("3.0.0")
+    gem "ruby-lsp-rspec"
+  end
 end
 
 gem "pry"
-

--- a/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
@@ -29,6 +29,10 @@ module Sentry
         scope&.clear
       end
 
+      def arity
+        method(:call).arity
+      end
+
       private
 
       def retryable?(context)

--- a/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
@@ -140,11 +140,11 @@ RSpec.describe Sentry::Sidekiq::SentryContextClientMiddleware do
 
       q = queue.to_a
       expect(q.size).to be(2)
-      first_headers = q.first["trace_propagation_headers"]
+      first_headers = q[0]["trace_propagation_headers"]
       expect(first_headers["sentry-trace"]).to eq(transaction.to_sentry_trace)
       expect(first_headers["baggage"]).to eq(transaction.to_baggage)
 
-      second_headers = q.second["trace_propagation_headers"]
+      second_headers = q[1]["trace_propagation_headers"]
       expect(second_headers["sentry-trace"]).to eq(transaction.to_sentry_trace)
       expect(second_headers["baggage"]).to eq(transaction.to_baggage)
     end


### PR DESCRIPTION
In https://github.com/sidekiq/sidekiq/pull/6051, Sidekiq changed the expected parameters on the error handler. However, because it assumes error handler to be a Proc, it uses `#arity` for checking the number of parameters. This is not compatible with our error handler, which is a class.
