### PR TITLE
Don't lock Rails under 7.1

### DIFF
--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
+          cache-version: 1
 
       - name: Run specs
         env:

--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -55,13 +55,12 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          bundler-cache: true
-          cache-version: 1
 
       - name: Run specs
         env:
           RUBYOPT: ${{ matrix.options.rubyopt }}
         run: |
+          bundle install --jobs 4 --retry 3
           bundle exec rake
 
       - name: Upload Coverage

--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -61,7 +61,6 @@ jobs:
         env:
           RUBYOPT: ${{ matrix.options.rubyopt }}
         run: |
-          bundle install --jobs 4 --retry 3
           bundle exec rake
 
       - name: Upload Coverage

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -53,7 +53,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
-          cache-version: 1
 
       - name: Start Redis
         uses: supercharge/redis-github-action@1.1.0

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
+          cache-version: 1
 
       - name: Start Redis
         uses: supercharge/redis-github-action@1.1.0

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sidekiq_version: ["5.0", "6.0", "7.0"]
+        sidekiq_version: ["5.0", "6.5", "7.0"]
         ruby_version: ["2.7", "3.0", "3.1", "3.2", "3.3", jruby]
         include:
           - { ruby_version: 2.4, sidekiq_version: 5.0 }

--- a/sentry-delayed_job/Gemfile
+++ b/sentry-delayed_job/Gemfile
@@ -11,7 +11,7 @@ gem "psych", "5.1.0"
 
 gem "delayed_job"
 gem "delayed_job_active_record"
-gem "rails", "> 5.0.0", "< 7.1.0"
+gem "rails", "> 5.0.0"
 
 platform :jruby do
   gem "activerecord-jdbcmysql-adapter"

--- a/sentry-delayed_job/Gemfile
+++ b/sentry-delayed_job/Gemfile
@@ -11,10 +11,12 @@ gem "psych", "5.1.0"
 
 gem "delayed_job"
 gem "delayed_job_active_record"
+
 gem "rails", "> 5.0.0"
 
 platform :jruby do
-  gem "activerecord-jdbcmysql-adapter"
+  # See https://github.com/jruby/activerecord-jdbc-adapter/issues/1139
+  gem "activerecord-jdbcmysql-adapter", github: "jruby/activerecord-jdbc-adapter"
   gem "jdbc-sqlite3"
 end
 

--- a/sentry-sidekiq/Gemfile
+++ b/sentry-sidekiq/Gemfile
@@ -24,6 +24,6 @@ if RUBY_VERSION.to_f >= 2.7 && sidekiq_version >= Gem::Version.new("6.0")
   gem "sidekiq-scheduler"
 end
 
-gem "rails", "> 5.0.0", "< 7.1.0"
+gem "rails", "> 5.0.0"
 
 eval_gemfile File.expand_path("../Gemfile", __dir__)


### PR DESCRIPTION
It's been over half of a year since Rails 7.1's release. I think all our test suites should include it in the test targets.

#skip-changelog