### PR TITLE
add delayed job context into the sampling context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Features
+
+- Make additional job context available to traces_sampler for determining sample rate (sentry-delayed_job) [#2148](https://github.com/getsentry/sentry-ruby/pull/2148)
+
 ### Bug Fixes
 
 - Fix puma integration for versions before v5 ([#2141](https://github.com/getsentry/sentry-ruby/pull/2141))

--- a/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
+++ b/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
@@ -20,7 +20,12 @@ module Sentry
             scope.set_contexts(**contexts)
             scope.set_tags("delayed_job.queue" => job.queue, "delayed_job.id" => job.id.to_s)
 
-            transaction = Sentry.start_transaction(name: scope.transaction_name, source: scope.transaction_source, op: OP_NAME)
+            transaction = Sentry.start_transaction(
+              name: scope.transaction_name,
+              source: scope.transaction_source,
+              op: OP_NAME,
+              custom_sampling_context: contexts
+            )
             scope.set_span(transaction) if transaction
 
             begin


### PR DESCRIPTION
## Description

This makes additional job context available in the `sampling_context` via the Sentry transaction's `custom_sampling_context`, which makes it available for making sampling rate determinations in `traces_sampler`.  In our case, we want to base the sampling rate off of the job's priority.  This PR allows you to write code like:

```ruby
    config.traces_sampler = lambda do |sampling_context|
        sample_rate = 1

        if sampling_context[:transaction_context][:op] == Sentry::DelayedJob::Plugin::OP_NAME
           job_priority = sampling_context.dig(Sentry::DelayedJob::Plugin::DELAYED_JOB_CONTEXT_KEY, :priority)
           if job_priority && job_priority >= 99
              sample_rate = 0.01
           end
        end

        sample_rate
   end
```