### PR TITLE
Example of a rake task with monitor check-ins

### DIFF
--- a/sentry-ruby/examples/crons/Gemfile
+++ b/sentry-ruby/examples/crons/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+ruby '> 2.6'
+
+gem "rake"
+gem 'sentry-ruby', path: "../../"

--- a/sentry-ruby/examples/crons/README.md
+++ b/sentry-ruby/examples/crons/README.md
@@ -1,0 +1,8 @@
+# sentry-ruby Crons example
+
+Crons monitoring allows you to track that certain that should be performed
+on a certain schedule are indeed performed on time and without errors. See 
+[documentation](https://docs.sentry.io/platforms/ruby/crons/) for more details.
+
+This example project has a few rake tasks that manually send monitor check-ins
+to Sentry.

--- a/sentry-ruby/examples/crons/Rakefile.rb
+++ b/sentry-ruby/examples/crons/Rakefile.rb
@@ -1,0 +1,79 @@
+require "sentry-ruby"
+
+Sentry.init do |config|
+  config.dsn = 'https://2fb45f003d054a7ea47feb45898f7649@o447951.ingest.sentry.io/5434472'
+end
+
+# Create a config from an interval schedule (every 10 minutes)
+monitor_config = Sentry::Cron::MonitorConfig.from_interval(
+  1,
+  :hour,
+  checkin_margin: 15, # Optional check-in margin in minutes
+  max_runtime: 15 # Optional max runtime in minutes
+)
+
+task :successful_cron do
+  # This check-in will tell Sentry that the cron job started and is in-progress.
+  # Sentry will expect it to send a :ok check-in within max_runtime minutes.
+  check_in_id = Sentry.capture_check_in(
+    "rake-task-example",
+    :in_progress,
+    monitor_config: monitor_config
+  )
+
+  puts "rake task is running"
+
+  Sentry.capture_check_in(
+    "rake-task-example",
+    :ok,
+    check_in_id: check_in_id,
+    monitor_config: monitor_config
+  )
+end
+
+task :failed_cron do
+  check_in_id = Sentry.capture_check_in(
+    "rake-task-example",
+    :in_progress,
+    monitor_config: monitor_config
+  )
+
+  puts "rake task is running"
+
+  # Sending an :error check-in will mark the cron job as errored on Sentry,
+  # and this will also create a new Issue on Sentry linked to that cron job.
+  Sentry.capture_check_in(
+    "rake-task-example",
+    :error,
+    check_in_id: check_in_id,
+    monitor_config: monitor_config
+  )
+end
+
+task :heartbeat do
+  puts "rake task is running"
+
+  # Heartbeat check-in sends :ok status
+  # without the parent check_in_id.
+  # This will tell Sentry that this cron run was successful.
+  Sentry.capture_check_in(
+    "rake-task-example",
+    :ok, 
+    monitor_config: monitor_config
+  )
+end
+
+task :raise_exception do
+  check_in_id = Sentry.capture_check_in(
+    "rake-task-example",
+    :in_progress,
+    monitor_config: monitor_config
+  )
+
+  puts "rake task is running"
+
+  # If you raise an error within the job, Sentry will report it and link 
+  # the issue to the cron job. But the job itself will be marked as "in progress"
+  # until either your job sends another check-in, or it timeouts.
+  raise "This job errored out"
+end


### PR DESCRIPTION
This PR contains an example of usign Crons / monitor check-ins in a rake task. 

I was learning the SDK and trying things out and made this as my own scratchpad. Not sure if it's very useful, but thought I would push this up. No hard feelings if we'd rather not merge this — I realize that maintaining examples and documentation spread across multiple places is difficult.

#skip-changelog  