### PR TITLE
Avoid invoking ActiveSupport::BroadcastLogger if not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - Fixed a deprecation in `sidekiq-ruby` error handler [#2160](https://github.com/getsentry/sentry-ruby/pull/2160)
+- Avoid instantiating `BroadcastLogger` in `sidekiq-ruby` if class not defined [#2169](https://github.com/getsentry/sentry-ruby/pull/2169)
 
 ## 5.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Bug Fixes
 
 - Fixed a deprecation in `sidekiq-ruby` error handler [#2160](https://github.com/getsentry/sentry-ruby/pull/2160)
-- Avoid instantiating `BroadcastLogger` in `sidekiq-ruby` if class not defined [#2169](https://github.com/getsentry/sentry-ruby/pull/2169)
+- Avoid invoking ActiveSupport::BroadcastLogger if not defined [#2169](https://github.com/getsentry/sentry-ruby/pull/2169)
 
 ## 5.13.0
 

--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -12,7 +12,7 @@ module Sentry
       @excluded_exceptions = @excluded_exceptions.concat(Sentry::Rails::IGNORE_DEFAULT)
 
       if ::Rails.logger
-        if ::Rails.logger.respond_to?(:broadcasts)
+        if defined?(::ActiveSupport::BroadcastLogger) && ::Rails.logger.is_a?(::ActiveSupport::BroadcastLogger)
           dupped_broadcasts = ::Rails.logger.broadcasts.map(&:dup)
           @logger = ::ActiveSupport::BroadcastLogger.new(*dupped_broadcasts)
         else


### PR DESCRIPTION
## Description

When `::ActiveSupport::BroadcastLogger` is not defined (Rails < 7.1) and `::Rails.logger` instance has `broadcasts` method defined, initialization of Sentry-ruby fails on `NameError: uninitialized constant ActiveSupport::BroadcastLogger (NameError)`.

I suggest changing the check to `::Rails.logger` being an instance of `::ActiveSupport::BroadcastLogger` (with a `defined?` check).