### PR TITLE
Don't add most scope data to CheckInEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
     ```
 - Clean up logging [#2216](https://github.com/getsentry/sentry-ruby/pull/2216)
 - Pick up config.cron.default_timezone from Rails config [#2213](https://github.com/getsentry/sentry-ruby/pull/2213)
+- Don't add most scope data (tags/extra/breadcrumbs) to `CheckInEvent` [#2217](https://github.com/getsentry/sentry-ruby/pull/2217)
 
 ## 5.15.2
 

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -446,12 +446,10 @@ module Sentry
     # @option options [Integer] duration seconds elapsed since this monitor started
     # @option options [Cron::MonitorConfig] monitor_config configuration for this monitor
     #
-    # @yieldparam scope [Scope]
-    #
     # @return [String, nil] The {CheckInEvent#check_in_id} to use for later updates on the same slug
-    def capture_check_in(slug, status, **options, &block)
+    def capture_check_in(slug, status, **options)
       return unless initialized?
-      get_current_hub.capture_check_in(slug, status, **options, &block)
+      get_current_hub.capture_check_in(slug, status, **options)
     end
 
     # Takes or initializes a new Sentry::Transaction and makes a sampling decision for it.

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -156,7 +156,7 @@ module Sentry
       capture_event(event, **options, &block)
     end
 
-    def capture_check_in(slug, status, **options, &block)
+    def capture_check_in(slug, status, **options)
       check_argument_type!(slug, ::String)
       check_argument_includes!(status, Sentry::CheckInEvent::VALID_STATUSES)
 
@@ -176,7 +176,7 @@ module Sentry
 
       return unless event
 
-      capture_event(event, **options, &block)
+      capture_event(event, **options)
       event.check_in_id
     end
 

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -222,9 +222,16 @@ RSpec.describe Sentry::Hub do
       expect(event[:monitor_config]).to include({ schedule: { type: :crontab, value: "* * * * *" } })
     end
 
-    it_behaves_like "capture_helper" do
-      let(:capture_helper) { :capture_check_in }
-      let(:capture_subject) { [slug, :ok] }
+    context "with sending not allowed" do
+      before do
+        expect(configuration).to receive(:sending_allowed?).and_return(false)
+      end
+
+      it "doesn't send the event nor assign last_event_id" do
+        subject.capture_check_in(slug, :ok)
+        expect(transport.events).to be_empty
+        expect(subject.last_event_id).to eq(nil)
+      end
     end
   end
 


### PR DESCRIPTION
I also removed the option to pass `&block` to the top level `Sentry.capture_check_in` since that would be useless now (pretty sure no one was using that anyway).

closes #2191 

