### PR TITLE
Pin sqlite3 for building gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.16.1
+
+### Bug Fixes
+
+- Pin `sqlite3` gem for building because of failed release [#2222](https://github.com/getsentry/sentry-ruby/pull/2222)
+
 ## 5.16.0
 
 ### Features

--- a/sentry-delayed_job/Gemfile
+++ b/sentry-delayed_job/Gemfile
@@ -18,6 +18,7 @@ platform :jruby do
   gem "jdbc-sqlite3"
 end
 
-gem "sqlite3", platform: :ruby
+# 1.7.0 dropped support for ruby < 3.0, remove later after upgrading craft setup
+gem "sqlite3", "1.6.9", platform: :ruby
 
 eval_gemfile File.expand_path("../Gemfile", __dir__)

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -17,7 +17,8 @@ rails_version = Gem::Version.new(rails_version)
 if rails_version < Gem::Version.new("6.0.0")
   gem "sqlite3", "~> 1.3.0", platform: :ruby
 else
-  gem "sqlite3", platform: :ruby
+  # 1.7.0 dropped support for ruby < 3.0, remove later after upgrading craft setup
+  gem "sqlite3", "1.6.9", platform: :ruby
 end
 
 if rails_version >= Gem::Version.new("7.2.0.alpha")


### PR DESCRIPTION
closes #2221 

new sqlite3 release 1.7.0 dropped support for ruby < 3.0, so building `sentry-rails` and `sentry-delayed_job` failed silently and only the rest were released by craft.

#skip-changelog