### PR TITLE
Allow proxy configuration via HTTP_PROXY env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix breadcrumbs with `warn` level not being ingested [#2150](https://github.com/getsentry/sentry-ruby/pull/2150)
   - Fixes [#2145](https://github.com/getsentry/sentry-ruby/issues/2145)
 - Don't send negative line numbers in profiles [#2158](https://github.com/getsentry/sentry-ruby/pull/2158)
+- Allow transport proxy configuration to be set with `HTTP_PROXY` environment variable [#2161](https://github.com/getsentry/sentry-ruby/pull/2161)
 
 ## 5.12.0
 

--- a/sentry-ruby/lib/sentry/transport/configuration.rb
+++ b/sentry-ruby/lib/sentry/transport/configuration.rb
@@ -3,7 +3,80 @@
 module Sentry
   class Transport
     class Configuration
-      attr_accessor :timeout, :open_timeout, :proxy, :ssl, :ssl_ca_file, :ssl_verification, :encoding
+
+      # The timeout in seconds to open a connection to Sentry, in seconds.
+      # Default value is 2.
+      #
+      # @return [Integer]
+      attr_accessor :timeout
+
+      # The timeout in seconds to read data from Sentry, in seconds.
+      # Default value is 1.
+      #
+      # @return [Integer]
+      attr_accessor :open_timeout
+
+      # The proxy configuration to use to connect to Sentry.
+      # Accepts either a URI formatted string, URI, or a hash with the `uri`,
+      # `user`, and `password` keys.
+      #
+      # @example
+      #   # setup proxy using a string:
+      #   config.transport.proxy = "https://user:password@proxyhost:8080"
+      #
+      #   # setup proxy using a URI:
+      #   config.transport.proxy = URI("https://user:password@proxyhost:8080")
+      #
+      #   # setup proxy using a hash:
+      #   config.transport.proxy = {
+      #     uri: URI("https://proxyhost:8080"),
+      #     user: "user",
+      #     password: "password"
+      #   }
+      #
+      # If you're using the default transport (`Sentry::HTTPTransport`),
+      # proxy settings will also automatically be read from tne environment
+      # variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`).
+      #
+      # @return [String, URI, Hash, nil]
+      attr_accessor :proxy
+
+      # The SSL configuration to use to connect to Sentry.
+      # You can either pass a `Hash` containing `ca_file` and `verification` keys,
+      # or you can set those options directly on the `Sentry::HTTPTransport::Configuration` object:
+      #
+      # @example
+      #   config.transport.ssl =  {
+      #     ca_file: "/path/to/ca_file",
+      #     verification: true
+      #   end
+      #
+      # @return [Hash, nil]
+      attr_accessor :ssl
+
+      # The path to the CA file to use to verify the SSL connection.
+      # Default value is `nil`.
+      #
+      # @return [String, nil]
+      attr_accessor :ssl_ca_file
+
+      # Whether to verify that the peer certificate is valid in SSL connections.
+      # Default value is `true`.
+      #
+      # @return [Boolean]
+      attr_accessor :ssl_verification
+
+      # The encoding to use to compress the request body.
+      # Default value is `Sentry::HTTPTransport::GZIP_ENCODING`.
+      #
+      # @return [String]
+      attr_accessor :encoding
+
+      # The class to use as a transport to connect to Sentry.
+      # If this option not set, it will return `nil`, and Sentry will use
+      # `Sentry::HTTPTransport` by default.
+      #
+      # @return [Class, nil]
       attr_reader :transport_class
 
       def initialize

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Sentry::HTTPTransport do
         expect(subject.send(:conn).port).to eq(80)
       end
     end
-    context "with http DSN" do
+    context "with https DSN" do
       let(:dsn) { "https://12345:67890@sentry.localdomain/sentry/42" }
 
       it "sets port to 443" do
@@ -127,6 +127,21 @@ RSpec.describe Sentry::HTTPTransport do
       end
 
       subject.send_data(data)
+    end
+
+    it "accepts a proxy from ENV[HTTP_PROXY]" do
+      ENV["http_proxy"] = "https://stan:foobar@example.com:8080"
+
+      stub_request(fake_response) do |_, http_obj|
+        expect(http_obj.proxy_address).to eq("example.com")
+        expect(http_obj.proxy_user).to eq("stan")
+        expect(http_obj.proxy_pass).to eq("foobar")
+        expect(http_obj.proxy_port).to eq(8080)
+      end
+
+      subject.send_data(data)
+
+      ENV["http_proxy"] = nil 
     end
 
     it "accepts custom timeout" do

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -130,18 +130,20 @@ RSpec.describe Sentry::HTTPTransport do
     end
 
     it "accepts a proxy from ENV[HTTP_PROXY]" do
-      ENV["http_proxy"] = "https://stan:foobar@example.com:8080"
-
-      stub_request(fake_response) do |_, http_obj|
-        expect(http_obj.proxy_address).to eq("example.com")
-        expect(http_obj.proxy_user).to eq("stan")
-        expect(http_obj.proxy_pass).to eq("foobar")
-        expect(http_obj.proxy_port).to eq(8080)
+      begin
+        ENV["http_proxy"] = "https://stan:foobar@example.com:8080"
+  
+        stub_request(fake_response) do |_, http_obj|
+          expect(http_obj.proxy_address).to eq("example.com")
+          expect(http_obj.proxy_user).to eq("stan")
+          expect(http_obj.proxy_pass).to eq("foobar")
+          expect(http_obj.proxy_port).to eq(8080)
+        end
+  
+        subject.send_data(data)
+      ensure
+        ENV["http_proxy"] = nil
       end
-
-      subject.send_data(data)
-
-      ENV["http_proxy"] = nil 
     end
 
     it "accepts custom timeout" do

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -135,9 +135,12 @@ RSpec.describe Sentry::HTTPTransport do
   
         stub_request(fake_response) do |_, http_obj|
           expect(http_obj.proxy_address).to eq("example.com")
-          expect(http_obj.proxy_user).to eq("stan")
-          expect(http_obj.proxy_pass).to eq("foobar")
           expect(http_obj.proxy_port).to eq(8080)
+
+          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.5")
+            expect(http_obj.proxy_user).to eq("stan")
+            expect(http_obj.proxy_pass).to eq("foobar")
+          end
         end
   
         subject.send_data(data)
@@ -152,7 +155,7 @@ RSpec.describe Sentry::HTTPTransport do
       stub_request(fake_response) do |_, http_obj|
         expect(http_obj.read_timeout).to eq(10)
 
-        if RUBY_VERSION >= "2.6"
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6")
           expect(http_obj.write_timeout).to eq(10)
         end
       end


### PR DESCRIPTION
## Summary

This PR allows `sentry-ruby` to use proxy config passed via environment variables, i.e. `HTTP_PROXY`. Closes #2131. The actual configuration settings is still respected over environment variables.

## Changes
- As @sl0thentr0py suggests, just removes the `nil` passed into `::Net::HTTP`, and allows it to do all the work for us.
- Adds a changelog entry. 

## TODOs
- [x] Add unit tests to https://github.com/getsentry/sentry-ruby/blob/c9b4eac913f0c6510178c451da57d91fc340fa20/sentry-ruby/spec/sentry/transport/http_transport_spec.rb#L94
- [x] I'll add a separate PR into `sentry-docs` to document how proxy config works. As of right now, `transport_configuration` block there is minimal. 
- [ ] Once this is shipped, further update `sentry-docs` with proxy via env var support.

## Review
- @stephanie-anderson, with this PR, `config.transport_configuration.proxy` is preferred over the environment values:
  - If the `config.transport_configuration.proxy` is present, but malformed (does not have the minimally required uri key), it will still be used over `HTTP_PROXY`, even if that has the correct setup. 
  - We should probably be consistent with how our other SDKs work with env vars — should we generally prefer the config passed in code, or the env vars? 