### PR TITLE
Release detector: Use full SHA hash in default release name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - Improve default slug generation for Crons [#2168](https://github.com/getsentry/sentry-ruby/pull/2168)
+- Change release name generator to use full SHA commit hash and align with `sentry-cli` and other Sentry SDKs [#2174](https://github.com/getsentry/sentry-ruby/pull/2174)
 - Automatic Crons support for scheduling gems
   - Add support for [`sidekiq-cron`](https://github.com/sidekiq-cron/sidekiq-cron) [#2170](https://github.com/getsentry/sentry-ruby/pull/2170)
 

--- a/sentry-ruby/lib/sentry/release_detector.rb
+++ b/sentry-ruby/lib/sentry/release_detector.rb
@@ -28,7 +28,7 @@ module Sentry
       end
 
       def detect_release_from_git
-        Sentry.sys_command("git rev-parse --short HEAD") if File.directory?(".git")
+        Sentry.sys_command("git rev-parse HEAD") if File.directory?(".git")
       end
 
       def detect_release_from_env

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -844,7 +844,7 @@ RSpec.describe Sentry do
         allow(File).to receive(:directory?).with(".git").and_return(true)
       end
       it 'gets release from git' do
-        allow(Sentry).to receive(:`).with("git rev-parse --short HEAD 2>&1").and_return("COMMIT_SHA")
+        allow(Sentry).to receive(:`).with("git rev-parse HEAD 2>&1").and_return("COMMIT_SHA")
 
         described_class.init
         expect(described_class.configuration.release).to eq('COMMIT_SHA')


### PR DESCRIPTION
## Summary

This pull request makes it so Sentry-Ruby will name releases by their full SHA commit hash instead of the short version. 
- Aligns with how `sentry-cli` does that
- Aligns with Python SDK: https://github.com/getsentry/sentry-python/issues/908
- Closes #2114

/cc @sl0thentr0py and @stephanie-anderson 