### PR TITLE
Add Ruby 3.3 to CI matrix

### DIFF
--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -13,7 +13,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      engine: cruby-jruby
+      min_version: 2.4
   test:
+    needs: ruby-versions
     defaults:
       run:
         working-directory: sentry-delayed_job
@@ -21,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.4, 2.5, 2.6, 2.7, "3.0", "3.1", "3.2", jruby]
+        ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ubuntu-latest]
         include:
           - {

--- a/.github/workflows/sentry_opentelemetry_test.yml
+++ b/.github/workflows/sentry_opentelemetry_test.yml
@@ -13,7 +13,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      engine: cruby-jruby
+      min_version: 2.6
   test:
+    needs: ruby-versions
     defaults:
       run:
         working-directory: sentry-opentelemetry
@@ -21,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.6, 2.7, "3.0", "3.1", "3.2", jruby]
+        ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         # opentelemetry_version: [1.2.0]
         os: [ubuntu-latest]
         include:

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         rails_version: [6.1.0, 7.0.0, 7.1.0]
-        ruby_version: [2.7, "3.0", "3.1", "3.2"]
+        ruby_version: [2.7, "3.0", "3.1", "3.2", "3.3"]
         os: [ubuntu-latest]
         include:
           - { os: ubuntu-latest, ruby_version: "2.4", rails_version: 5.0.0 }

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -13,7 +13,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      engine: cruby-jruby
+      min_version: 2.4
   test:
+    needs: ruby-versions
     defaults:
       run:
         working-directory: sentry-resque
@@ -21,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.4, 2.5, 2.6, 2.7, "3.0", "3.1", "3.2", jruby]
+        ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ubuntu-latest]
         include:
           - {

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -13,7 +13,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      engine: cruby-jruby
+      min_version: 2.4
   test:
+    needs: ruby-versions
     defaults:
       run:
         working-directory: sentry-ruby
@@ -21,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: [2.4, 2.5, 2.6, 2.7, "3.0", "3.1", "3.2", jruby]
+        ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         rack_version: [2.0, 3.0]
         redis_rb_version: [4.0]
         os: [ubuntu-latest]

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         sidekiq_version: ["5.0", "6.0", "7.0"]
-        ruby_version: ["2.7", "3.0", "3.1", "3.2", jruby]
+        ruby_version: ["2.7", "3.0", "3.1", "3.2", "3.3", jruby]
         os: [ubuntu-latest]
         include:
           - { os: ubuntu-latest, ruby_version: 2.4, sidekiq_version: 5.0 }


### PR DESCRIPTION
1. The `ruby_versions` workflow will save us from manually updating Ruby matrix in the future, a minor improvement.
    - It already adds Ruby 3.3 to the matrix to those adopted it.
1. We can't apply `ruby_versions` easily to sentry-rails & sentry-sidekiq as they have rather complicated Ruby vs lib version mapping.
    - So I manually added 3.3 to the Ruby matrix.

#skip-changelog