### PR TITLE
(fix) crons: require sidekiq-cron early

### DIFF
--- a/sentry-sidekiq/lib/sentry/sidekiq/cron/job.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/cron/job.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
-return unless defined?(::Sidekiq::Cron::Job)
+# Try requiring sidekiq-cron to ensure it's loaded before the integration.
+# If sidekiq-cron is not available, do nothing.
+begin
+  require "sidekiq-cron"
+rescue LoadError
+  return
+end
 
 module Sentry
   module Sidekiq

--- a/sentry-sidekiq/spec/sentry/sidekiq/cron/job_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/cron/job_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe Sentry::Sidekiq::Cron::Job do
   before do
     schedule_file = 'spec/fixtures/schedule.yml'
     schedule = Sidekiq::Cron::Support.load_yaml(ERB.new(IO.read(schedule_file)).result)
-    Sidekiq::Cron::Job.load_from_hash!(schedule, source: 'schedule')
+    # sidekiq-cron 2.0+ accepts second argument to `load_from_hash!` with options,
+    # such as {source: 'schedule'}, but sidekiq-cron 1.9.1 (last version to support Ruby 2.6) does not.
+    # Since we're not using the source option in our code anyway, it's safe to not pass the 2nd arg.
+    Sidekiq::Cron::Job.load_from_hash!(schedule)
   end
 
   it 'patches class' do


### PR DESCRIPTION
#skip-changelog
(am I doing this right?)

## Summary

Addressing [this review](https://github.com/getsentry/sentry-ruby/pull/2170#discussion_r1401289145) by @st0012 on `sidekiq-cron` integration — the corresponsing fix for `sidekiq-scheduler` is in #2172.