### PR TITLE
Correctly parse IPv6 addresses in Net::HTTP instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed a deprecation in `sidekiq-ruby` error handler [#2160](https://github.com/getsentry/sentry-ruby/pull/2160)
 - Avoid invoking ActiveSupport::BroadcastLogger if not defined [#2169](https://github.com/getsentry/sentry-ruby/pull/2169)
 - Respect custom `Delayed::Job.max_attempts` if it's defined [#2176](https://github.com/getsentry/sentry-ruby/pull/2176)
+- Fixed a bug where `Net::HTTP` instrumentation won't work for some IPv6 addresses [#2180](https://github.com/getsentry/sentry-ruby/pull/2180)
 
 ## 5.13.0
 

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -77,7 +77,10 @@ module Sentry
       end
 
       def extract_request_info(req)
-        uri = req.uri || URI.parse("#{use_ssl? ? 'https' : 'http'}://#{address}#{req.path}")
+        # IPv6 url could look like '::1/path', and that won't parse without
+        # wrapping it in square brackets.
+        hostname = address =~ Resolv::IPv6::Regex ? "[#{address}]" : address
+        uri = req.uri || URI.parse("#{use_ssl? ? 'https' : 'http'}://#{hostname}#{req.path}")
         url = "#{uri.scheme}://#{uri.host}#{uri.path}" rescue uri.to_s
 
         result = { method: req.method, url: url }

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "net/http"
+require "resolv"
 
 module Sentry
   # @api private

--- a/sentry-ruby/lib/sentry/transport/http_transport.rb
+++ b/sentry-ruby/lib/sentry/transport/http_transport.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "net/http"
+require "resolv"
 require "zlib"
 
 module Sentry

--- a/sentry-ruby/lib/sentry/transport/http_transport.rb
+++ b/sentry-ruby/lib/sentry/transport/http_transport.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "net/http"
-require "resolv"
 require "zlib"
 
 module Sentry

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe Sentry::Net::HTTP do
 
   context "with IPv6 addresses" do
     before do
-      perform_basic_setup
+      perform_basic_setup do |config|
+        config.traces_sample_rate = 1.0
+      end
     end
 
     it "correctly parses the short-hand IPv6 addresses" do

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -9,6 +9,21 @@ RSpec.describe Sentry::Net::HTTP do
     ::Logger.new(string_io)
   end
 
+  context "with IPv6 addresses" do
+    before do
+      perform_basic_setup
+    end
+
+    it "correctly parses the short-hand IPv6 addresses" do
+      stub_normal_response
+
+      conn = Net::HTTP.new('::1', 8080)
+      expect do
+        conn.request_post('/path', 'foo=1')
+      end.not_to raise_error
+    end
+  end
+
   context "with tracing enabled" do
     before do
       perform_basic_setup do |config|


### PR DESCRIPTION
## Summary

This pull request adds a `Net::HTTP` instrumentation fix for `extract_request_info` that makes it parse `IPv6` addresses correctly.

Fixes #2163. 

Thank you @Rotario for reporting and suggesting a fix!

## Changes
- Applied the workaround similar to what @Rotario suggested.
- Added a unit test.
- Added a changelog entry.