### PR TITLE
Add Ruby 3.2 support to README.

### DIFF
--- a/sentry-ruby/README.md
+++ b/sentry-ruby/README.md
@@ -33,7 +33,7 @@ If you're using `sentry-raven`, we recommend you to migrate to this new SDK. You
 
 ## Requirements
 
-We test on Ruby 2.4, 2.5, 2.6, 2.7, 3.0, and 3.1 at the latest patchlevel/teeny version. We also support JRuby 9.0.
+We test on Ruby 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, and 3.2 at the latest patchlevel/teeny version. We also support JRuby 9.0.
 
 If you use self-hosted Sentry, please also make sure its version is above `20.6.0`.
 

--- a/sentry-ruby/README.md
+++ b/sentry-ruby/README.md
@@ -33,7 +33,7 @@ If you're using `sentry-raven`, we recommend you to migrate to this new SDK. You
 
 ## Requirements
 
-We test on Ruby 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, and 3.2 at the latest patchlevel/teeny version. We also support JRuby 9.0.
+We test from Ruby 2.4 to Ruby 3.2 at the latest patchlevel/teeny version. We also support JRuby 9.0.
 
 If you use self-hosted Sentry, please also make sure its version is above `20.6.0`.
 


### PR DESCRIPTION
Please don't ban me for 4-character PRs 🙈

This PR adds Ruby 3.2 note to the README. Originally, Ruby 3.2 was added to CIs in https://github.com/getsentry/sentry-ruby/pull/2052 by @st0012.