### PR TITLE
Fix puma integration for versions before v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Fix puma integration for versions before v5 ([#2141](https://github.com/getsentry/sentry-ruby/pull/2141))
+
 ## 5.12.0
 
 ### Features


### PR DESCRIPTION
Older versions of puma only takes 2 arguments for the `Puma::Server#lowlevel_error` method, so we need to pass the right number of arguments when calling `super` depending on the puma version.

Closes #2067 