### PR TITLE
Allow SENTRY_TRACE and SENTRY_BAGGAGE env vars to continue traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     ```rb
     config.enabled_patches += [:sidekiq_scheduler]
     ```
+- Passing a distributed trace ID in SENTRY_TRACE and baggage in SENTRY_BAGGAGE environment variables is now supported [#2179](https://github.com/getsentry/sentry-ruby/pull/2179)
 
 ### Bug Fixes
 

--- a/sentry-opentelemetry/lib/sentry/opentelemetry/propagator.rb
+++ b/sentry-opentelemetry/lib/sentry/opentelemetry/propagator.rb
@@ -52,7 +52,7 @@ module Sentry
         baggage_header = getter.get(carrier, BAGGAGE_HEADER_NAME)
 
         baggage = if baggage_header && !baggage_header.empty?
-                    Baggage.from_incoming_header(baggage_header)
+                    Baggage.from_baggage_string(baggage_header)
                   else
                     # If there's an incoming sentry-trace but no incoming baggage header,
                     # for instance in traces coming from older SDKs,

--- a/sentry-ruby/lib/sentry/baggage.rb
+++ b/sentry-ruby/lib/sentry/baggage.rb
@@ -26,11 +26,11 @@ module Sentry
     #
     # @param header [String] The incoming Baggage header string.
     # @return [Baggage, nil]
-    def self.from_incoming_header(header)
+    def self.from_baggage_string(baggage_string)
       items = {}
       mutable = true
 
-      header.split(',').each do |item|
+      baggage_string.split(',').each do |item|
         item = item.strip
         key, val = item.split('=')
 

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -111,7 +111,7 @@ module Sentry
       trace_id, parent_span_id, parent_sampled = sentry_trace_data
 
       baggage = if baggage && !baggage.empty?
-                  Baggage.from_incoming_header(baggage)
+                  Baggage.from_baggage_string(baggage)
                 else
                   # If there's an incoming sentry-trace but no incoming baggage header,
                   # for instance in traces coming from older SDKs,

--- a/sentry-ruby/spec/sentry/baggage_spec.rb
+++ b/sentry-ruby/spec/sentry/baggage_spec.rb
@@ -17,21 +17,21 @@ RSpec.describe Sentry::Baggage do
   describe "#dynamic_sampling_context" do
     context "when malformed baggage" do
       it "is empty" do
-        baggage = described_class.from_incoming_header(malformed_baggage)
+        baggage = described_class.from_baggage_string(malformed_baggage)
         expect(baggage.dynamic_sampling_context).to eq({})
       end
     end
 
     context "when only third party baggage" do
       it "is empty" do
-        baggage = described_class.from_incoming_header(third_party_baggage)
+        baggage = described_class.from_baggage_string(third_party_baggage)
         expect(baggage.dynamic_sampling_context).to eq({})
       end
     end
 
     context "when mixed baggage" do
       it "populates DSC" do
-        baggage = described_class.from_incoming_header(mixed_baggage)
+        baggage = described_class.from_baggage_string(mixed_baggage)
 
         expect(baggage.dynamic_sampling_context).to eq({
           "sample_rate" => "0.01337",
@@ -48,21 +48,21 @@ RSpec.describe Sentry::Baggage do
     context "default args (without third party)" do
       context "when malformed baggage" do
         it "is empty string" do
-          baggage = described_class.from_incoming_header(malformed_baggage)
+          baggage = described_class.from_baggage_string(malformed_baggage)
           expect(baggage.serialize).to eq("")
         end
       end
 
       context "when only third party baggage" do
         it "is empty" do
-          baggage = described_class.from_incoming_header(third_party_baggage)
+          baggage = described_class.from_baggage_string(third_party_baggage)
           expect(baggage.serialize).to eq("")
         end
       end
 
       context "when mixed baggage" do
         it "populates DSC" do
-          baggage = described_class.from_incoming_header(mixed_baggage)
+          baggage = described_class.from_baggage_string(mixed_baggage)
 
           expect(baggage.serialize).to eq(
             "sentry-trace_id=771a43a4192642f0b136d5159a501700,"\
@@ -79,14 +79,14 @@ RSpec.describe Sentry::Baggage do
   describe "#mutable" do
     context "when only third party baggage" do
       it "is mutable" do
-        baggage = described_class.from_incoming_header(third_party_baggage)
+        baggage = described_class.from_baggage_string(third_party_baggage)
         expect(baggage.mutable).to eq(true)
       end
     end
 
     context "when has sentry baggage" do
       it "is immutable" do
-        baggage = described_class.from_incoming_header(mixed_baggage)
+        baggage = described_class.from_baggage_string(mixed_baggage)
         expect(baggage.mutable).to eq(false)
       end
     end
@@ -94,7 +94,7 @@ RSpec.describe Sentry::Baggage do
 
   describe "#freeze!" do
     it "makes it immutable" do
-      baggage = described_class.from_incoming_header(third_party_baggage)
+      baggage = described_class.from_baggage_string(third_party_baggage)
       expect(baggage.mutable).to eq(true)
       baggage.freeze!
       expect(baggage.mutable).to eq(false)

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Sentry::Client do
     end
 
     it "correct dynamic_sampling_context when incoming baggage header" do
-      baggage = Sentry::Baggage.from_incoming_header(
+      baggage = Sentry::Baggage.from_baggage_string(
         "other-vendor-value-1=foo;bar;baz, "\
         "sentry-trace_id=771a43a4192642f0b136d5159a501700, "\
         "sentry-public_key=49d0f7386ad645858ae85020e393bef3, "\
@@ -599,7 +599,7 @@ RSpec.describe Sentry::Client do
     let(:string_io) { StringIO.new }
     let(:logger) { ::Logger.new(string_io) }
     let(:baggage) do
-      Sentry::Baggage.from_incoming_header(
+      Sentry::Baggage.from_baggage_string(
         "other-vendor-value-1=foo;bar;baz, sentry-trace_id=771a43a4192642f0b136d5159a501700, "\
         "sentry-public_key=49d0f7386ad645858ae85020e393bef3, sentry-sample_rate=0.01337, "\
         "sentry-user_id=Am%C3%A9lie, other-vendor-value-2=foo;bar;"

--- a/sentry-ruby/spec/sentry/propagation_context_spec.rb
+++ b/sentry-ruby/spec/sentry/propagation_context_spec.rb
@@ -73,46 +73,50 @@ RSpec.describe Sentry::PropagationContext do
     end
 
     it "generates correct attributes when reading from ENV['SENTRY_TRACE'] and ENV['SENTRY_BAGGAGE]" do
-      ENV["SENTRY_TRACE"] = "771a43a4192642f0b136d5159a501700-7c51afd529da4a2a"
-      ENV["SENTRY_BAGGAGE"] = "other-vendor-value-1=foo;bar;baz, "\
-                          "sentry-trace_id=771a43a4192642f0b136d5159a501700, "\
-                          "sentry-public_key=49d0f7386ad645858ae85020e393bef3, "\
-                          "sentry-sample_rate=0.01337, "\
-                          "sentry-user_id=Am%C3%A9lie,  "\
-                          "other-vendor-value-2=foo;bar;"
+      begin
+        ENV["SENTRY_TRACE"] = "771a43a4192642f0b136d5159a501700-7c51afd529da4a2a"
+        ENV["SENTRY_BAGGAGE"] = "other-vendor-value-1=foo;bar;baz, "\
+                            "sentry-trace_id=771a43a4192642f0b136d5159a501700, "\
+                            "sentry-public_key=49d0f7386ad645858ae85020e393bef3, "\
+                            "sentry-sample_rate=0.01337, "\
+                            "sentry-user_id=Am%C3%A9lie,  "\
+                            "other-vendor-value-2=foo;bar;"
 
-      subject = described_class.new(scope)
-      expect(subject.trace_id).to eq("771a43a4192642f0b136d5159a501700")
-      expect(subject.span_id.length).to eq(16)
-      expect(subject.parent_span_id).to eq("7c51afd529da4a2a")
-      expect(subject.parent_sampled).to eq(nil)
-      expect(subject.incoming_trace).to eq(true)
-      expect(subject.baggage).to be_a(Sentry::Baggage)
-      expect(subject.baggage.mutable).to eq(false)
-      expect(subject.baggage.items).to eq({
-        "public_key"=>"49d0f7386ad645858ae85020e393bef3",
-        "sample_rate"=>"0.01337",
-        "trace_id"=>"771a43a4192642f0b136d5159a501700",
-        "user_id"=>"Amélie"
-      })
-    ensure
-      ENV.delete("SENTRY_TRACE")
-      ENV.delete("SENTRY_BAGGAGE")
+        subject = described_class.new(scope)
+        expect(subject.trace_id).to eq("771a43a4192642f0b136d5159a501700")
+        expect(subject.span_id.length).to eq(16)
+        expect(subject.parent_span_id).to eq("7c51afd529da4a2a")
+        expect(subject.parent_sampled).to eq(nil)
+        expect(subject.incoming_trace).to eq(true)
+        expect(subject.baggage).to be_a(Sentry::Baggage)
+        expect(subject.baggage.mutable).to eq(false)
+        expect(subject.baggage.items).to eq({
+          "public_key"=>"49d0f7386ad645858ae85020e393bef3",
+          "sample_rate"=>"0.01337",
+          "trace_id"=>"771a43a4192642f0b136d5159a501700",
+          "user_id"=>"Amélie"
+        })
+      ensure
+        ENV.delete("SENTRY_TRACE")
+        ENV.delete("SENTRY_BAGGAGE")
+      end
     end
 
     it "generates correct new trace_id when ENV values are malformed" do
-      ENV["SENTRY_TRACE"] = "I am borked lol"
-      ENV["SENTRY_BAGGAGE"] = "that's not it chief"
+      begin
+        ENV["SENTRY_TRACE"] = "I am borked lol"
+        ENV["SENTRY_BAGGAGE"] = "that's not it chief"
 
-      subject = described_class.new(scope)
-      expect(subject.trace_id.length).to eq(32)
-      expect(subject.span_id.length).to eq(16)
-      expect(subject.parent_sampled).to eq(nil)
-      expect(subject.incoming_trace).to eq(false)
-      expect(subject.baggage).to eq(nil)
-    ensure
-      ENV.delete("SENTRY_TRACE")
-      ENV.delete("SENTRY_BAGGAGE") 
+        subject = described_class.new(scope)
+        expect(subject.trace_id.length).to eq(32)
+        expect(subject.span_id.length).to eq(16)
+        expect(subject.parent_sampled).to eq(nil)
+        expect(subject.incoming_trace).to eq(false)
+        expect(subject.baggage).to eq(nil)
+      ensure
+        ENV.delete("SENTRY_TRACE")
+        ENV.delete("SENTRY_BAGGAGE") 
+      end
     end
 
     it "generates correct attributes when incoming sentry-trace only (from older SDKs)" do

--- a/sentry-ruby/spec/sentry/propagation_context_spec.rb
+++ b/sentry-ruby/spec/sentry/propagation_context_spec.rb
@@ -72,6 +72,49 @@ RSpec.describe Sentry::PropagationContext do
       })
     end
 
+    it "generates correct attributes when reading from ENV['SENTRY_TRACE'] and ENV['SENTRY_BAGGAGE]" do
+      ENV["SENTRY_TRACE"] = "771a43a4192642f0b136d5159a501700-7c51afd529da4a2a"
+      ENV["SENTRY_BAGGAGE"] = "other-vendor-value-1=foo;bar;baz, "\
+                          "sentry-trace_id=771a43a4192642f0b136d5159a501700, "\
+                          "sentry-public_key=49d0f7386ad645858ae85020e393bef3, "\
+                          "sentry-sample_rate=0.01337, "\
+                          "sentry-user_id=Am%C3%A9lie,  "\
+                          "other-vendor-value-2=foo;bar;"
+
+      subject = described_class.new(scope)
+      expect(subject.trace_id).to eq("771a43a4192642f0b136d5159a501700")
+      expect(subject.span_id.length).to eq(16)
+      expect(subject.parent_span_id).to eq("7c51afd529da4a2a")
+      expect(subject.parent_sampled).to eq(nil)
+      expect(subject.incoming_trace).to eq(true)
+      expect(subject.baggage).to be_a(Sentry::Baggage)
+      expect(subject.baggage.mutable).to eq(false)
+      expect(subject.baggage.items).to eq({
+        "public_key"=>"49d0f7386ad645858ae85020e393bef3",
+        "sample_rate"=>"0.01337",
+        "trace_id"=>"771a43a4192642f0b136d5159a501700",
+        "user_id"=>"Amélie"
+      })
+    ensure
+      ENV.delete("SENTRY_TRACE")
+      ENV.delete("SENTRY_BAGGAGE")
+    end
+
+    it "generates correct new trace_id when ENV values are malformed" do
+      ENV["SENTRY_TRACE"] = "I am borked lol"
+      ENV["SENTRY_BAGGAGE"] = "that's not it chief"
+
+      subject = described_class.new(scope)
+      expect(subject.trace_id.length).to eq(32)
+      expect(subject.span_id.length).to eq(16)
+      expect(subject.parent_sampled).to eq(nil)
+      expect(subject.incoming_trace).to eq(false)
+      expect(subject.baggage).to eq(nil)
+    ensure
+      ENV.delete("SENTRY_TRACE")
+      ENV.delete("SENTRY_BAGGAGE") 
+    end
+
     it "generates correct attributes when incoming sentry-trace only (from older SDKs)" do
       env = {
         "sentry-trace" => "771a43a4192642f0b136d5159a501700-7c51afd529da4a2a"

--- a/sentry-ruby/spec/sentry/span_spec.rb
+++ b/sentry-ruby/spec/sentry/span_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Sentry::Span do
     end
 
     subject do
-      baggage = Sentry::Baggage.from_incoming_header(
+      baggage = Sentry::Baggage.from_baggage_string(
         "other-vendor-value-1=foo;bar;baz, "\
         "sentry-trace_id=771a43a4192642f0b136d5159a501700, "\
         "sentry-public_key=49d0f7386ad645858ae85020e393bef3, "\

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -566,7 +566,7 @@ RSpec.describe Sentry::Transaction do
 
     context "when incoming baggage with sentry items" do
       let(:incoming_baggage) do
-        Sentry::Baggage.from_incoming_header("sentry-trace_id=12345,foo=bar")
+        Sentry::Baggage.from_baggage_string("sentry-trace_id=12345,foo=bar")
       end
 
       it "does not populate new baggage" do
@@ -580,7 +580,7 @@ RSpec.describe Sentry::Transaction do
 
     context "when incoming baggage with no sentry items" do
       let(:incoming_baggage) do
-        Sentry::Baggage.from_incoming_header("foo=bar")
+        Sentry::Baggage.from_baggage_string("foo=bar")
       end
 
       it "populates sentry baggage" do


### PR DESCRIPTION
## Summary

This pull request is part 3 of https://github.com/getsentry/sentry-ruby/issues/2056. It adds support for continuing traces by passing `SENTRY_TRACE` and `SENTRY_BAGGAGE` environment variables.

Closes #2099. 

## Changes

- I've renamed `Baggage.from_header` to be `Baggage.from_baggage_string` and ditto for traces, just for readability.
- Added ENV vars support and unit tests.
- Added a changelog entry.

## Reviewing

I'm new to distributed tracing, and Sentry implementation in particular, so I might need more handholding with the next few PRs. 

In #2056:

> You may update the traceId and dynamicSamplingContext from the request headers during an incoming request or **if the process was exposed to a SENTRY_TRACE and/or SENTRY_BAGGAGE environment variable if performance is disabled**.

In my current implementation, if the trace string was not passed in headers otherwise, `PropagationContext` will try and read the environment variable. It does NOT check whether Sentry Performance is enabled. Is that correct?

/cc @sl0thentr0py 