### PR TITLE
Make sure sending_allowed? is respected irrespective of spotlight configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@
 - Only instantiate SessionFlusher when the SDK is enabled under the current env [#2245](https://github.com/getsentry/sentry-ruby/pull/2245)
   - Fixes [#2234](https://github.com/getsentry/sentry-ruby/issues/2234)
 - Update backtrace parsing regexp to support Ruby 3.4 ([#2252](https://github.com/getsentry/sentry-ruby/pull/2252))
+- Make sure ``sending_allowed?`` is respected irrespective of spotlight configuration ([#2231](https://github.com/getsentry/sentry-ruby/pull/2231))
+  - Fixes [#2226](https://github.com/getsentry/sentry-ruby/issues/2226)
 
 ## 5.16.1
 

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -172,8 +172,8 @@ module Sentry
         end
       end
 
-      transport.send_event(event)
-      spotlight_transport&.send_event(event)
+      transport.send_event(event) if configuration.sending_to_dsn_allowed?
+      spotlight_transport.send_event(event) if spotlight_transport
 
       event
     rescue => e

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -485,9 +485,13 @@ module Sentry
     end
 
     def sending_allowed?
+      spotlight || sending_to_dsn_allowed?
+    end
+
+    def sending_to_dsn_allowed?
       @errors = []
 
-      spotlight || (valid? && capture_in_environment?)
+      valid? && capture_in_environment?
     end
 
     def sample_allowed?

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -276,6 +276,17 @@ RSpec.describe Sentry::Configuration do
       subject.spotlight = true
       expect(subject.sending_allowed?).to eq(true)
     end
+
+    it "true when sending to dsn allowed" do
+      allow(subject).to receive(:sending_to_dsn_allowed?).and_return(true)
+      expect(subject.sending_allowed?).to eq(true)
+    end
+
+    it "false when no spotlight and sending to dsn not allowed" do
+      allow(subject).to receive(:sending_to_dsn_allowed?).and_return(false)
+      subject.spotlight = false
+      expect(subject.sending_allowed?).to eq(false)
+    end
   end
 
   context 'configuring for async' do

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -116,14 +116,22 @@ RSpec.describe Sentry do
         capture_subject
       end
 
-      it "doesn't send the event nor assign last_event_id" do
-        # don't even initialize Event objects
+      it "doesn't build the event" do
+        # don't even initialize event objects
         expect(Sentry::Event).not_to receive(:new)
-
         described_class.send(capture_helper, capture_subject)
+      end
+    end
 
+    context "with sending allowed but sending to dsn not allowed" do
+      before do
+        allow(Sentry.configuration).to receive(:sending_allowed?).and_return(true)
+        allow(Sentry.configuration).to receive(:sending_to_dsn_allowed?).and_return(false)
+      end
+
+      it "doesn't send the event nor assign last_event_id" do
+        described_class.send(capture_helper, capture_subject)
         expect(sentry_events).to be_empty
-        expect(subject.last_event_id).to eq(nil)
       end
     end
 


### PR DESCRIPTION
we need to make a difference between the 'event building' and the 'sending' so I made this more explicit. 

fixes #2226 