### PR TITLE
Put development/test dependencies into a shared Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,25 @@
 source "https://rubygems.org"
 git_source(:github) { |name| "https://github.com/#{name}.git" }
+
+gem "rake", "~> 12.0"
+
+ruby_version = Gem::Version.new(RUBY_VERSION)
+
+# Development tools
+if ruby_version >= Gem::Version.new("2.7.0")
+  gem "debug", github: "ruby/debug", platform: :ruby
+  gem "irb"
+
+  if ruby_version >= Gem::Version.new("3.0.0")
+    gem "ruby-lsp-rspec"
+  end
+end
+
+gem "pry"
+
+# For RSpec
+gem "rspec", "~> 3.0"
+gem "rspec-retry"
+gem 'simplecov'
+gem "simplecov-cobertura", "~> 1.4"
+gem "rexml"

--- a/sentry-delayed_job/Gemfile
+++ b/sentry-delayed_job/Gemfile
@@ -9,12 +9,6 @@ gem "sentry-rails", path: "../sentry-rails"
 # For https://github.com/ruby/psych/issues/655
 gem "psych", "5.1.0"
 
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"
-gem 'simplecov'
-gem "simplecov-cobertura", "~> 1.4"
-gem "rexml"
-
 gem "delayed_job"
 gem "delayed_job_active_record"
 gem "rails", "> 5.0.0", "< 7.1.0"
@@ -26,9 +20,4 @@ end
 
 gem "sqlite3", platform: :ruby
 
-if RUBY_VERSION.to_f >= 2.6
-  gem "debug", github: "ruby/debug", platform: :ruby
-  gem "irb"
-end
-
-gem "pry"
+eval_gemfile File.expand_path("../Gemfile", __dir__)

--- a/sentry-opentelemetry/Gemfile
+++ b/sentry-opentelemetry/Gemfile
@@ -4,21 +4,9 @@ git_source(:github) { |name| "https://github.com/#{name}.git" }
 # Specify your gem's dependencies in sentry-ruby.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"
-gem 'simplecov'
-gem "simplecov-cobertura", "~> 1.4"
-gem "rexml"
-
-# opentelemetry_version = ENV["OPENTELEMETRY_VERSION"]
-# opentelemetry_version = "1.2.0" if opentelemetry_version.nil?
-# gem "opentelemetry-sdk", "~> #{opentelemetry_version}"
-
 gem "opentelemetry-sdk"
 gem "opentelemetry-instrumentation-rails"
 
 gem "sentry-ruby", path: "../sentry-ruby"
 
-gem "object_tracer"
-gem "debug", github: "ruby/debug", platform: :ruby if RUBY_VERSION.to_f >= 2.6
-gem "pry"
+eval_gemfile File.expand_path("../Gemfile", __dir__)

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -35,12 +35,7 @@ gem "sprockets-rails"
 
 gem "sidekiq"
 
-gem "rspec", "~> 3.0"
-gem "rspec-retry"
 gem "rspec-rails", "~> 4.0"
-gem 'simplecov'
-gem "simplecov-cobertura", "~> 1.4"
-gem "rexml"
 
 ruby_version = Gem::Version.new(RUBY_VERSION)
 
@@ -50,20 +45,9 @@ if ruby_version < Gem::Version.new("2.5.0")
   gem "loofah", "2.20.0"
 end
 
-if ruby_version >= Gem::Version.new("2.6.0")
-  gem "debug", github: "ruby/debug", platform: :ruby
-  gem "irb"
-
-  if ruby_version >= Gem::Version.new("3.0.0")
-    gem "ruby-lsp-rspec"
-  end
-end
-
-gem "rake", "~> 12.0"
-
-gem "pry"
-
 gem "benchmark-ips"
 gem "benchmark_driver"
 gem "benchmark-ipsa"
 gem "benchmark-memory"
+
+eval_gemfile File.expand_path("../Gemfile", __dir__)

--- a/sentry-resque/Gemfile
+++ b/sentry-resque/Gemfile
@@ -8,20 +8,9 @@ gem "sentry-rails", path: "../sentry-rails"
 
 gem "rails"
 
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"
-gem 'simplecov'
-gem "simplecov-cobertura", "~> 1.4"
-gem "rexml"
-
 # For https://github.com/ruby/psych/issues/655
 gem "psych", "5.1.0"
 
 gem "resque-retry", "~> 1.8"
 
-if RUBY_VERSION.to_f >= 2.6
-  gem "debug", github: "ruby/debug", platform: :ruby
-  gem "irb"
-end
-
-gem "pry"
+eval_gemfile File.expand_path("../Gemfile", __dir__)

--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -12,27 +12,8 @@ gem "redis", "~> #{redis_rb_version}"
 
 gem "puma"
 
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"
-gem "rspec-retry"
 gem "timecop"
-gem "simplecov"
-gem "simplecov-cobertura", "~> 1.4"
-gem "rexml"
 gem "stackprof" unless RUBY_PLATFORM == "java"
-
-ruby_version = Gem::Version.new(RUBY_VERSION)
-
-if ruby_version >= Gem::Version.new("2.6.0")
-  gem "debug", github: "ruby/debug", platform: :ruby
-  gem "irb"
-
-  if ruby_version >= Gem::Version.new("3.0.0")
-    gem "ruby-lsp-rspec"
-  end
-end
-
-gem "pry"
 
 gem "benchmark-ips"
 gem "benchmark_driver"
@@ -41,3 +22,5 @@ gem "benchmark-memory"
 
 gem "yard", github: "lsegal/yard"
 gem "webrick"
+
+eval_gemfile File.expand_path("../Gemfile", __dir__)

--- a/sentry-sidekiq/Gemfile
+++ b/sentry-sidekiq/Gemfile
@@ -6,11 +6,6 @@ gemspec
 gem "sentry-ruby", path: "../sentry-ruby"
 gem "sentry-rails", path: "../sentry-rails"
 
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"
-gem 'simplecov'
-gem "simplecov-cobertura", "~> 1.4"
-gem "rexml"
 # https://github.com/flavorjones/loofah/pull/267
 # loofah changed the required ruby version in a patch so we need to explicitly pin it
 gem "loofah", "2.20.0" if RUBY_VERSION.to_f < 2.5
@@ -31,9 +26,4 @@ end
 
 gem "rails", "> 5.0.0", "< 7.1.0"
 
-if RUBY_VERSION.to_f >= 2.6
-  gem "debug", github: "ruby/debug", platform: :ruby
-  gem "irb"
-end
-
-gem "pry"
+eval_gemfile File.expand_path("../Gemfile", __dir__)


### PR DESCRIPTION
With 6 gems under this repo, it's been a headache to update development tooling for them with consistency. I think using a shared Gemfile to host all development (e.g. `debug`, `irb`) and test (e.g. `rspec`) dependencies will make this easier.

It also fixes the master CI as `debug` now requires Ruby 2.7+.

#skip-changelog