### PR TITLE
Drop sidekiq patch from the Gemfile

### DIFF
--- a/sentry-sidekiq/Gemfile
+++ b/sentry-sidekiq/Gemfile
@@ -19,13 +19,8 @@ sidekiq_version = ENV["SIDEKIQ_VERSION"]
 sidekiq_version = "6.0" if sidekiq_version.nil?
 sidekiq_version = Gem::Version.new(sidekiq_version)
 
-if sidekiq_version >= Gem::Version.new("7.0")
-  # This is for a unreleased fix for sidekiq 7
-  # https://github.com/sidekiq/sidekiq/commit/b7236f814ccb61d3b1e6fc5251ed3d3ac7428eb3
-  gem "sidekiq", github: "sidekiq/sidekiq"
-else
-  gem "sidekiq", "~> #{sidekiq_version}"
-end
+gem "sidekiq", "~> #{sidekiq_version}"
+
 gem "rails", "> 5.0.0", "< 7.1.0"
 
 if RUBY_VERSION.to_f >= 2.6


### PR DESCRIPTION
The fix we were waiting for has been released in 7.1.6.

#skip-changelog
