### PR TITLE
Adopt rubocop and format the project

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: Lint
+
+on:
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - name: Run rubocop
+        run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,9 @@
+inherit_gem:
+  rubocop-rails-omakase: rubocop.yml
+
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: false
+
+AllCops:
+  Exclude:
+    - 'sentry-raven/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ end
 # For RSpec
 gem "rspec", "~> 3.0"
 gem "rspec-retry"
-gem 'simplecov'
+gem "simplecov"
 gem "simplecov-cobertura", "~> 1.4"
 gem "rexml"
+
+gem "rubocop-rails-omakase"

--- a/sentry-delayed_job/Rakefile
+++ b/sentry-delayed_job/Rakefile
@@ -5,4 +5,4 @@ RSpec::Core::RakeTask.new(:spec).tap do |task|
   task.rspec_opts = "--order rand"
 end
 
-task :default => :spec
+task default: :spec

--- a/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
+++ b/sentry-delayed_job/lib/sentry/delayed_job/plugin.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "delayed_job"
 
 module Sentry
@@ -55,7 +56,7 @@ module Sentry
           created_at: job.created_at,
           last_error: job.last_error&.byteslice(0..1000),
           handler: job.handler&.byteslice(0..1000),
-          job_class: compute_job_class(job.payload_object),
+          job_class: compute_job_class(job.payload_object)
         }
 
         if job.payload_object.respond_to?(:job_data)

--- a/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
+++ b/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
@@ -357,7 +357,6 @@ RSpec.describe Sentry::DelayedJob do
     end
 
     it 'returns the class name for anything else' do
-
       expect(Sentry::DelayedJob::Plugin.compute_job_class("something")).to eq("String")
       expect(Sentry::DelayedJob::Plugin.compute_job_class(Sentry::DelayedJob::Plugin)).to eq("Class")
     end

--- a/sentry-opentelemetry/Rakefile
+++ b/sentry-opentelemetry/Rakefile
@@ -5,4 +5,4 @@ RSpec::Core::RakeTask.new(:spec).tap do |task|
   task.rspec_opts = "--order rand"
 end
 
-task :default => :spec
+task default: :spec

--- a/sentry-opentelemetry/lib/sentry/opentelemetry/propagator.rb
+++ b/sentry-opentelemetry/lib/sentry/opentelemetry/propagator.rb
@@ -3,7 +3,6 @@
 module Sentry
   module OpenTelemetry
     class Propagator
-
       FIELDS = [SENTRY_TRACE_HEADER_NAME, BAGGAGE_HEADER_NAME].freeze
 
       SENTRY_TRACE_KEY = ::OpenTelemetry::Context.create_key('sentry-trace')
@@ -53,12 +52,12 @@ module Sentry
 
         baggage = if baggage_header && !baggage_header.empty?
                     Baggage.from_incoming_header(baggage_header)
-                  else
+        else
                     # If there's an incoming sentry-trace but no incoming baggage header,
                     # for instance in traces coming from older SDKs,
                     # baggage will be empty and frozen and won't be populated as head SDK.
                     Baggage.new({})
-                  end
+        end
 
         baggage.freeze!
         context = context.set_value(SENTRY_BAGGAGE_KEY, baggage)

--- a/sentry-opentelemetry/lib/sentry/opentelemetry/propagator.rb
+++ b/sentry-opentelemetry/lib/sentry/opentelemetry/propagator.rb
@@ -50,14 +50,15 @@ module Sentry
 
         baggage_header = getter.get(carrier, BAGGAGE_HEADER_NAME)
 
-        baggage = if baggage_header && !baggage_header.empty?
-                    Baggage.from_incoming_header(baggage_header)
-        else
-                    # If there's an incoming sentry-trace but no incoming baggage header,
-                    # for instance in traces coming from older SDKs,
-                    # baggage will be empty and frozen and won't be populated as head SDK.
-                    Baggage.new({})
-        end
+        baggage =
+          if baggage_header && !baggage_header.empty?
+            Baggage.from_incoming_header(baggage_header)
+          else
+            # If there's an incoming sentry-trace but no incoming baggage header,
+            # for instance in traces coming from older SDKs,
+            # baggage will be empty and frozen and won't be populated as head SDK.
+            Baggage.new({})
+          end
 
         baggage.freeze!
         context = context.set_value(SENTRY_BAGGAGE_KEY, baggage)

--- a/sentry-opentelemetry/lib/sentry/opentelemetry/span_processor.rb
+++ b/sentry-opentelemetry/lib/sentry/opentelemetry/span_processor.rb
@@ -10,7 +10,7 @@ module Sentry
       include Singleton
 
       SEMANTIC_CONVENTIONS = ::OpenTelemetry::SemanticConventions::Trace
-      INTERNAL_SPAN_KINDS = %i(client internal)
+      INTERNAL_SPAN_KINDS = %i[client internal]
 
       # The mapping from otel span ids to sentry spans
       # @return [Hash]

--- a/sentry-rails/Rakefile
+++ b/sentry-rails/Rakefile
@@ -11,4 +11,4 @@ task :isolated_specs do
   end
 end
 
-task :default => [:spec, :isolated_specs]
+task default: [:spec, :isolated_specs]

--- a/sentry-rails/app/jobs/sentry/send_event_job.rb
+++ b/sentry-rails/app/jobs/sentry/send_event_job.rb
@@ -31,4 +31,3 @@ else
     class SendEventJob; end
   end
 end
-

--- a/sentry-rails/benchmarks/application.rb
+++ b/sentry-rails/benchmarks/application.rb
@@ -10,4 +10,3 @@ def create_app(&block)
   session.extend(app.routes.url_helpers)
   session.extend(app.routes.mounted_helpers)
 end
-

--- a/sentry-rails/examples/rails-5.2/app/controllers/welcome_controller.rb
+++ b/sentry-rails/examples/rails-5.2/app/controllers/welcome_controller.rb
@@ -4,6 +4,6 @@ class WelcomeController < ApplicationController
   end
 
   def report_demo
-    render(:status => 500)
+    render(status: 500)
   end
 end

--- a/sentry-rails/examples/rails-5.2/db/schema.rb
+++ b/sentry-rails/examples/rails-5.2/db/schema.rb
@@ -11,12 +11,10 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_01_12_160711) do
-
   create_table "posts", force: :cascade do |t|
     t.string "title"
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
-
 end

--- a/sentry-rails/examples/rails-6.0/app/controllers/welcome_controller.rb
+++ b/sentry-rails/examples/rails-6.0/app/controllers/welcome_controller.rb
@@ -42,7 +42,7 @@ class WelcomeController < ApplicationController
 
   def report_demo
     # @sentry_event_id = Raven.last_event_id
-    render(:status => 500)
+    render(status: 500)
   end
 
   private

--- a/sentry-rails/examples/rails-6.0/config/environments/test.rb
+++ b/sentry-rails/examples/rails-6.0/config/environments/test.rb
@@ -5,7 +5,7 @@
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-  
+
   config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application

--- a/sentry-rails/examples/rails-6.0/config/routes.rb
+++ b/sentry-rails/examples/rails-6.0/config/routes.rb
@@ -2,7 +2,7 @@ require "resque/server"
 
 Rails.application.routes.draw do
   resources :posts
-  get '500', :to => 'welcome#report_demo'
+  get '500', to: 'welcome#report_demo'
   root to: "welcome#index"
 
   get 'appearance', to: 'welcome#appearance'
@@ -16,5 +16,5 @@ Rails.application.routes.draw do
   require 'sidekiq/web'
 
   mount Sidekiq::Web => '/sidekiq'
-  mount Resque::Server.new, :at => "/resque"
+  mount Resque::Server.new, at: "/resque"
 end

--- a/sentry-rails/examples/rails-6.0/db/schema.rb
+++ b/sentry-rails/examples/rails-6.0/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_12_19_212232) do
-
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false

--- a/sentry-rails/examples/rails-7.0/app/controllers/welcome_controller.rb
+++ b/sentry-rails/examples/rails-7.0/app/controllers/welcome_controller.rb
@@ -42,7 +42,7 @@ class WelcomeController < ApplicationController
 
   def report_demo
     # @sentry_event_id = Raven.last_event_id
-    render(:status => 500)
+    render(status: 500)
   end
 
   private

--- a/sentry-rails/examples/rails-7.0/config/routes.rb
+++ b/sentry-rails/examples/rails-7.0/config/routes.rb
@@ -2,7 +2,7 @@ require "resque/server"
 
 Rails.application.routes.draw do
   resources :posts
-  get '500', :to => 'welcome#report_demo'
+  get '500', to: 'welcome#report_demo'
   root to: "welcome#index"
 
   get 'appearance', to: 'welcome#appearance'
@@ -16,5 +16,5 @@ Rails.application.routes.draw do
   require 'sidekiq/web'
 
   mount Sidekiq::Web => '/sidekiq'
-  mount Resque::Server.new, :at => "/resque"
+  mount Resque::Server.new, at: "/resque"
 end

--- a/sentry-rails/examples/rails-7.0/db/schema.rb
+++ b/sentry-rails/examples/rails-7.0/db/schema.rb
@@ -17,5 +17,4 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_03_110436) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
-
 end

--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -104,7 +104,7 @@ module Sentry
       "service_url.active_storage" => %i[service key url],
       "service_update_metadata.active_storage" => %i[service key],
       "preview.active_storage" => %i[key],
-      "analyze.active_storage" => %i[analyzer],
+      "analyze.active_storage" => %i[analyzer]
     }.freeze
 
     class Configuration

--- a/sentry-rails/lib/sentry/rails/tracing/abstract_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/abstract_subscriber.rb
@@ -2,7 +2,6 @@ module Sentry
   module Rails
     module Tracing
       class AbstractSubscriber
-
         class << self
           def subscribe!
             raise NotImplementedError

--- a/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
@@ -27,11 +27,12 @@ module Sentry
 
               next unless connection
 
-              db_config = if connection.pool.respond_to?(:db_config)
-                            connection.pool.db_config.configuration_hash
-              elsif connection.pool.respond_to?(:spec)
-                            connection.pool.spec.config
-              end
+              db_config =
+                if connection.pool.respond_to?(:db_config)
+                  connection.pool.db_config.configuration_hash
+                elsif connection.pool.respond_to?(:spec)
+                  connection.pool.spec.config
+                end
 
               next unless db_config
 

--- a/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
@@ -29,9 +29,9 @@ module Sentry
 
               db_config = if connection.pool.respond_to?(:db_config)
                             connection.pool.db_config.configuration_hash
-                          elsif connection.pool.respond_to?(:spec)
+              elsif connection.pool.respond_to?(:spec)
                             connection.pool.spec.config
-                          end
+              end
 
               next unless db_config
 

--- a/sentry-rails/lib/sentry/rails/tracing/active_storage_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/active_storage_subscriber.rb
@@ -4,7 +4,7 @@ module Sentry
   module Rails
     module Tracing
       class ActiveStorageSubscriber < AbstractSubscriber
-        EVENT_NAMES = %w(
+        EVENT_NAMES = %w[
           service_upload.active_storage
           service_download.active_storage
           service_streaming_download.active_storage
@@ -17,7 +17,7 @@ module Sentry
           service_update_metadata.active_storage
           preview.active_storage
           analyze.active_storage
-        ).freeze
+        ].freeze
 
         def self.subscribe!
           subscribe_to_event(EVENT_NAMES) do |event_name, duration, payload|

--- a/sentry-rails/spec/dummy/test_rails_app/app.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/app.rb
@@ -24,17 +24,17 @@ v7_1 = Gem::Version.new("7.1.alpha")
 
 FILE_NAME =
   case Gem::Version.new(Rails.version)
-  when -> (v) { v < v5_2 }
+  when ->(v) { v < v5_2 }
     "5-0"
-  when -> (v) { v.between?(v5_2, v6_0) }
+  when ->(v) { v.between?(v5_2, v6_0) }
     "5-2"
-  when -> (v) { v.between?(v6_0, v6_1) }
+  when ->(v) { v.between?(v6_0, v6_1) }
     "6-0"
-  when -> (v) { v.between?(v6_1, v7_0) }
+  when ->(v) { v.between?(v6_1, v7_0) }
     "6-1"
-  when -> (v) { v > v7_0 && v < v7_1 }
+  when ->(v) { v > v7_0 && v < v7_1 }
     "7-0"
-  when -> (v) { v >= v7_1 }
+  when ->(v) { v >= v7_1 }
     "7-1"
   end
 
@@ -60,10 +60,10 @@ def make_basic_app(&block)
   configure_app(app)
 
   app.routes.append do
-    get "/exception", :to => "hello#exception"
-    get "/view_exception", :to => "hello#view_exception"
-    get "/view", :to => "hello#view"
-    get "/not_found", :to => "hello#not_found"
+    get "/exception", to: "hello#exception"
+    get "/view_exception", to: "hello#view_exception"
+    get "/view", to: "hello#view"
+    get "/not_found", to: "hello#not_found"
     get "/world", to: "hello#world"
     get "/with_custom_instrumentation", to: "hello#with_custom_instrumentation"
     resources :posts, only: [:index, :show] do
@@ -72,7 +72,7 @@ def make_basic_app(&block)
       end
     end
     get "500", to: "hello#reporting"
-    root :to => "hello#world"
+    root to: "hello#world"
   end
 
   app.initializer :configure_sentry do

--- a/sentry-rails/spec/dummy/test_rails_app/apps/5-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/5-0.rb
@@ -46,7 +46,7 @@ class HelloController < ActionController::Base
   end
 
   def world
-    render :plain => "Hello World!"
+    render plain: "Hello World!"
   end
 
   def with_custom_instrumentation

--- a/sentry-rails/spec/dummy/test_rails_app/apps/5-2.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/5-2.rb
@@ -61,7 +61,7 @@ class PostsController < ActionController::Base
 
     attach_params = {
       io: File.open(File.join(Rails.root, 'public', 'sentry-logo.png')),
-      filename: 'sentry-logo.png',
+      filename: 'sentry-logo.png'
     }
 
     p.cover.attach(attach_params)
@@ -88,7 +88,7 @@ class HelloController < ActionController::Base
   end
 
   def world
-    render :plain => "Hello World!"
+    render plain: "Hello World!"
   end
 
   def with_custom_instrumentation

--- a/sentry-rails/spec/dummy/test_rails_app/apps/6-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/6-0.rb
@@ -61,7 +61,7 @@ class PostsController < ActionController::Base
 
     attach_params = {
       io: File.open(File.join(Rails.root, 'public', 'sentry-logo.png')),
-      filename: 'sentry-logo.png',
+      filename: 'sentry-logo.png'
     }
 
     p.cover.attach(attach_params)
@@ -88,7 +88,7 @@ class HelloController < ActionController::Base
   end
 
   def world
-    render :plain => "Hello World!"
+    render plain: "Hello World!"
   end
 
   def with_custom_instrumentation

--- a/sentry-rails/spec/dummy/test_rails_app/apps/6-1.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/6-1.rb
@@ -89,7 +89,7 @@ class HelloController < ActionController::Base
   end
 
   def world
-    render :plain => "Hello World!"
+    render plain: "Hello World!"
   end
 
   def with_custom_instrumentation

--- a/sentry-rails/spec/dummy/test_rails_app/apps/7-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/7-0.rb
@@ -89,7 +89,7 @@ class HelloController < ActionController::Base
   end
 
   def world
-    render :plain => "Hello World!"
+    render plain: "Hello World!"
   end
 
   def with_custom_instrumentation

--- a/sentry-rails/spec/dummy/test_rails_app/apps/7-1.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/7-1.rb
@@ -89,7 +89,7 @@ class HelloController < ActionController::Base
   end
 
   def world
-    render :plain => "Hello World!"
+    render plain: "Hello World!"
   end
 
   def with_custom_instrumentation

--- a/sentry-rails/spec/dummy/test_rails_app/configs/5-2.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/5-2.rb
@@ -5,4 +5,3 @@ def run_pre_initialize_cleanup; end
 def configure_app(app)
   app.config.active_storage.service = :test
 end
-

--- a/sentry-rails/spec/dummy/test_rails_app/configs/6-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/6-0.rb
@@ -11,4 +11,3 @@ def configure_app(app)
   app.config.active_record.sqlite3 = ActiveSupport::OrderedOptions.new
   app.config.active_record.sqlite3.represent_boolean_as_integer = nil
 end
-

--- a/sentry-rails/spec/dummy/test_rails_app/configs/6-1.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/6-1.rb
@@ -9,4 +9,3 @@ end
 def configure_app(app)
   app.config.active_storage.service = :test
 end
-

--- a/sentry-rails/spec/isolated/active_job_activation.rb
+++ b/sentry-rails/spec/isolated/active_job_activation.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # for https://github.com/getsentry/sentry-ruby/issues/1249
 require "active_job/railtie"
 require "active_support/all"

--- a/sentry-rails/spec/sentry/rails/action_cable_spec.rb
+++ b/sentry-rails/spec/sentry/rails/action_cable_spec.rb
@@ -132,7 +132,7 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
 
       describe ContentChannel do
         before { subscribe }
-        
+
         it "perform_action returns content" do
           expect(perform :content, foo: 'bar').to eq("value")
         end

--- a/sentry-rails/spec/sentry/rails/activejob_spec.rb
+++ b/sentry-rails/spec/sentry/rails/activejob_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe "ActiveJob integration" do
         [
           {
             "integer" => 1,
-            "post" => post.to_s,
+            "post" => post.to_s
           }
         ]
       )

--- a/sentry-rails/spec/sentry/rails/breadcrumbs/active_support_logger_spec.rb
+++ b/sentry-rails/spec/sentry/rails/breadcrumbs/active_support_logger_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Sentry::Breadcrumbs::ActiveSupportLogger", type: :request do
           "action" => "exception",
           "params" => { "controller" => "hello", "action" => "exception" },
           "format" => "html",
-          "method" => "GET", "path" => "/exception",
+          "method" => "GET", "path" => "/exception"
         }
       )
       expect(breadcrumb["data"].keys).not_to include("headers")
@@ -83,7 +83,7 @@ RSpec.describe "Sentry::Breadcrumbs::ActiveSupportLogger", type: :request do
             "action" => "exception",
             "params" => { "controller" => "hello", "action" => "exception" },
             "format" => "html",
-            "method" => "GET", "path" => "/exception",
+            "method" => "GET", "path" => "/exception"
           }
         )
         expect(breadcrumb["data"].keys).not_to include("controller")
@@ -113,7 +113,7 @@ RSpec.describe "Sentry::Breadcrumbs::ActiveSupportLogger", type: :request do
           "action" => "show",
           "params" => { "controller" => "posts", "action" => "show", "id" => p.id.to_s },
           "format" => "html",
-          "method" => "GET", "path" => "/posts/#{p.id}",
+          "method" => "GET", "path" => "/posts/#{p.id}"
         }
       )
       expect(breadcrumb["data"].keys).not_to include("headers")

--- a/sentry-rails/spec/sentry/rails/breadcrumbs/monotonic_active_support_logger_spec.rb
+++ b/sentry-rails/spec/sentry/rails/breadcrumbs/monotonic_active_support_logger_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Sentry::Breadcrumbs::MonotonicActiveSupportLogger", type: :reque
             "action" => "exception",
             "params" => { "controller" => "hello", "action" => "exception" },
             "format" => "html",
-            "method" => "GET", "path" => "/exception",
+            "method" => "GET", "path" => "/exception"
           }
         )
         expect(breadcrumb["data"].keys).not_to include("headers")
@@ -117,7 +117,7 @@ RSpec.describe "Sentry::Breadcrumbs::MonotonicActiveSupportLogger", type: :reque
             "action" => "show",
             "params" => { "controller" => "posts", "action" => "show", "id" => p.id.to_s },
             "format" => "html",
-            "method" => "GET", "path" => "/posts/#{p.id}",
+            "method" => "GET", "path" => "/posts/#{p.id}"
           }
         )
         expect(breadcrumb["data"].keys).not_to include("headers")

--- a/sentry-rails/spec/sentry/rails/controller_methods_spec.rb
+++ b/sentry-rails/spec/sentry/rails/controller_methods_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Sentry::Rails::ControllerMethods do
   end
 
   let(:options) do
-    { tags: { new_tag: true }}
+    { tags: { new_tag: true } }
   end
 
   let(:transport) do

--- a/sentry-rails/spec/sentry/rails/error_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/error_subscriber_spec.rb
@@ -103,6 +103,5 @@ RSpec.describe Sentry::Rails::ErrorSubscriber, skip: Rails.version.to_f < 7.0 ? 
         end
       end
     end
-
   end
 end

--- a/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
       cached_query_span = transaction[:spans][1]
       expect(cached_query_span[:op]).to eq("db.sql.active_record")
       expect(cached_query_span[:description]).to eq("SELECT \"posts\".* FROM \"posts\"")
-      expect(cached_query_span[:tags]).to include({cached: true})
+      expect(cached_query_span[:tags]).to include({ cached: true })
 
       data = cached_query_span[:data]
       expect(data["db.name"]).to include("db")

--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
           app.config.public_file_server.enabled = true
           config.traces_sample_rate = 1.0
           config.logger = logger
-          config.rails.assets_regexp = %r(/foo/)
+          config.rails.assets_regexp = %r{/foo/}
         end
       end
 

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe Sentry::Rails, type: :request do
         end
 
         expect(event.level).to eq(:info)
-        expect(event.contexts).to include({ "rails.error" => { foo: "bar" }})
+        expect(event.contexts).to include({ "rails.error" => { foo: "bar" } })
       end
 
       it "skips cache storage sources", skip: Rails.version.to_f < 7.1 do

--- a/sentry-resque/Rakefile
+++ b/sentry-resque/Rakefile
@@ -5,4 +5,4 @@ RSpec::Core::RakeTask.new(:spec).tap do |task|
   task.rspec_opts = "--order rand"
 end
 
-task :default => :spec
+task default: :spec

--- a/sentry-resque/spec/sentry/resque_spec.rb
+++ b/sentry-resque/spec/sentry/resque_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Sentry::Resque do
       expect(transport.events.count).to eq(1)
       event = transport.events.last.to_hash
 
-      expect(event[:tags]).to eq({ "resque.queue" => "default", number: 1})
+      expect(event[:tags]).to eq({ "resque.queue" => "default", number: 1 })
       expect(Sentry.get_current_scope.extra).to eq({})
       expect(Sentry.get_current_scope.tags).to eq({})
 

--- a/sentry-ruby/Rakefile
+++ b/sentry-ruby/Rakefile
@@ -17,4 +17,4 @@ task :isolated_specs do
   end
 end
 
-task :default => [:spec, :isolated_specs]
+task default: [:spec, :isolated_specs]

--- a/sentry-ruby/examples/crons/Rakefile.rb
+++ b/sentry-ruby/examples/crons/Rakefile.rb
@@ -58,7 +58,7 @@ task :heartbeat do
   # This will tell Sentry that this cron run was successful.
   Sentry.capture_check_in(
     "rake-task-example",
-    :ok, 
+    :ok,
     monitor_config: monitor_config
   )
 end
@@ -72,7 +72,7 @@ task :raise_exception do
 
   puts "rake task is running"
 
-  # If you raise an error within the job, Sentry will report it and link 
+  # If you raise an error within the job, Sentry will report it and link
   # the issue to the cron job. But the job itself will be marked as "in progress"
   # until either your job sends another check-in, or it timeouts.
   raise "This job errored out"

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -26,7 +26,7 @@ require "sentry/cron/monitor_check_ins"
 
 [
   "sentry/rake",
-  "sentry/rack",
+  "sentry/rack"
 ].each do |lib|
   begin
     require lib

--- a/sentry-ruby/lib/sentry/check_in_event.rb
+++ b/sentry-ruby/lib/sentry/check_in_event.rb
@@ -27,7 +27,7 @@ module Sentry
     # @return [Symbol]
     attr_accessor :status
 
-    VALID_STATUSES = %i(ok in_progress error)
+    VALID_STATUSES = %i[ok in_progress error]
 
     def initialize(
       slug:,

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -311,11 +311,11 @@ module Sentry
       'Sinatra::NotFound'
     ].freeze
 
-    RACK_ENV_WHITELIST_DEFAULT = %w(
+    RACK_ENV_WHITELIST_DEFAULT = %w[
       REMOTE_ADDR
       SERVER_NAME
       SERVER_PORT
-    ).freeze
+    ].freeze
 
     HEROKU_DYNO_METADATA_MESSAGE = "You are running on Heroku but haven't enabled Dyno Metadata. For Sentry's "\
     "release detection to work correctly, please run `heroku labs:enable runtime-dyno-metadata`".freeze
@@ -328,7 +328,7 @@ module Sentry
 
     PROPAGATION_TARGETS_MATCH_ALL = /.*/.freeze
 
-    DEFAULT_PATCHES = %i(redis puma http).freeze
+    DEFAULT_PATCHES = %i[redis puma http].freeze
 
     class << self
       # Post initialization callbacks are called at the end of initialization process
@@ -337,7 +337,7 @@ module Sentry
         @post_initialization_callbacks ||= []
       end
 
-    # allow extensions to add their hooks to the Configuration class
+      # allow extensions to add their hooks to the Configuration class
       def add_post_initialization_callback(&block)
         post_initialization_callbacks << block
       end

--- a/sentry-ruby/lib/sentry/cron/monitor_schedule.rb
+++ b/sentry-ruby/lib/sentry/cron/monitor_schedule.rb
@@ -26,7 +26,7 @@ module Sentry
         # @return [Symbol]
         attr_accessor :unit
 
-        VALID_UNITS = %i(year month week day hour minute)
+        VALID_UNITS = %i[year month week day hour minute]
 
         def initialize(value, unit)
           @value = value

--- a/sentry-ruby/lib/sentry/dsn.rb
+++ b/sentry-ruby/lib/sentry/dsn.rb
@@ -5,7 +5,7 @@ require "uri"
 module Sentry
   class DSN
     PORT_MAP = { 'http' => 80, 'https' => 443 }.freeze
-    REQUIRED_ATTRIBUTES = %w(host path public_key project_id).freeze
+    REQUIRED_ATTRIBUTES = %w[host path public_key project_id].freeze
 
     attr_reader :scheme, :secret_key, :port, *REQUIRED_ATTRIBUTES
 

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -14,16 +14,16 @@ module Sentry
   class Event
     TYPE = "event"
     # These are readable attributes.
-    SERIALIZEABLE_ATTRIBUTES = %i(
+    SERIALIZEABLE_ATTRIBUTES = %i[
       event_id level timestamp
       release environment server_name modules
       message user tags contexts extra
       fingerprint breadcrumbs transaction transaction_info
       platform sdk type
-    )
+    ]
 
     # These are writable attributes.
-    WRITER_ATTRIBUTES = SERIALIZEABLE_ATTRIBUTES - %i(type timestamp level)
+    WRITER_ATTRIBUTES = SERIALIZEABLE_ATTRIBUTES - %i[type timestamp level]
 
     MAX_MESSAGE_SIZE_IN_BYTES = 1024 * 8
 
@@ -145,11 +145,11 @@ module Sentry
     # REMOTE_ADDR to determine the Event IP, and must use other headers instead.
     def calculate_real_ip_from_rack(env)
       Utils::RealIp.new(
-        :remote_addr => env["REMOTE_ADDR"],
-        :client_ip => env["HTTP_CLIENT_IP"],
-        :real_ip => env["HTTP_X_REAL_IP"],
-        :forwarded_for => env["HTTP_X_FORWARDED_FOR"],
-        :trusted_proxies => @trusted_proxies
+        remote_addr: env["REMOTE_ADDR"],
+        client_ip: env["HTTP_CLIENT_IP"],
+        real_ip: env["HTTP_X_REAL_IP"],
+        forwarded_for: env["HTTP_X_FORWARDED_FOR"],
+        trusted_proxies: @trusted_proxies
       ).calculate_ip
     end
   end

--- a/sentry-ruby/lib/sentry/interfaces/exception.rb
+++ b/sentry-ruby/lib/sentry/interfaces/exception.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "set"
 
 module Sentry

--- a/sentry-ruby/lib/sentry/interfaces/request.rb
+++ b/sentry-ruby/lib/sentry/interfaces/request.rb
@@ -2,8 +2,8 @@
 
 module Sentry
   class RequestInterface < Interface
-    REQUEST_ID_HEADERS = %w(action_dispatch.request_id HTTP_X_REQUEST_ID).freeze
-    CONTENT_HEADERS = %w(CONTENT_TYPE CONTENT_LENGTH).freeze
+    REQUEST_ID_HEADERS = %w[action_dispatch.request_id HTTP_X_REQUEST_ID].freeze
+    CONTENT_HEADERS = %w[CONTENT_TYPE CONTENT_LENGTH].freeze
     IP_HEADERS = [
       "REMOTE_ADDR",
       "HTTP_CLIENT_IP",

--- a/sentry-ruby/lib/sentry/propagation_context.rb
+++ b/sentry-ruby/lib/sentry/propagation_context.rb
@@ -50,14 +50,15 @@ module Sentry
           if sentry_trace_data
             @trace_id, @parent_span_id, @parent_sampled = sentry_trace_data
 
-            @baggage = if baggage_header && !baggage_header.empty?
-                        Baggage.from_incoming_header(baggage_header)
-            else
-                        # If there's an incoming sentry-trace but no incoming baggage header,
-                        # for instance in traces coming from older SDKs,
-                        # baggage will be empty and frozen and won't be populated as head SDK.
-                        Baggage.new({})
-            end
+            @baggage =
+              if baggage_header && !baggage_header.empty?
+                Baggage.from_incoming_header(baggage_header)
+              else
+                # If there's an incoming sentry-trace but no incoming baggage header,
+                # for instance in traces coming from older SDKs,
+                # baggage will be empty and frozen and won't be populated as head SDK.
+                Baggage.new({})
+              end
 
             @baggage.freeze!
             @incoming_trace = true

--- a/sentry-ruby/lib/sentry/propagation_context.rb
+++ b/sentry-ruby/lib/sentry/propagation_context.rb
@@ -52,12 +52,12 @@ module Sentry
 
             @baggage = if baggage_header && !baggage_header.empty?
                         Baggage.from_incoming_header(baggage_header)
-                      else
+            else
                         # If there's an incoming sentry-trace but no incoming baggage header,
                         # for instance in traces coming from older SDKs,
                         # baggage will be empty and frozen and won't be populated as head SDK.
                         Baggage.new({})
-                      end
+            end
 
             @baggage.freeze!
             @incoming_trace = true

--- a/sentry-ruby/lib/sentry/puma.rb
+++ b/sentry-ruby/lib/sentry/puma.rb
@@ -7,7 +7,7 @@ module Sentry
     module Server
       PUMA_4_AND_PRIOR = Gem::Version.new(::Puma::Const::PUMA_VERSION) < Gem::Version.new("5.0.0")
 
-      def lowlevel_error(e, env, status=500)
+      def lowlevel_error(e, env, status = 500)
         result =
           if PUMA_4_AND_PRIOR
             super(e, env)

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -295,7 +295,7 @@ module Sentry
     private
 
     def set_default_value
-      @contexts = { :os => self.class.os_context, :runtime => self.class.runtime_context }
+      @contexts = { os: self.class.os_context, runtime: self.class.runtime_context }
       @extra = {}
       @tags = {}
       @user = {}
@@ -355,6 +355,5 @@ module Sentry
         global_event_processors << block
       end
     end
-
   end
 end

--- a/sentry-ruby/lib/sentry/session.rb
+++ b/sentry-ruby/lib/sentry/session.rb
@@ -5,8 +5,8 @@ module Sentry
     attr_reader :started, :status, :aggregation_key
 
     # TODO-neel add :crashed after adding handled mechanism
-    STATUSES = %i(ok errored exited)
-    AGGREGATE_STATUSES = %i(errored exited)
+    STATUSES = %i[ok errored exited]
+    AGGREGATE_STATUSES = %i[errored exited]
 
     def initialize
       @started = Sentry.utc_now

--- a/sentry-ruby/lib/sentry/session_flusher.rb
+++ b/sentry-ruby/lib/sentry/session_flusher.rb
@@ -85,6 +85,5 @@ module Sentry
         end
       end
     end
-
   end
 end

--- a/sentry-ruby/lib/sentry/span.rb
+++ b/sentry-ruby/lib/sentry/span.rb
@@ -4,7 +4,6 @@ require "securerandom"
 
 module Sentry
   class Span
-
     # We will try to be consistent with OpenTelemetry on this front going forward.
     # https://develop.sentry.dev/sdk/performance/span-data-conventions/
     module DataConventions

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -110,14 +110,15 @@ module Sentry
 
       trace_id, parent_span_id, parent_sampled = sentry_trace_data
 
-      baggage = if baggage && !baggage.empty?
-                  Baggage.from_incoming_header(baggage)
-      else
-                  # If there's an incoming sentry-trace but no incoming baggage header,
-                  # for instance in traces coming from older SDKs,
-                  # baggage will be empty and frozen and won't be populated as head SDK.
-                  Baggage.new({})
-      end
+      baggage =
+        if baggage && !baggage.empty?
+          Baggage.from_incoming_header(baggage)
+        else
+          # If there's an incoming sentry-trace but no incoming baggage header,
+          # for instance in traces coming from older SDKs,
+          # baggage will be empty and frozen and won't be populated as head SDK.
+          Baggage.new({})
+        end
 
       baggage.freeze!
 

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -13,7 +13,7 @@ module Sentry
     MESSAGE_PREFIX = "[Tracing]"
 
     # https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations
-    SOURCES = %i(custom url route view component task)
+    SOURCES = %i[custom url route view component task]
 
     include LoggingHelper
 
@@ -112,12 +112,12 @@ module Sentry
 
       baggage = if baggage && !baggage.empty?
                   Baggage.from_incoming_header(baggage)
-                else
+      else
                   # If there's an incoming sentry-trace but no incoming baggage header,
                   # for instance in traces coming from older SDKs,
                   # baggage will be empty and frozen and won't be populated as head SDK.
                   Baggage.new({})
-                end
+      end
 
       baggage.freeze!
 

--- a/sentry-ruby/lib/sentry/transport/configuration.rb
+++ b/sentry-ruby/lib/sentry/transport/configuration.rb
@@ -3,7 +3,6 @@
 module Sentry
   class Transport
     class Configuration
-
       # The timeout in seconds to open a connection to Sentry, in seconds.
       # Default value is 2.
       #

--- a/sentry-ruby/lib/sentry/utils/real_ip.rb
+++ b/sentry-ruby/lib/sentry/utils/real_ip.rb
@@ -15,7 +15,7 @@ module Sentry
         "fc00::/7",       # private IPv6 range fc00::/7
         "10.0.0.0/8",     # private IPv4 range 10.x.x.x
         "172.16.0.0/12",  # private IPv4 range 172.16.0.0 .. 172.31.255.255
-        "192.168.0.0/16", # private IPv4 range 192.168.x.x
+        "192.168.0.0/16" # private IPv4 range 192.168.x.x
       ]
 
       attr_reader :ip

--- a/sentry-ruby/lib/sentry/utils/request_id.rb
+++ b/sentry-ruby/lib/sentry/utils/request_id.rb
@@ -3,7 +3,7 @@
 module Sentry
   module Utils
     module RequestId
-      REQUEST_ID_HEADERS = %w(action_dispatch.request_id HTTP_X_REQUEST_ID).freeze
+      REQUEST_ID_HEADERS = %w[action_dispatch.request_id HTTP_X_REQUEST_ID].freeze
 
       # Request ID based on ActionDispatch::RequestId
       def self.read_from(env)

--- a/sentry-ruby/spec/initialization_check_spec.rb
+++ b/sentry-ruby/spec/initialization_check_spec.rb
@@ -41,4 +41,3 @@ RSpec.describe "with uninitialized SDK" do
     expect(result).to eq("foo")
   end
 end
-

--- a/sentry-ruby/spec/isolated/puma_spec.rb
+++ b/sentry-ruby/spec/isolated/puma_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Puma::Server do
     end
 
     def new_connection
-      TCPSocket.new(@host, @port).tap {|sock| @ios << sock}
+      TCPSocket.new(@host, @port).tap { |sock| @ios << sock }
     end
 
     def close

--- a/sentry-ruby/spec/sentry/background_worker_spec.rb
+++ b/sentry-ruby/spec/sentry/background_worker_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Sentry::BackgroundWorker do
   describe "#initialize" do
     context "when config.async is set" do
       before do
-        configuration.async = proc {}
+        configuration.async = proc { }
       end
 
       it "initializes a background_worker with ImmediateExecutor" do

--- a/sentry-ruby/spec/sentry/client/event_sending_spec.rb
+++ b/sentry-ruby/spec/sentry/client/event_sending_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe Sentry::Client do
         end
 
         it "swallows and logs errors caused by the user (like in before_send)" do
-          configuration.before_send = -> (_, _) { raise TypeError }
+          configuration.before_send = ->(_, _) { raise TypeError }
 
           expect(subject.capture_event(event, scope)).to be_nil
 
@@ -388,7 +388,7 @@ RSpec.describe Sentry::Client do
         end
 
         it "swallows and logs errors caused by the user (like in before_send)" do
-          configuration.before_send = -> (_, _) { raise TypeError }
+          configuration.before_send = ->(_, _) { raise TypeError }
 
           expect(subject.capture_event(event, scope)).to be_a(Sentry::ErrorEvent)
           sleep(0.2)
@@ -403,7 +403,7 @@ RSpec.describe Sentry::Client do
         end
 
         it "swallows Redis related error and send the event synchronizely" do
-          configuration.async = -> (_, _) { raise Redis::ConnectionError }
+          configuration.async = ->(_, _) { raise Redis::ConnectionError }
 
           subject.capture_event(event, scope)
 
@@ -411,7 +411,7 @@ RSpec.describe Sentry::Client do
         end
 
         it "swallows and logs the exception" do
-          configuration.async = -> (_, _) { raise TypeError }
+          configuration.async = ->(_, _) { raise TypeError }
 
           subject.capture_event(event, scope)
 

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -291,25 +291,25 @@ RSpec.describe Sentry::Configuration do
   end
 
   it 'raises error when setting async to anything other than callable or nil' do
-    subject.async = -> {}
+    subject.async = -> { }
     subject.async = nil
     expect { subject.async = true }.to raise_error(ArgumentError, "async must be callable (or nil to disable)")
   end
 
   it 'raises error when setting before_send to anything other than callable or nil' do
-    subject.before_send = -> {}
+    subject.before_send = -> { }
     subject.before_send = nil
     expect { subject.before_send = true }.to raise_error(ArgumentError, "before_send must be callable (or nil to disable)")
   end
 
   it 'raises error when setting before_send_transaction to anything other than callable or nil' do
-    subject.before_send_transaction = -> {}
+    subject.before_send_transaction = -> { }
     subject.before_send_transaction = nil
     expect { subject.before_send_transaction = true }.to raise_error(ArgumentError, "before_send_transaction must be callable (or nil to disable)")
   end
 
   it 'raises error when setting before_breadcrumb to anything other than callable or nil' do
-    subject.before_breadcrumb = -> {}
+    subject.before_breadcrumb = -> { }
     subject.before_breadcrumb = nil
     expect { subject.before_breadcrumb = true }.to raise_error(ArgumentError, "before_breadcrumb must be callable (or nil to disable)")
   end
@@ -321,14 +321,14 @@ RSpec.describe Sentry::Configuration do
     end
 
     it 'should send events if test is whitelisted' do
-      subject.enabled_environments = %w(test)
+      subject.enabled_environments = %w[test]
       subject.sending_allowed?
       puts subject.errors
       expect(subject.sending_allowed?).to eq(true)
     end
 
     it 'should not send events if test is not whitelisted' do
-      subject.enabled_environments = %w(not_test)
+      subject.enabled_environments = %w[not_test]
       expect(subject.sending_allowed?).to eq(false)
       expect(subject.errors).to eq(["Not configured to send/capture in environment 'test'"])
     end
@@ -386,7 +386,7 @@ RSpec.describe Sentry::Configuration do
     end
 
     it "takes a proc and store it" do
-      subject.backtrace_cleanup_callback = proc {}
+      subject.backtrace_cleanup_callback = proc { }
 
       expect(subject.backtrace_cleanup_callback).to be_a(Proc)
     end
@@ -567,12 +567,12 @@ RSpec.describe Sentry::Configuration do
 
   describe "#enabled_patches" do
     it "sets default patches" do
-      expect(subject.enabled_patches).to eq(%i(redis puma http))
+      expect(subject.enabled_patches).to eq(%i[redis puma http])
     end
 
     it "can override" do
       subject.enabled_patches.delete(:puma)
-      expect(subject.enabled_patches).to eq(%i(redis http))
+      expect(subject.enabled_patches).to eq(%i[redis http])
     end
   end
 end

--- a/sentry-ruby/spec/sentry/cron/monitor_check_ins_spec.rb
+++ b/sentry-ruby/spec/sentry/cron/monitor_check_ins_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Sentry::Cron::MonitorCheckIns do
     end
 
     context 'patched with monitor config' do
-      let(:monitor_config) { Sentry::Cron::MonitorConfig::from_interval(1, :minute) }
+      let(:monitor_config) { Sentry::Cron::MonitorConfig.from_interval(1, :minute) }
 
       before do
         mod = described_class
@@ -242,7 +242,7 @@ RSpec.describe Sentry::Cron::MonitorCheckIns do
     end
 
     context 'with custom monitor config object and cron configs' do
-      let(:monitor_config) { Sentry::Cron::MonitorConfig::from_interval(1, :minute) }
+      let(:monitor_config) { Sentry::Cron::MonitorConfig.from_interval(1, :minute) }
 
       before do
         perform_basic_setup do |config|
@@ -305,7 +305,7 @@ RSpec.describe Sentry::Cron::MonitorCheckIns do
     end
 
     context 'patched with custom options with exception' do
-      let(:monitor_config) { Sentry::Cron::MonitorConfig::from_crontab('5 * * * *') }
+      let(:monitor_config) { Sentry::Cron::MonitorConfig.from_crontab('5 * * * *') }
 
       before do
         mod = described_class
@@ -316,7 +316,7 @@ RSpec.describe Sentry::Cron::MonitorCheckIns do
 
           sentry_monitor_check_ins slug: 'custom_slug', monitor_config: config
 
-          def work(a, b, c);
+          def work(a, b, c)
             1 / 0
           end
 

--- a/sentry-ruby/spec/sentry/dsn_spec.rb
+++ b/sentry-ruby/spec/sentry/dsn_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Sentry::DSN do
     expect(subject.port).to       eq(3000)
     expect(subject.path).to       eq("/sentry")
 
-    expect(subject.to_s).to     eq("http://12345:67890@sentry.localdomain:3000/sentry/42")
+    expect(subject.to_s).to eq("http://12345:67890@sentry.localdomain:3000/sentry/42")
   end
 
   describe "#envelope_endpoint" do

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Sentry::Event do
           Sentry.get_current_scope.apply_to_event(event)
 
           expect(event.to_hash[:request]).to eq(
-            :data=>{"foo"=>"bar"},
+            data: { "foo"=>"bar" },
             env: { 'SERVER_NAME' => 'localhost', 'SERVER_PORT' => '80', "REMOTE_ADDR" => "192.168.1.1" },
             headers: { 'Host' => 'localhost', "X-Forwarded-For" => "1.1.1.1, 2.2.2.2", "X-Request-Id" => "abcd-1234-abcd-1234" },
             method: 'POST',

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -54,14 +54,14 @@ RSpec.describe Sentry::Hub do
 
       it "merges the contexts/tags/extrac with what the scope already has" do
         scope.set_tags(old_tag: true)
-        scope.set_contexts({ character: { name: "John", age: 25 }})
+        scope.set_contexts({ character: { name: "John", age: 25 } })
         scope.set_extras(old_extra: true)
 
         subject.send(
           capture_helper,
           *capture_subject,
           tags: { new_tag: true },
-          contexts: { another_character: { name: "Jane", age: 20 }},
+          contexts: { another_character: { name: "Jane", age: 20 } },
           extra: { new_extra: true }
         )
 
@@ -76,7 +76,7 @@ RSpec.describe Sentry::Hub do
         expect(event.extra).to eq({ new_extra: true, old_extra: true })
 
         expect(scope.tags).to eq(old_tag: true)
-        expect(scope.contexts).to include({ character: { name: "John", age: 25 }})
+        expect(scope.contexts).to include({ character: { name: "John", age: 25 } })
         expect(scope.extra).to eq(old_extra: true)
       end
     end
@@ -116,17 +116,17 @@ RSpec.describe Sentry::Hub do
         hint = nil
         configuration.before_send = ->(event, h) { hint = h }
 
-        subject.send(capture_helper, *capture_subject, hint: {foo: "bar"})
+        subject.send(capture_helper, *capture_subject, hint: { foo: "bar" })
 
         case capture_subject
         when String
-          expect(hint).to eq({message: capture_subject, foo: "bar"})
+          expect(hint).to eq({ message: capture_subject, foo: "bar" })
         when Exception
-          expect(hint).to eq({exception: capture_subject, foo: "bar"})
+          expect(hint).to eq({ exception: capture_subject, foo: "bar" })
         when Array
-          expect(hint).to eq({slug: capture_subject.first, foo: "bar"})
+          expect(hint).to eq({ slug: capture_subject.first, foo: "bar" })
         else
-          expect(hint).to eq({foo: "bar"})
+          expect(hint).to eq({ foo: "bar" })
         end
       end
     end
@@ -610,7 +610,7 @@ RSpec.describe Sentry::Hub do
     end
 
     it "doesn't interfere events outside of the block" do
-      subject.with_background_worker_disabled {}
+      subject.with_background_worker_disabled { }
 
       subject.capture_message("foo")
       expect(transport.events.count).to eq(0)

--- a/sentry-ruby/spec/sentry/interface_spec.rb
+++ b/sentry-ruby/spec/sentry/interface_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe Sentry::Interface do
     interface = TestInterface.new
     interface.some_attr = "test"
 
-    expect(interface.to_hash).to eq(:some_attr => "test")
+    expect(interface.to_hash).to eq(some_attr: "test")
   end
 end

--- a/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Sentry::RequestInterface do
     end
 
     context "with provided whitelist" do
-      let(:rack_env_whitelist) { %w(random_param query_string) }
+      let(:rack_env_whitelist) { %w[random_param query_string] }
 
       it 'formats rack env according to the provided whitelist' do
         expect(subject.env).to eq(additional_env)
@@ -61,7 +61,7 @@ RSpec.describe Sentry::RequestInterface do
       it "doesn't cause any issue" do
         json = JSON.generate(subject.to_hash)
 
-        expect(JSON.parse(json)["headers"]).to eq({"Content-Length"=>"0", "Foo"=>"Tekirda�"})
+        expect(JSON.parse(json)["headers"]).to eq({ "Content-Length"=>"0", "Foo"=>"Tekirda�" })
       end
     end
 

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Sentry::Net::HTTP do
         expect(request_span.data).to eq({
           "http.response.status_code" => 200,
           "url" => "http://example.com/path",
-          "http.request.method" => "GET",
+          "http.request.method" => "GET"
         })
       end
     end
@@ -327,7 +327,7 @@ RSpec.describe Sentry::Net::HTTP do
         expect(request_span.data).to eq({
           "http.response.status_code" => 200,
           "url" => "http://example.com/path",
-          "http.request.method" => "GET",
+          "http.request.method" => "GET"
         })
 
         request_span = transaction.span_recorder.spans[2]
@@ -339,7 +339,7 @@ RSpec.describe Sentry::Net::HTTP do
         expect(request_span.data).to eq({
           "http.response.status_code" => 404,
           "url" => "http://example.com/path",
-          "http.request.method" => "GET",
+          "http.request.method" => "GET"
         })
       end
 

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
       end
       it "doesn't pollute the top-level scope" do
         request_1 = lambda do |e|
-          Sentry.configure_scope { |s| s.set_tags({tag_1: "foo"}) }
+          Sentry.configure_scope { |s| s.set_tags({ tag_1: "foo" }) }
           Sentry.capture_message("test")
           [200, {}, ["ok"]]
         end
@@ -194,7 +194,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
       end
       it "doesn't pollute other request's scope" do
         request_1 = lambda do |e|
-          Sentry.configure_scope { |s| s.set_tags({tag_1: "foo"}) }
+          Sentry.configure_scope { |s| s.set_tags({ tag_1: "foo" }) }
           e['rack.exception'] = Exception.new
           [200, {}, ["ok"]]
         end
@@ -206,7 +206,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
         expect(Sentry.get_current_scope.tags).to eq(tag_1: "don't change me")
 
         request_2 = proc do |e|
-          Sentry.configure_scope { |s| s.set_tags({tag_2: "bar"}) }
+          Sentry.configure_scope { |s| s.set_tags({ tag_2: "bar" }) }
           e['rack.exception'] = Exception.new
           [200, {}, ["ok"]]
         end

--- a/sentry-ruby/spec/sentry/scope/setters_spec.rb
+++ b/sentry-ruby/spec/sentry/scope/setters_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe Sentry::Scope do
     end
 
     it "sets the user" do
-      subject.set_user({id: 1, name: "Jack"})
+      subject.set_user({ id: 1, name: "Jack" })
 
-      expect(subject.user).to eq({id: 1, name: "Jack"})
+      expect(subject.user).to eq({ id: 1, name: "Jack" })
     end
 
     it "unsets user when given empty data" do
-      subject.set_user({id: 1, name: "Jack"})
+      subject.set_user({ id: 1, name: "Jack" })
 
       subject.set_user({})
 
@@ -81,21 +81,21 @@ RSpec.describe Sentry::Scope do
     end
 
     it "merges the extras" do
-      subject.set_extras({bar: "baz"})
-      expect(subject.extra).to eq({bar: "baz"})
+      subject.set_extras({ bar: "baz" })
+      expect(subject.extra).to eq({ bar: "baz" })
 
-      subject.set_extras({foo: "bar"})
-      expect(subject.extra).to eq({bar: "baz", foo: "bar"})
+      subject.set_extras({ foo: "bar" })
+      expect(subject.extra).to eq({ bar: "baz", foo: "bar" })
     end
   end
 
   describe "#set_extra" do
     it "merges the key value with existing extra" do
-      subject.set_extras({bar: "baz"})
+      subject.set_extras({ bar: "baz" })
 
       subject.set_extra(:foo, "bar")
 
-      expect(subject.extra).to eq({foo: "bar", bar: "baz"})
+      expect(subject.extra).to eq({ foo: "bar", bar: "baz" })
     end
   end
 
@@ -113,25 +113,25 @@ RSpec.describe Sentry::Scope do
     end
 
     it "merges the context hash" do
-      subject.set_contexts({ character: { name: "John" }})
-      expect(subject.contexts).to include({ character: { name: "John" }})
+      subject.set_contexts({ character: { name: "John" } })
+      expect(subject.contexts).to include({ character: { name: "John" } })
 
-      subject.set_contexts({ character: { name: "John", age: 25 }})
-      subject.set_contexts({ another_character: { name: "Jane", age: 20 }})
-      expect(subject.contexts).to include({ character: { name: "John", age: 25 }})
-      expect(subject.contexts).to include({ another_character: { name: "Jane", age: 20 }})
+      subject.set_contexts({ character: { name: "John", age: 25 } })
+      subject.set_contexts({ another_character: { name: "Jane", age: 20 } })
+      expect(subject.contexts).to include({ character: { name: "John", age: 25 } })
+      expect(subject.contexts).to include({ another_character: { name: "Jane", age: 20 } })
     end
 
     it "merges context with the same key" do
-      subject.set_contexts({ character: { name: "John" }})
-      subject.set_contexts({ character: { age: 25 }})
-      expect(subject.contexts).to include({ character: { name: "John", age: 25 }})
+      subject.set_contexts({ character: { name: "John" } })
+      subject.set_contexts({ character: { age: 25 } })
+      expect(subject.contexts).to include({ character: { name: "John", age: 25 } })
     end
 
     it "allows overwriting old values" do
-      subject.set_contexts({ character: { name: "John" }})
-      subject.set_contexts({ character: { name: "Jimmy" }})
-      expect(subject.contexts).to include({ character: { name: "Jimmy" }})
+      subject.set_contexts({ character: { name: "John" } })
+      subject.set_contexts({ character: { name: "Jimmy" } })
+      expect(subject.contexts).to include({ character: { name: "Jimmy" } })
     end
   end
 
@@ -144,10 +144,10 @@ RSpec.describe Sentry::Scope do
 
     it "merges the key value with existing context" do
       subject.set_context(:character, { name: "John" })
-      expect(subject.contexts).to include({ character: { name: "John" }})
+      expect(subject.contexts).to include({ character: { name: "John" } })
 
       subject.set_context(:character, { name: "John", age: 25 })
-      expect(subject.contexts).to include({ character: { name: "John", age: 25 }})
+      expect(subject.contexts).to include({ character: { name: "John", age: 25 } })
 
       subject.set_context(:another_character, { name: "Jane", age: 20 })
       expect(subject.contexts).to include(
@@ -161,13 +161,13 @@ RSpec.describe Sentry::Scope do
     it "merges context with the same key" do
       subject.set_context(:character, { name: "John" })
       subject.set_context(:character, { age: 25 })
-      expect(subject.contexts).to include({ character: { name: "John", age: 25 }})
+      expect(subject.contexts).to include({ character: { name: "John", age: 25 } })
     end
 
     it "allows overwriting old values" do
       subject.set_context(:character, { name: "John" })
       subject.set_context(:character, { name: "Jimmy" })
-      expect(subject.contexts).to include({ character: { name: "Jimmy" }})
+      expect(subject.contexts).to include({ character: { name: "Jimmy" } })
     end
   end
 
@@ -179,21 +179,21 @@ RSpec.describe Sentry::Scope do
     end
 
     it "merges tags" do
-      subject.set_tags({bar: "baz"})
-      expect(subject.tags).to eq({bar: "baz"})
+      subject.set_tags({ bar: "baz" })
+      expect(subject.tags).to eq({ bar: "baz" })
 
-      subject.set_tags({foo: "bar"})
-      expect(subject.tags).to eq({bar: "baz", foo: "bar"})
+      subject.set_tags({ foo: "bar" })
+      expect(subject.tags).to eq({ bar: "baz", foo: "bar" })
     end
   end
 
   describe "#set_tag" do
     it "merges the key value with existing tag" do
-      subject.set_tags({bar: "baz"})
+      subject.set_tags({ bar: "baz" })
 
       subject.set_tag(:foo, "bar")
 
-      expect(subject.tags).to eq({foo: "bar", bar: "baz"})
+      expect(subject.tags).to eq({ foo: "bar", bar: "baz" })
     end
   end
 

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -125,9 +125,9 @@ RSpec.describe Sentry::Scope do
 
   describe "#clear" do
     it "resets the scope's data" do
-      subject.set_tags({foo: "bar"})
-      subject.set_extras({additional_info: "hello"})
-      subject.set_user({id: 1})
+      subject.set_tags({ foo: "bar" })
+      subject.set_extras({ additional_info: "hello" })
+      subject.set_user({ id: 1 })
       subject.set_transaction_name("WelcomeController#index")
       subject.set_span(Sentry::Transaction.new(op: "foo", hub: hub))
       subject.set_fingerprint(["foo"])
@@ -197,9 +197,9 @@ RSpec.describe Sentry::Scope do
 
     subject do
       scope = described_class.new
-      scope.set_tags({foo: "bar"})
-      scope.set_extras({additional_info: "hello"})
-      scope.set_user({id: 1})
+      scope.set_tags({ foo: "bar" })
+      scope.set_extras({ additional_info: "hello" })
+      scope.set_user({ id: 1 })
       scope.set_transaction_name("WelcomeController#index", source: :view)
       scope.set_fingerprint(["foo"])
       scope
@@ -210,9 +210,9 @@ RSpec.describe Sentry::Scope do
 
     it "applies the contextual data to event" do
       subject.apply_to_event(event)
-      expect(event.tags).to eq({foo: "bar"})
-      expect(event.user).to eq({id: 1})
-      expect(event.extra).to eq({additional_info: "hello"})
+      expect(event.tags).to eq({ foo: "bar" })
+      expect(event.user).to eq({ id: 1 })
+      expect(event.extra).to eq({ additional_info: "hello" })
       expect(event.transaction).to eq("WelcomeController#index")
       expect(event.transaction_info).to eq({ source: :view })
       expect(event.breadcrumbs).to be_a(Sentry::BreadcrumbBuffer)
@@ -235,14 +235,14 @@ RSpec.describe Sentry::Scope do
     end
 
     it "doesn't override event's pre-existing data" do
-      event.tags = {foo: "baz"}
-      event.user = {id: 2}
-      event.extra = {additional_info: "nothing"}
-      event.contexts = {os: nil}
+      event.tags = { foo: "baz" }
+      event.user = { id: 2 }
+      event.extra = { additional_info: "nothing" }
+      event.contexts = { os: nil }
 
       subject.apply_to_event(event)
-      expect(event.tags).to eq({foo: "baz"})
-      expect(event.user).to eq({id: 2})
+      expect(event.tags).to eq({ foo: "baz" })
+      expect(event.user).to eq({ id: 2 })
       expect(event.extra[:additional_info]).to eq("nothing")
       expect(event.contexts[:os]).to eq(nil)
     end

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Sentry::Transaction do
         {
           "metric.foo" => { value: 0.1, unit: "second" },
           "metric.bar" => { value: 1.0, unit: "minute" },
-          "metric.baz" => { value: 1.0, unit: "" },
+          "metric.baz" => { value: 1.0, unit: "" }
         }
       )
 
@@ -171,7 +171,7 @@ RSpec.describe Sentry::Transaction do
         {
           "metric.foo" => { value: 2, unit: "second" },
           "metric.bar" => { value: 1.0, unit: "minute" },
-          "metric.baz" => { value: 1.0, unit: "" },
+          "metric.baz" => { value: 1.0, unit: "" }
         }
       )
     end
@@ -290,7 +290,7 @@ RSpec.describe Sentry::Transaction do
       context "when traces_sampler is provided" do
         it "prioritizes traces_sampler over traces_sample_rate" do
           Sentry.configuration.traces_sample_rate = 1.0
-          Sentry.configuration.traces_sampler = -> (_) { false }
+          Sentry.configuration.traces_sampler = ->(_) { false }
 
           subject.set_initial_sample_decision(sampling_context: {})
           expect(subject.sampled).to eq(false)
@@ -298,7 +298,7 @@ RSpec.describe Sentry::Transaction do
         end
 
         it "prioritizes traces_sampler over inherited decision" do
-          Sentry.configuration.traces_sampler = -> (_) { false }
+          Sentry.configuration.traces_sampler = ->(_) { false }
 
           subject.set_initial_sample_decision(sampling_context: { parent_sampled: true })
           expect(subject.sampled).to eq(false)
@@ -314,7 +314,7 @@ RSpec.describe Sentry::Transaction do
         end
 
         it "discards the transaction if generated sample rate is not valid" do
-          Sentry.configuration.traces_sampler = -> (_) { "foo" }
+          Sentry.configuration.traces_sampler = ->(_) { "foo" }
           subject.set_initial_sample_decision(sampling_context: {})
 
           expect(subject.sampled).to eq(false)
@@ -327,19 +327,19 @@ RSpec.describe Sentry::Transaction do
         it "uses the genereted rate for sampling (positive)" do
           expect(Sentry.configuration.logger).to receive(:debug).exactly(3).and_call_original
 
-          Sentry.configuration.traces_sampler = -> (_) { true }
+          Sentry.configuration.traces_sampler = ->(_) { true }
           subject = described_class.new(hub: Sentry.get_current_hub)
           subject.set_initial_sample_decision(sampling_context: {})
           expect(subject.sampled).to eq(true)
           expect(subject.effective_sample_rate).to eq(1.0)
 
-          Sentry.configuration.traces_sampler = -> (_) { 1.0 }
+          Sentry.configuration.traces_sampler = ->(_) { 1.0 }
           subject = described_class.new(hub: Sentry.get_current_hub)
           subject.set_initial_sample_decision(sampling_context: {})
           expect(subject.sampled).to eq(true)
           expect(subject.effective_sample_rate).to eq(1.0)
 
-          Sentry.configuration.traces_sampler = -> (_) { 1 }
+          Sentry.configuration.traces_sampler = ->(_) { 1 }
           subject = described_class.new(hub: Sentry.get_current_hub)
           subject.set_initial_sample_decision(sampling_context: {})
           expect(subject.sampled).to eq(true)
@@ -353,13 +353,13 @@ RSpec.describe Sentry::Transaction do
         it "uses the genereted rate for sampling (negative)" do
           expect(Sentry.configuration.logger).to receive(:debug).exactly(2).and_call_original
 
-          Sentry.configuration.traces_sampler = -> (_) { false }
+          Sentry.configuration.traces_sampler = ->(_) { false }
           subject = described_class.new(hub: Sentry.get_current_hub)
           subject.set_initial_sample_decision(sampling_context: {})
           expect(subject.sampled).to eq(false)
           expect(subject.effective_sample_rate).to eq(0.0)
 
-          Sentry.configuration.traces_sampler = -> (_) { 0.0 }
+          Sentry.configuration.traces_sampler = ->(_) { 0.0 }
           subject = described_class.new(hub: Sentry.get_current_hub)
           subject.set_initial_sample_decision(sampling_context: {})
           expect(subject.sampled).to eq(false)

--- a/sentry-ruby/spec/sentry/transport/http_transport_rate_limiting_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_rate_limiting_spec.rb
@@ -188,11 +188,11 @@ RSpec.describe "rate limiting" do
             header: "48", expected_limits: { nil => now + 48 }
           },
           {
-            header: "invalid", expected_limits: { nil => now + 60}
+            header: "invalid", expected_limits: { nil => now + 60 }
           },
           {
-            header: "", expected_limits: { nil => now + 60}
-          },
+            header: "", expected_limits: { nil => now + 60 }
+          }
         ].each do |pair|
           context "with header value: '#{pair[:header]}'" do
             let(:headers) do

--- a/sentry-ruby/spec/sentry/utils/real_ip_spec.rb
+++ b/sentry-ruby/spec/sentry/utils/real_ip_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Sentry::Utils::RealIp do
   context "when no ip addresses are provided other than REMOTE_ADDR" do
-    subject { Sentry::Utils::RealIp.new(:remote_addr => "1.1.1.1") }
+    subject { Sentry::Utils::RealIp.new(remote_addr: "1.1.1.1") }
 
     it "should return the remote_addr" do
       expect(subject.calculate_ip).to eq("1.1.1.1")
@@ -12,8 +12,8 @@ RSpec.describe Sentry::Utils::RealIp do
   context "when a list of x-forwarded-for ips is provided" do
     subject do
       Sentry::Utils::RealIp.new(
-        :forwarded_for => "2.2.2.2, 3.3.3.3, 4.4.4.4, 192.168.0.2",
-        :remote_addr => "192.168.0.1"
+        forwarded_for: "2.2.2.2, 3.3.3.3, 4.4.4.4, 192.168.0.2",
+        remote_addr: "192.168.0.1"
       )
     end
 
@@ -25,10 +25,10 @@ RSpec.describe Sentry::Utils::RealIp do
   context "when client/real ips are provided" do
     subject do
       Sentry::Utils::RealIp.new(
-        :forwarded_for => "2.2.2.2",
-        :real_ip => "4.4.4.4",
-        :client_ip => "3.3.3.3",
-        :remote_addr => "192.168.0.1"
+        forwarded_for: "2.2.2.2",
+        real_ip: "4.4.4.4",
+        client_ip: "3.3.3.3",
+        remote_addr: "192.168.0.1"
       )
     end
 
@@ -40,8 +40,8 @@ RSpec.describe Sentry::Utils::RealIp do
   context "all provided ip addresses are actually local addresses" do
     subject do
       Sentry::Utils::RealIp.new(
-        :forwarded_for => "127.0.0.1, ::1, 10.0.0.0",
-        :remote_addr => "192.168.0.1"
+        forwarded_for: "127.0.0.1, ::1, 10.0.0.0",
+        remote_addr: "192.168.0.1"
       )
     end
 
@@ -53,8 +53,8 @@ RSpec.describe Sentry::Utils::RealIp do
   context "when custom proxies are provided" do
     subject do
       Sentry::Utils::RealIp.new(
-        :forwarded_for => "2.2.2.2, 3.3.3.3, 4.4.4.4",
-        :trusted_proxies => ["4.4.4.4"]
+        forwarded_for: "2.2.2.2, 3.3.3.3, 4.4.4.4",
+        trusted_proxies: ["4.4.4.4"]
       )
     end
 
@@ -66,8 +66,8 @@ RSpec.describe Sentry::Utils::RealIp do
   context "when custom proxies are provided as IPAddr" do
     subject do
       Sentry::Utils::RealIp.new(
-        :forwarded_for => "2.2.2.2, 3.3.3.3, 4.4.4.4",
-        :trusted_proxies => [IPAddr.new("4.4.4.4")]
+        forwarded_for: "2.2.2.2, 3.3.3.3, 4.4.4.4",
+        trusted_proxies: [IPAddr.new("4.4.4.4")]
       )
     end
 
@@ -79,8 +79,8 @@ RSpec.describe Sentry::Utils::RealIp do
   context "when an invalid IP is provided" do
     subject do
       Sentry::Utils::RealIp.new(
-        :forwarded_for => "4.4.4.4.4, 2.2.2.2",
-        :remote_addr => "192.168.0.1"
+        forwarded_for: "4.4.4.4.4, 2.2.2.2",
+        remote_addr: "192.168.0.1"
       )
     end
 
@@ -92,8 +92,8 @@ RSpec.describe Sentry::Utils::RealIp do
   context "with IPv6 ips" do
     subject do
       Sentry::Utils::RealIp.new(
-        :forwarded_for => "2001:db8:a0b:12f0::1",
-        :remote_addr => "192.168.0.1"
+        forwarded_for: "2001:db8:a0b:12f0::1",
+        remote_addr: "192.168.0.1"
       )
     end
 
@@ -101,12 +101,12 @@ RSpec.describe Sentry::Utils::RealIp do
       expect(subject.calculate_ip).to eq("2001:db8:a0b:12f0::1")
     end
   end
-  
+
   context "when custom proxies are provided as IPAddr as IP subnet" do
     subject do
       Sentry::Utils::RealIp.new(
-        :forwarded_for => "2.2.2.2, 3.3.3.3, 4.4.4.4",
-        :trusted_proxies => [IPAddr.new("4.4.4.0/24")]
+        forwarded_for: "2.2.2.2, 3.3.3.3, 4.4.4.4",
+        trusted_proxies: [IPAddr.new("4.4.4.0/24")]
       )
     end
 

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -735,7 +735,6 @@ RSpec.describe Sentry do
   end
 
   describe ".continue_trace" do
-
     context "without incoming sentry trace" do
       let(:env) { { "HTTP_FOO" => "bar" } }
 
@@ -999,7 +998,6 @@ RSpec.describe Sentry do
         expect(Thread.current.thread_variable_get(described_class::THREAD_LOCAL)).to be_a(Sentry::Hub)
         described_class.close
         expect(Thread.current.thread_variable_get(described_class::THREAD_LOCAL)).to eq(nil)
-
       end
 
       it "calls background worker shutdown" do
@@ -1089,7 +1087,7 @@ RSpec.describe Sentry do
 
       it "prepends patch if in enabled_patches" do
         expect(target_class).to receive(:prepend).with(module_patch).and_call_original
-        perform_basic_setup  { |c| c.enabled_patches = %i(module_patch) }
+        perform_basic_setup  { |c| c.enabled_patches = %i[module_patch] }
 
         expect(target_class.ancestors.first).to eq(module_patch)
         expect(target_class.instance_methods).to include(:foo)
@@ -1111,7 +1109,7 @@ RSpec.describe Sentry do
 
       it "calls block if in enabled_patches" do
         expect(target_class).to receive(:prepend).with(module_patch).and_call_original
-        perform_basic_setup  { |c| c.enabled_patches = %i(block_patch) }
+        perform_basic_setup  { |c| c.enabled_patches = %i[block_patch] }
 
         expect(target_class.ancestors.first).to eq(module_patch)
         expect(target_class.instance_methods).to include(:foo)

--- a/sentry-sidekiq/Rakefile
+++ b/sentry-sidekiq/Rakefile
@@ -5,4 +5,4 @@ RSpec::Core::RakeTask.new(:spec).tap do |task|
   task.rspec_opts = "--order rand"
 end
 
-task :default => :spec
+task default: :spec

--- a/sentry-sidekiq/lib/sentry/sidekiq-scheduler/scheduler.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq-scheduler/scheduler.rb
@@ -36,7 +36,7 @@ module Sentry
         # Rufus::Scheduler::EveryJob stores it's frequency in seconds,
         # so we convert it to minutes before passing in to the monitor.
         monitor_config = case interval_type
-          when "cron"
+        when "cron"
             # fugit is a second order dependency of sidekiq-scheduler via rufus-scheduler
             parsed_cron = ::Fugit.parse_cron(schedule)
             timezone = parsed_cron.timezone
@@ -50,7 +50,7 @@ module Sentry
             else
               Sentry::Cron::MonitorConfig.from_crontab(schedule)
             end
-          when "every", "interval"
+        when "every", "interval"
             Sentry::Cron::MonitorConfig.from_interval(rufus_job.frequency.to_i / 60, :minute)
         end
 

--- a/sentry-sidekiq/lib/sentry/sidekiq-scheduler/scheduler.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq-scheduler/scheduler.rb
@@ -35,8 +35,9 @@ module Sentry
         # For cron, every, or interval jobs — grab their schedule.
         # Rufus::Scheduler::EveryJob stores it's frequency in seconds,
         # so we convert it to minutes before passing in to the monitor.
-        monitor_config = case interval_type
-        when "cron"
+        monitor_config =
+          case interval_type
+          when "cron"
             # fugit is a second order dependency of sidekiq-scheduler via rufus-scheduler
             parsed_cron = ::Fugit.parse_cron(schedule)
             timezone = parsed_cron.timezone
@@ -50,9 +51,9 @@ module Sentry
             else
               Sentry::Cron::MonitorConfig.from_crontab(schedule)
             end
-        when "every", "interval"
+          when "every", "interval"
             Sentry::Cron::MonitorConfig.from_interval(rufus_job.frequency.to_i / 60, :minute)
-        end
+          end
 
         # If we couldn't build a monitor config, it's either an error, or
         # it's a one-time job (interval_type is in, or at), in which case

--- a/sentry-sidekiq/spec/sentry/sidekiq-scheduler/scheduler_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq-scheduler/scheduler_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Sentry::SidekiqScheduler::Scheduler do
     expect(EveryHappyWorker.sentry_monitor_slug).to eq('regularly_happy')
     expect(EveryHappyWorker.sentry_monitor_config).to be_a(Sentry::Cron::MonitorConfig)
     expect(EveryHappyWorker.sentry_monitor_config.schedule).to be_a(Sentry::Cron::MonitorSchedule::Interval)
-    expect(EveryHappyWorker.sentry_monitor_config.schedule.to_hash).to eq({value: 10, type: :interval, unit: :minute})
+    expect(EveryHappyWorker.sentry_monitor_config.schedule.to_hash).to eq({ value: 10, type: :interval, unit: :minute })
   end
 
   it "does not add monitors for a one-off job" do
@@ -70,4 +70,3 @@ RSpec.describe Sentry::SidekiqScheduler::Scheduler do
     expect(VeryLongOuterModule::VeryVeryVeryVeryLongInnerModule::Job.sentry_monitor_config.schedule.value).to eq('* * * * *')
  end
 end
-

--- a/sentry-sidekiq/spec/sentry/sidekiq/context_filter_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/context_filter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Sentry::Sidekiq::ContextFilter do
 
     context "filters out ActiveJob keys from context" do
       let(:context) do
-        { :_aj_globalid => "gid://app/model/id", :key => "value" }
+        { _aj_globalid: "gid://app/model/id", key: "value" }
       end
 
       it "removes reserved keys" do
@@ -17,8 +17,8 @@ RSpec.describe Sentry::Sidekiq::ContextFilter do
     context "filters out ActiveJob keys from nested context" do
       let(:context) do
         {
-          :_aj_globalid => "gid://app/model/id",
-          :arguments => { :key => "value", :_aj_symbol_keys => ["key"] }
+          _aj_globalid: "gid://app/model/id",
+          arguments: { key: "value", _aj_symbol_keys: ["key"] }
         }
       end
       let(:expected_context) do

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -126,7 +126,7 @@ class SadWorker
   def perform
     crumb = Sentry::Breadcrumb.new(message: "I'm sad!")
     Sentry.add_breadcrumb(crumb)
-    Sentry.set_tags :mood => 'sad'
+    Sentry.set_tags mood: 'sad'
 
     raise "I'm sad!"
   end
@@ -153,7 +153,7 @@ class VerySadWorker
   def perform
     crumb = Sentry::Breadcrumb.new(message: "I'm very sad!")
     Sentry.add_breadcrumb(crumb)
-    Sentry.set_tags :mood => 'very sad'
+    Sentry.set_tags mood: 'very sad'
 
     raise "I'm very sad!"
   end


### PR DESCRIPTION
In addition to having a consistent coding style through CI checks, anyone uses a LSP server (whether `Ruby LSP` or `Solargraph`) will have auto-formatting in their editor as well.

1. After checking different rubocop rules, I think [rubocop-rails-omakase](https://github.com/rails/rubocop-rails-omakase)'s rules match my taste the most but also doesn't require much changes in our codebase.
    - I didn't use `standard` as it's not supported by `Ruby LSP` atm
1. I ran `rubocop -a` on the entire project to apply the styles, with a couple of manual adjustments.
1. I also added a new CI job for linting.

#skip-changelog