### PR TITLE
Fix CI and simplify matrix

### DIFF
--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -37,6 +37,11 @@ jobs:
                 },
             }
           - { ruby_version: "3.2", options: { codecov: 1 } }
+        exclude:
+          # Because Rails 7.0 currently doesn't work with Ruby head
+          # LoadError:
+          #  cannot load such file -- mutex_m
+          - { ruby_version: "head" }
     steps:
       - uses: actions/checkout@v1
       - name: Install sqlite

--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -24,21 +24,19 @@ jobs:
       run:
         working-directory: sentry-delayed_job
     name: Ruby ${{ matrix.ruby_version }}, options - ${{ toJson(matrix.options) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
-        os: [ubuntu-latest]
         include:
           - {
-              os: ubuntu-latest,
               ruby_version: "3.2",
               options:
                 {
                   rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal",
                 },
             }
-          - { os: ubuntu-latest, ruby_version: "3.2", options: { codecov: 1 } }
+          - { ruby_version: "3.2", options: { codecov: 1 } }
     steps:
       - uses: actions/checkout@v1
       - name: Install sqlite

--- a/.github/workflows/sentry_opentelemetry_test.yml
+++ b/.github/workflows/sentry_opentelemetry_test.yml
@@ -24,22 +24,20 @@ jobs:
       run:
         working-directory: sentry-opentelemetry
     name: Ruby ${{ matrix.ruby_version }} & OpenTelemetry ${{ matrix.opentelemetry_version }}, options - ${{ toJson(matrix.options) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         # opentelemetry_version: [1.2.0]
-        os: [ubuntu-latest]
         include:
           - {
-              os: ubuntu-latest,
               ruby_version: 3.2,
               options:
                 {
                   rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal",
                 },
             }
-          - { os: ubuntu-latest, ruby_version: 3.2, options: { codecov: 1 } }
+          - { ruby_version: 3.2, options: { codecov: 1 } }
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -18,35 +18,33 @@ jobs:
       run:
         working-directory: sentry-rails
     name: Ruby ${{ matrix.ruby_version }} & Rails ${{ matrix.rails_version }}, options - ${{ toJson(matrix.options) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         rails_version: [6.1.0, 7.0.0, 7.1.0]
         ruby_version: [2.7, "3.0", "3.1", "3.2", "3.3"]
-        os: [ubuntu-latest]
         include:
-          - { os: ubuntu-latest, ruby_version: "2.4", rails_version: 5.0.0 }
-          - { os: ubuntu-latest, ruby_version: "2.4", rails_version: 5.1.0 }
-          - { os: ubuntu-latest, ruby_version: "2.4", rails_version: 5.2.0 }
-          - { os: ubuntu-latest, ruby_version: "2.5", rails_version: 5.0.0 }
-          - { os: ubuntu-latest, ruby_version: "2.5", rails_version: 5.1.0 }
-          - { os: ubuntu-latest, ruby_version: "2.5", rails_version: 5.2.0 }
-          - { os: ubuntu-latest, ruby_version: "2.5", rails_version: 6.0.0 }
-          - { os: ubuntu-latest, ruby_version: "2.5", rails_version: 6.1.0 }
-          - { os: ubuntu-latest, ruby_version: "2.6", rails_version: 5.0.0 }
-          - { os: ubuntu-latest, ruby_version: "2.6", rails_version: 5.1.0 }
-          - { os: ubuntu-latest, ruby_version: "2.6", rails_version: 5.2.0 }
-          - { os: ubuntu-latest, ruby_version: "2.6", rails_version: 6.0.0 }
-          - { os: ubuntu-latest, ruby_version: "2.6", rails_version: 6.1.0 }
-          - { os: ubuntu-latest, ruby_version: "2.7", rails_version: 5.0.0 }
-          - { os: ubuntu-latest, ruby_version: "2.7", rails_version: 5.1.0 }
-          - { os: ubuntu-latest, ruby_version: "2.7", rails_version: 5.2.0 }
-          - { os: ubuntu-latest, ruby_version: "2.7", rails_version: 6.0.0 }
-          - { os: ubuntu-latest, ruby_version: "2.7", rails_version: 6.1.0 }
-          - { os: ubuntu-latest, ruby_version: "jruby", rails_version: 6.1.0 }
+          - { ruby_version: "2.4", rails_version: 5.0.0 }
+          - { ruby_version: "2.4", rails_version: 5.1.0 }
+          - { ruby_version: "2.4", rails_version: 5.2.0 }
+          - { ruby_version: "2.5", rails_version: 5.0.0 }
+          - { ruby_version: "2.5", rails_version: 5.1.0 }
+          - { ruby_version: "2.5", rails_version: 5.2.0 }
+          - { ruby_version: "2.5", rails_version: 6.0.0 }
+          - { ruby_version: "2.5", rails_version: 6.1.0 }
+          - { ruby_version: "2.6", rails_version: 5.0.0 }
+          - { ruby_version: "2.6", rails_version: 5.1.0 }
+          - { ruby_version: "2.6", rails_version: 5.2.0 }
+          - { ruby_version: "2.6", rails_version: 6.0.0 }
+          - { ruby_version: "2.6", rails_version: 6.1.0 }
+          - { ruby_version: "2.7", rails_version: 5.0.0 }
+          - { ruby_version: "2.7", rails_version: 5.1.0 }
+          - { ruby_version: "2.7", rails_version: 5.2.0 }
+          - { ruby_version: "2.7", rails_version: 6.0.0 }
+          - { ruby_version: "2.7", rails_version: 6.1.0 }
+          - { ruby_version: "jruby", rails_version: 6.1.0 }
           - {
-              os: ubuntu-latest,
               ruby_version: "3.2",
               rails_version: 7.1.0,
               options:
@@ -55,7 +53,6 @@ jobs:
                 },
             }
           - {
-              os: ubuntu-latest,
               ruby_version: "3.2",
               rails_version: 7.1.0,
               options: { codecov: 1 },

--- a/.github/workflows/sentry_raven_test.yml
+++ b/.github/workflows/sentry_raven_test.yml
@@ -7,8 +7,8 @@ on:
       - master
   pull_request:
     paths:
-      - 'sentry-raven/**'
-      - '.github/workflows/sentry_raven_test.yml'
+      - "sentry-raven/**"
+      - ".github/workflows/sentry_raven_test.yml"
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
@@ -20,14 +20,13 @@ jobs:
       run:
         working-directory: sentry-raven
     name: Test on ruby ${{ matrix.ruby_version }} and rails ${{ matrix.rails_version }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         rails_version: [0, 4.2, 5.2, 6.0.0]
-        ruby_version: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', jruby-9.3]
-        os: [ubuntu-latest]
+        ruby_version: [2.3, 2.4, 2.5, 2.6, 2.7, "3.0", jruby-9.3]
         include:
-          - ruby_version: '3.0'
+          - ruby_version: "3.0"
             rails_version: 0
           - ruby_version: 2.7
             rails_version: 6.0.0
@@ -41,30 +40,30 @@ jobs:
             rails_version: 4.2
           - ruby_version: jruby-9.3
             rails_version: 4.2
-          - ruby_version: '3.0'
+          - ruby_version: "3.0"
             rails_version: 4.2
-          - ruby_version: '3.0'
+          - ruby_version: "3.0"
             rails_version: 5.2
-          - ruby_version: '3.0'
+          - ruby_version: "3.0"
             rails_version: 6.0.0
 
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    - name: Set up Ruby ${{ matrix.ruby_version }}
-      uses: ruby/setup-ruby@v1
-      with:
-        bundler: 1
-        ruby-version: ${{ matrix.ruby_version }}
+      - name: Set up Ruby ${{ matrix.ruby_version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler: 1
+          ruby-version: ${{ matrix.ruby_version }}
 
-    - name: Start Redis
-      uses: supercharge/redis-github-action@1.1.0
-      with:
-        redis-version: 5
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.1.0
+        with:
+          redis-version: 5
 
-    - name: Build with Rails ${{ matrix.rails_version }}
-      env:
-        RAILS_VERSION: ${{ matrix.rails_version }}
-      run: |
-        bundle install --jobs 4 --retry 3
-        bundle exec rake
+      - name: Build with Rails ${{ matrix.rails_version }}
+        env:
+          RAILS_VERSION: ${{ matrix.rails_version }}
+        run: |
+          bundle install --jobs 4 --retry 3
+          bundle exec rake

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -24,21 +24,19 @@ jobs:
       run:
         working-directory: sentry-resque
     name: Ruby ${{ matrix.ruby_version }}, options - ${{ toJson(matrix.options) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
-        os: [ubuntu-latest]
         include:
           - {
-              os: ubuntu-latest,
               ruby_version: "3.2",
               options:
                 {
                   rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal",
                 },
             }
-          - { os: ubuntu-latest, ruby_version: "3.2", options: { codecov: 1 } }
+          - { ruby_version: "3.2", options: { codecov: 1 } }
     steps:
       - uses: actions/checkout@v1
       - name: Set up Ruby ${{ matrix.ruby_version }}

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -24,28 +24,16 @@ jobs:
       run:
         working-directory: sentry-ruby
     name: Ruby ${{ matrix.ruby_version }} & Rack ${{ matrix.rack_version }}, options - ${{ toJson(matrix.options) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         rack_version: [2.0, 3.0]
         redis_rb_version: [4.0]
-        os: [ubuntu-latest]
         include:
+          - { ruby_version: 3.2, rack_version: 0, redis_rb_version: 5.0 }
+          - { ruby_version: 3.2, rack_version: 2.0, redis_rb_version: 5.0 }
           - {
-              os: ubuntu-latest,
-              ruby_version: 3.2,
-              rack_version: 0,
-              redis_rb_version: 5.0,
-            }
-          - {
-              os: ubuntu-latest,
-              ruby_version: 3.2,
-              rack_version: 2.0,
-              redis_rb_version: 5.0,
-            }
-          - {
-              os: ubuntu-latest,
               ruby_version: 3.2,
               rack_version: 3.0,
               redis_rb_version: 5.0,
@@ -55,7 +43,6 @@ jobs:
                 },
             }
           - {
-              os: ubuntu-latest,
               ruby_version: 3.2,
               rack_version: 3.0,
               redis_rb_version: 5.0,

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -18,23 +18,21 @@ jobs:
       run:
         working-directory: sentry-sidekiq
     name: Ruby ${{ matrix.ruby_version }} & Sidekiq ${{ matrix.sidekiq_version }}, options - ${{ toJson(matrix.options) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         sidekiq_version: ["5.0", "6.0", "7.0"]
         ruby_version: ["2.7", "3.0", "3.1", "3.2", "3.3", jruby]
-        os: [ubuntu-latest]
         include:
-          - { os: ubuntu-latest, ruby_version: 2.4, sidekiq_version: 5.0 }
-          - { os: ubuntu-latest, ruby_version: 2.5, sidekiq_version: 5.0 }
-          - { os: ubuntu-latest, ruby_version: 2.5, sidekiq_version: 6.0 }
-          - { os: ubuntu-latest, ruby_version: 2.6, sidekiq_version: 5.0 }
-          - { os: ubuntu-latest, ruby_version: 2.6, sidekiq_version: 6.0 }
-          - { os: ubuntu-latest, ruby_version: jruby, sidekiq_version: 5.0 }
-          - { os: ubuntu-latest, ruby_version: jruby, sidekiq_version: 6.0 }
-          - { os: ubuntu-latest, ruby_version: jruby, sidekiq_version: 7.0 }
+          - { ruby_version: 2.4, sidekiq_version: 5.0 }
+          - { ruby_version: 2.5, sidekiq_version: 5.0 }
+          - { ruby_version: 2.5, sidekiq_version: 6.0 }
+          - { ruby_version: 2.6, sidekiq_version: 5.0 }
+          - { ruby_version: 2.6, sidekiq_version: 6.0 }
+          - { ruby_version: jruby, sidekiq_version: 5.0 }
+          - { ruby_version: jruby, sidekiq_version: 6.0 }
+          - { ruby_version: jruby, sidekiq_version: 7.0 }
           - {
-              os: ubuntu-latest,
               ruby_version: "3.2",
               sidekiq_version: 7.0,
               options:
@@ -43,7 +41,6 @@ jobs:
                 },
             }
           - {
-              os: ubuntu-latest,
               ruby_version: "3.2",
               sidekiq_version: 7.0,
               options: { codecov: 1 },


### PR DESCRIPTION
1. Since we only test against `ubuntu-latest`, I removed `os` from the matrix to simplify our workflow configs.
2. Because `sentry-delayed_job` still tests against `Rails 7.0`, which doesn't work with Ruby head atm due to `mutex_m` gem being migrated to bundled gem:

```
Failure/Error: require "active_record"

LoadError:
  cannot load such file -- mutex_m
# ./spec/spec_helper.rb:4:in `<top (required)>'
# ./spec/sentry/delayed_job/configuration_spec.rb:1:in `<top (required)>'
```

And I fixed it by excluding Ruby head from the matrix.

Ideally the fix should be to use Rails 7.1 for testing instead, but it's trickier than I thought. So I decided to fix it first and work on #2229 later.

#skip-changelog