### PR TITLE
Pick up config.cron.default_timezone from Rails config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
     end
     ```
 
+- Pick up config.cron.default_timezone from Rails config ([#2213](https://github.com/getsentry/sentry-ruby/pull/2213))
+
 ## 5.15.2
 
 ### Bug Fixes

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -40,6 +40,7 @@ module Sentry
 
       configure_project_root
       configure_trusted_proxies
+      configure_cron_timezone
       extend_controller_methods if defined?(ActionController)
       patch_background_worker if defined?(ActiveRecord)
       override_streaming_reporter if defined?(ActionView)
@@ -68,6 +69,11 @@ module Sentry
 
     def configure_trusted_proxies
       Sentry.configuration.trusted_proxies += Array(::Rails.application.config.action_dispatch.trusted_proxies)
+    end
+
+    def configure_cron_timezone
+      tz_info = ::ActiveSupport::TimeZone.find_tzinfo(::Rails.application.config.time_zone)
+      Sentry.configuration.cron.default_timezone = tz_info.name
     end
 
     def extend_controller_methods

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe Sentry::Rails, type: :request do
       expect(app.middleware.find_index(Sentry::Rails::RescuedExceptionInterceptor)).to eq(index_of_debug_exceptions + 1)
     end
 
+    it "propagates timezone to cron config" do
+      # cron.default_timezone is set to nil by default
+      expect(Sentry.configuration.cron.default_timezone).to eq("Etc/UTC")
+    end
+
     it "inserts a callback to disable background_worker for the runner mode" do
       Sentry.configuration.background_worker_threads = 10
 


### PR DESCRIPTION
Since Rails apps should have their timezone set, I think we can pick up `config.cron.default_timezone` from it.