### PR TITLE
Add accidentally removed a test for a one-off job

### DIFF
--- a/sentry-sidekiq/spec/sentry/sidekiq-scheduler/scheduler_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq-scheduler/scheduler_spec.rb
@@ -49,6 +49,10 @@ RSpec.describe Sentry::SidekiqScheduler::Scheduler do
     expect(EveryHappyWorker.sentry_monitor_config.schedule.to_hash).to eq({value: 10, type: :interval, unit: :minute})
   end
 
+  it "does not add monitors for a one-off job" do
+    expect(ReportingWorker.ancestors).not_to include(Sentry::Cron::MonitorCheckIns)
+  end
+
  it 'truncates from the beginning and parameterizes slug' do
     expect(VeryLongOuterModule::VeryVeryVeryVeryLongInnerModule::Job.ancestors).to include(Sentry::Cron::MonitorCheckIns)
     expect(VeryLongOuterModule::VeryVeryVeryVeryLongInnerModule::Job.sentry_monitor_slug).to eq('ongoutermodule-veryveryveryverylonginnermodule-job')


### PR DESCRIPTION
## Description

I accidentally removed a test for a one-off job by #2184.
https://github.com/getsentry/sentry-ruby/pull/2184/files#diff-cab4c85d3478fad76ad07be02317c10e9d08a27eb9d50ae1f2a14b3166983c29L52-L54

This PR brings back it 🙏 
