### PR TITLE
Fix sentry-delayed_job: respect custom max_attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - Fixed a deprecation in `sidekiq-ruby` error handler [#2160](https://github.com/getsentry/sentry-ruby/pull/2160)
 - Avoid invoking ActiveSupport::BroadcastLogger if not defined [#2169](https://github.com/getsentry/sentry-ruby/pull/2169)
+- Respect custom `Delayed::Job.max_attempts` if it's defined [#2176](https://github.com/getsentry/sentry-ruby/pull/2176)
 
 ## 5.13.0
 

--- a/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
+++ b/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
@@ -87,7 +87,8 @@ module Sentry
 
         # We use the predecessor because the job's attempts haven't been increased to the new
         # count at this point.
-        job.attempts >= Delayed::Worker.max_attempts.pred
+        max_attempts = job&.max_attempts&.pred || Delayed::Worker.max_attempts.pred
+        job.attempts >= max_attempts
       end
 
       def self.finish_transaction(transaction, status)

--- a/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
+++ b/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Sentry::DelayedJob do
       # custom job-level max_attempts is reached.
       # See https://github.com/collectiveidea/delayed_job#custom-jobs
       it "reports exception after the job's custom max_attempts" do
-        enqueued_job.update(attempts:2)
+        enqueued_job.update(attempts: 2)
         allow(enqueued_job).to receive(:max_attempts).and_return(3)
 
         expect do

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -275,7 +275,6 @@ RSpec.describe Sentry::HTTPTransport do
         stub_request(error_response)
 
         expect { subject.send_data(data) }.to raise_error(Sentry::ExternalError, /error_in_header/)
-
       end
     end
   end


### PR DESCRIPTION
## Summary

- Fixes #2076:
- Applies the fix that @claireannecotter proposed, ensuring it's safe.
- Adds specs and the CHANGELOG entry.

/cc @sl0thentr0py are you tired of me yet?