### PR TITLE
Fix broken PR link in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- You can now use [Spotlight](https://spotlightjs.com) with your apps that use sentry-ruby! [#2175](https://github.com/getsentry/sentry-ruby/pulls/2175)
+- You can now use [Spotlight](https://spotlightjs.com) with your apps that use sentry-ruby! [#2175](https://github.com/getsentry/sentry-ruby/pull/2175)
 - Improve default slug generation for `sidekiq-scheduler` [#2184](https://github.com/getsentry/sentry-ruby/pull/2184)
 
 ### Bug Fixes


### PR DESCRIPTION
## Description
The link should point to <https://github.com/getsentry/sentry-ruby/pull/2175> `https://github.com/getsentry/sentry-ruby/pull/2175` (not "pulls").
