### PR TITLE
Fix warning about default gems on Ruby 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix warning about default gems on Ruby 3.3.0 ([#2225](https://github.com/getsentry/sentry-ruby/pull/2225))
+
 ## 5.16.1
 
 ### Bug Fixes

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "json"
-require "base64"
 require "sentry/envelope"
 
 module Sentry

--- a/sentry-ruby/sentry-ruby.gemspec
+++ b/sentry-ruby/sentry-ruby.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "concurrent-ruby", '~> 1.0', '>= 1.0.2'
+  spec.add_dependency "bigdecimal"
 end


### PR DESCRIPTION
## Description

Since Ruby 3.3.0, RubyGems and Bundler warn if users do require the gems that will become the bundled gems in the future version of Ruby.

Please see the "Standard library updates" section for the details.
https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/

`sentry-ruby` uses one of those gems, `bigdecimal`. So now get the warning like the following.
https://github.com/getsentry/sentry-ruby/actions/runs/7463068254/job/20306920751#step:6:89

This PR adds `bigdecimal` to the gemspec to fix the warning.

This PR also removed unused require of `base64`. `base64` is also the gem that will become the bundled gems. But, it seems that `sentry-ruby` doesn't use it now. So I just removed it.