### PR TITLE
(sentry-sidekiq): Fixed a deprecation warning in error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix breadcrumbs with `warn` level not being ingested [#2150](https://github.com/getsentry/sentry-ruby/pull/2150)
   - Fixes [#2145](https://github.com/getsentry/sentry-ruby/issues/2145)
 - Don't send negative line numbers in profiles [#2158](https://github.com/getsentry/sentry-ruby/pull/2158)
+- Fixed a deprecation in `sidekiq-ruby` error handler [#2160](https://github.com/getsentry/sentry-ruby/pull/2160)
 
 ## 5.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Fixed a deprecation in `sidekiq-ruby` error handler [#2160](https://github.com/getsentry/sentry-ruby/pull/2160)
+
 ## 5.13.0
 
 ### Features
@@ -18,7 +24,6 @@
 - Fix breadcrumbs with `warn` level not being ingested [#2150](https://github.com/getsentry/sentry-ruby/pull/2150)
   - Fixes [#2145](https://github.com/getsentry/sentry-ruby/issues/2145)
 - Don't send negative line numbers in profiles [#2158](https://github.com/getsentry/sentry-ruby/pull/2158)
-- Fixed a deprecation in `sidekiq-ruby` error handler [#2160](https://github.com/getsentry/sentry-ruby/pull/2160)
 
 ## 5.12.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,15 @@ And if you have any questions, please feel free to reach out on [Discord].
 
 ## Contribute To Individual Gems
 
+- Install the dependencies of a specific gem by running `bundle` in it's subdirectory. I.e:
+  ```bash
+  cd sentry-sidekiq
+  bundle install
+  ```
+- Install any additional dependencies. `sentry-sidekiq` assumes you have `redis` running.
 - Use `bundle exec rake` to run tests.
-  - In `sentry-rails`, you can use `RAILS_VERSION=version` to specify the Rails version to test against. Default is `6.1`
+  - In `sentry-rails`, you can use `RAILS_VERSION=version` to specify the Rails version to test against. Default is `7.0`
+  - In `sentry-sidekiq`, you can use `SIDEKIQ_VERSION=version` to specify what version of Sidekiq to install when you run `bundle install`. Default is `7.0`
 - Use example apps under the `example` or `examples` folder to test the change. (Remember to change the DSN first)
 - To learn more about `sentry-ruby`'s structure, you can read the [Sentry SDK spec]
 

--- a/sentry-sidekiq/Gemfile
+++ b/sentry-sidekiq/Gemfile
@@ -19,7 +19,7 @@ gem "loofah", "2.20.0" if RUBY_VERSION.to_f < 2.5
 gem "psych", "5.1.0"
 
 sidekiq_version = ENV["SIDEKIQ_VERSION"]
-sidekiq_version = "6.0" if sidekiq_version.nil?
+sidekiq_version = "7.0" if sidekiq_version.nil?
 sidekiq_version = Gem::Version.new(sidekiq_version)
 
 gem "sidekiq", "~> #{sidekiq_version}"

--- a/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
@@ -5,7 +5,13 @@ module Sentry
     class ErrorHandler
       WITH_SIDEKIQ_7 = ::Gem::Version.new(::Sidekiq::VERSION) >= ::Gem::Version.new("7.0")
 
-      def call(ex, context)
+      # @param ex [Exception] the exception / error that occured
+      # @param context [Hash or Array] Sidekiq error context
+      # @param sidekiq_config [Sidekiq::Config] Sidekiq configuration,
+      #   defaults to Sidekiq's default configuration `Sidekiq.default_configuration`
+      #   Sidekiq will pass the config in starting Sidekiq 7.1.5, see
+      #   https://github.com/sidekiq/sidekiq/pull/6051
+      def call(ex, context, sidekiq_config = ::Sidekiq.default_configuration)
         return unless Sentry.initialized?
 
         context_filter = Sentry::Sidekiq::ContextFilter.new(context)


### PR DESCRIPTION
## Summary

This PR fixes the deprecation warning that occurs when using Sidekiq >= 7.1.5: #2157. Closes #2157.

## Changes

I'm just getting started, so I documented some steps as I was onboarding: 
- Added more instructions to `CONTRIBUTING.md`, and bumped Rails version there.
- Bumped default Sidekiq version to 7.0 in `sentry-sidekiq` Gemfile.
- Fixed the deprecation warning in the error handler and added a comment there.
- Also added a changelog entry linking to this pull request.

## Next steps

We could in theory use some of those configuration values to enrich the reported errors: https://github.com/sidekiq/sidekiq/blob/main/lib/sidekiq/config.rb, but, they are not specific to the error at hand.