### PR TITLE
Fix breadcrumbs with `warn` level not being ingested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Bug Fixes
 
-- Fix puma integration for versions before v5 ([#2141](https://github.com/getsentry/sentry-ruby/pull/2141))
+- Fix puma integration for versions before v5 [#2141](https://github.com/getsentry/sentry-ruby/pull/2141)
+- Fix breadcrumbs with `warn` level not being ingested [#2150](https://github.com/getsentry/sentry-ruby/pull/2150)
+  - Fixes [#2145](https://github.com/getsentry/sentry-ruby/issues/2145)
 
 ## 5.12.0
 

--- a/sentry-ruby/lib/sentry/breadcrumb.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb.rb
@@ -9,7 +9,7 @@ module Sentry
     # @return [Hash, nil]
     attr_accessor :data
     # @return [String, nil]
-    attr_accessor :level
+    attr_reader :level
     # @return [Time, Integer, nil]
     attr_accessor :timestamp
     # @return [String, nil]
@@ -26,10 +26,10 @@ module Sentry
     def initialize(category: nil, data: nil, message: nil, timestamp: nil, level: nil, type: nil)
       @category = category
       @data = data || {}
-      @level = level
       @timestamp = timestamp || Sentry.utc_now.to_i
       @type = type
       self.message = message
+      self.level = level
     end
 
     # @return [Hash]
@@ -48,6 +48,12 @@ module Sentry
     # @return [void]
     def message=(message)
       @message = (message || "").byteslice(0..Event::MAX_MESSAGE_SIZE_IN_BYTES)
+    end
+
+    # @param level [String]
+    # @return [void]
+    def level=(level) # needed to meet the Sentry spec
+      @level = level == "warn" ? "warning" : level
     end
 
     private

--- a/sentry-ruby/spec/sentry/breadcrumb_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe Sentry::Breadcrumb do
       crumb = described_class.new(message: long_message)
       expect(crumb.message.length).to eq(Sentry::Event::MAX_MESSAGE_SIZE_IN_BYTES + 1)
     end
+
+    it "sets the level to warning if warn" do
+      crumb = described_class.new(level: "warn")
+      expect(crumb.level).to eq("warning")
+    end
   end
 
   describe "#message=" do
@@ -32,6 +37,20 @@ RSpec.describe Sentry::Breadcrumb do
       crumb = described_class.new
       crumb.message = long_message
       expect(crumb.message.length).to eq(Sentry::Event::MAX_MESSAGE_SIZE_IN_BYTES + 1)
+    end
+  end
+
+  describe "#level=" do
+    it "sets the level" do
+      crumb = described_class.new
+      crumb.level = "error"
+      expect(crumb.level).to eq("error")
+    end
+
+    it "sets the level to warning if warn" do
+      crumb = described_class.new
+      crumb.level = "warn"
+      expect(crumb.level).to eq("warning")
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-ruby/issues/2145
