### PR TITLE
Only instantiate SessionFlusher when the SDK is enabled under the current env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Fix warning about default gems on Ruby 3.3.0 ([#2225](https://github.com/getsentry/sentry-ruby/pull/2225))
 - Add `hint:` support to `Sentry::Rails::ErrorSubscriber` [#2235](https://github.com/getsentry/sentry-ruby/pull/2235)
 
+### Bug Fixes
+
+- Only instantiate SessionFlusher when the SDK is enabled under the current env [#2245](https://github.com/getsentry/sentry-ruby/pull/2245)
+  - Fixes [#2234](https://github.com/getsentry/sentry-ruby/issues/2234)
+
 ## 5.16.1
 
 ### Bug Fixes

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -222,7 +222,7 @@ module Sentry
       Thread.current.thread_variable_set(THREAD_LOCAL, hub)
       @main_hub = hub
       @background_worker = Sentry::BackgroundWorker.new(config)
-      @session_flusher = config.auto_session_tracking ? Sentry::SessionFlusher.new(config, client) : nil
+      @session_flusher = config.session_tracking? ? Sentry::SessionFlusher.new(config, client) : nil
       @backpressure_monitor = config.enable_backpressure_handling ? Sentry::BackpressureMonitor.new(config, client) : nil
       exception_locals_tp.enable if config.include_local_variables
       at_exit { close }

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -490,6 +490,10 @@ module Sentry
       Random.rand < sample_rate
     end
 
+    def session_tracking?
+      auto_session_tracking && enabled_in_current_env?
+    end
+
     def exception_class_allowed?(exc)
       if exc.is_a?(Sentry::Error)
         # Try to prevent error reporting loops

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -533,6 +533,43 @@ RSpec.describe Sentry::Configuration do
     end
   end
 
+  describe "session_tracking?" do
+    before do
+      subject.enabled_environments = %w[production]
+    end
+
+    context "when auto_session_tracking is true" do
+      before do
+        subject.auto_session_tracking = true
+      end
+
+      it "returns true when in enabled_environments" do
+        subject.environment = "production"
+        expect(subject.session_tracking?).to eq(true)
+      end
+
+      it "returns false when not in enabled_environments" do
+        subject.environment = "test"
+        expect(subject.session_tracking?).to eq(false)
+      end
+    end
+
+    context "when auto_session_tracking is false" do
+      before do
+        subject.auto_session_tracking = false
+      end
+      it "returns false when in enabled_environments" do
+        subject.environment = "production"
+        expect(subject.session_tracking?).to eq(false)
+      end
+
+      it "returns false when not in enabled_environments" do
+        subject.environment = "test"
+        expect(subject.session_tracking?).to eq(false)
+      end
+    end
+  end
+
   describe "#trace_propagation_targets" do
     it "returns match all by default" do
       expect(subject.trace_propagation_targets).to eq([/.*/])

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -47,6 +47,27 @@ RSpec.describe Sentry do
       current_scope = described_class.get_current_scope
       expect(current_scope.breadcrumbs.buffer.size).to eq(1)
     end
+
+    context "with config.auto_session_tracking = true" do
+      it "initializes session flusher" do
+        described_class.init do |config|
+          config.auto_session_tracking = true
+        end
+
+        expect(described_class.session_flusher).to be_a(Sentry::SessionFlusher)
+      end
+
+      context "when it's not under the enabled environment" do
+        it "doesn't initialize any session flusher" do
+          described_class.init do |config|
+            config.auto_session_tracking = true
+            config.enabled_environments = ["production"]
+          end
+
+          expect(described_class.session_flusher).to be_nil
+        end
+      end
+    end
   end
 
   describe "#clone_hub_to_current_thread" do


### PR DESCRIPTION
This method aims to encapsulate the conditions we need to consider for enabling session tracking. Currently, it includes:
- Whether the auto_session_tracking option is enabled
- Whether the SDK is enabled under the current environment

Closes #2234