### PR TITLE
Add `SimpleCov.command_name` for isolated_specs

### DIFF
--- a/sentry-ruby/spec/isolated/puma_spec.rb
+++ b/sentry-ruby/spec/isolated/puma_spec.rb
@@ -4,6 +4,8 @@ require_relative "../spec_helper"
 # Because puma doesn't have any dependency, if Rack is not installed the entire test won't work
 return if ENV["RACK_VERSION"] == "0"
 
+SimpleCov.command_name "RSpecIsolated"
+
 RSpec.describe Puma::Server do
   class TestServer
     def initialize(app, options)


### PR DESCRIPTION
this ensures the coverage generated will be the merged version and not just from the last `isolated_specs` run.

see https://github.com/simplecov-ruby/simplecov#test-suite-names

#skip-changelog