### PR TITLE
Add support for distributed tracing for DelayedJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- Add support for distributed tracing in `sentry-delayed_job` [#2233](https://github.com/getsentry/sentry-ruby/pull/2233)
 - Fix warning about default gems on Ruby 3.3.0 ([#2225](https://github.com/getsentry/sentry-ruby/pull/2225))
 - Add `hint:` support to `Sentry::Rails::ErrorSubscriber` [#2235](https://github.com/getsentry/sentry-ruby/pull/2235)
 

--- a/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
+++ b/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
@@ -120,12 +120,10 @@ module Sentry
         payload_object = job.payload_object
         return nil unless payload_object.is_a?(Delayed::PerformableMethod)
 
-        ind = payload_object.args.index { |a| a.is_a?(Hash) && a.key?(:sentry) }
-        return nil unless ind
-
-        env = payload_object.args[ind][:sentry]
-        payload_object.args.delete_at(ind)
-        env
+        target_payload = payload_object.args.find { |a| a.is_a?(Hash) && a.key?(:sentry) }
+        return nil unless target_payload
+        payload_object.args.delete(target_payload)
+        target_payload[:sentry]
       end
     end
   end

--- a/sentry-delayed_job/spec/spec_helper.rb
+++ b/sentry-delayed_job/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "bundler/setup"
+require "debug" if RUBY_VERSION.to_f >= 2.6 && RUBY_ENGINE == "ruby"
 require "pry"
 
 require "active_record"


### PR DESCRIPTION
* works for `PerformableMethod`
* activejob will be done more generally

part of #1904 