### PR TITLE
Add Metrics API and aggregator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@
 - Add support for distributed tracing in `sentry-delayed_job` [#2233](https://github.com/getsentry/sentry-ruby/pull/2233)
 - Fix warning about default gems on Ruby 3.3.0 ([#2225](https://github.com/getsentry/sentry-ruby/pull/2225))
 - Add `hint:` support to `Sentry::Rails::ErrorSubscriber` [#2235](https://github.com/getsentry/sentry-ruby/pull/2235)
+- Add [Metrics](https://docs.sentry.io/product/metrics/) support
+  - Add main APIs and `Aggregator` thread [#2247](https://github.com/getsentry/sentry-ruby/pull/2247)
+
+    The SDK now supports recording and aggregating metrics. A new thread will be started
+    for aggregation and will flush the pending data to Sentry every 5 seconds.
+
+    To enable this behavior, use:
+
+    ```ruby
+    Sentry.init do |config|
+      # ...
+      config.enable_metrics = true
+    end
+    ```
+
+    And then in your application code, collect metrics as follows:
+
+    ```ruby
+    # increment a simple counter
+    Sentry::Metrics.incr('button_click')
+    # set a value, unit and tags
+    Sentry::Metrics.incr('time', 5, 'second', tags: { browser:' firefox' })
+
+    # distribution - get statistical aggregates from an array of observations
+    Sentry::Metrics.distribution('page_load', 15.0, 'millisecond')
+
+    # gauge - record statistical aggregates directly on the SDK, more space efficient
+    Sentry::Metrics.gauge('page_load', 15.0, 'millisecond')
+
+    # set - get unique counts of elements
+    Sentry::Metrics.set('user_view', 'jane')
+    ```
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
     ```ruby
     Sentry.init do |config|
       # ...
-      config.enable_metrics = true
+      config.metrics.enabled = true
     end
     ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,13 @@
     # increment a simple counter
     Sentry::Metrics.incr('button_click')
     # set a value, unit and tags
-    Sentry::Metrics.incr('time', 5, 'second', tags: { browser:' firefox' })
+    Sentry::Metrics.incr('time', 5, unit: 'second', tags: { browser:' firefox' })
 
     # distribution - get statistical aggregates from an array of observations
-    Sentry::Metrics.distribution('page_load', 15.0, 'millisecond')
+    Sentry::Metrics.distribution('page_load', 15.0, unit: 'millisecond')
 
     # gauge - record statistical aggregates directly on the SDK, more space efficient
-    Sentry::Metrics.gauge('page_load', 15.0, 'millisecond')
+    Sentry::Metrics.gauge('page_load', 15.0, unit: 'millisecond')
 
     # set - get unique counts of elements
     Sentry::Metrics.set('user_view', 'jane')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@
 
     ```ruby
     # increment a simple counter
-    Sentry::Metrics.incr('button_click')
+    Sentry::Metrics.increment('button_click')
     # set a value, unit and tags
-    Sentry::Metrics.incr('time', 5, unit: 'second', tags: { browser:' firefox' })
+    Sentry::Metrics.increment('time', 5, unit: 'second', tags: { browser:' firefox' })
 
     # distribution - get statistical aggregates from an array of observations
     Sentry::Metrics.distribution('page_load', 15.0, unit: 'millisecond')

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,6 @@ ruby_version = Gem::Version.new(RUBY_VERSION)
 if ruby_version >= Gem::Version.new("2.7.0")
   gem "debug", github: "ruby/debug", platform: :ruby
   gem "irb"
-  # new release breaks on jruby
-  gem "io-console", "0.6.0"
 
   if ruby_version >= Gem::Version.new("3.0.0")
     gem "ruby-lsp-rspec"

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -229,7 +229,7 @@ module Sentry
       @background_worker = Sentry::BackgroundWorker.new(config)
       @session_flusher = config.session_tracking? ? Sentry::SessionFlusher.new(config, client) : nil
       @backpressure_monitor = config.enable_backpressure_handling ? Sentry::BackpressureMonitor.new(config, client) : nil
-      @metrics_aggregator = config.enable_metrics ? Sentry::Metrics::Aggregator.new(config, client) : nil
+      @metrics_aggregator = config.metrics.enabled ? Sentry::Metrics::Aggregator.new(config, client) : nil
       exception_locals_tp.enable if config.include_local_variables
       at_exit { close }
     end

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -251,7 +251,6 @@ module Sentry
       end
 
       if @metrics_aggregator
-        # TODO-neel-metrics force flush?
         @metrics_aggregator.flush(force: true)
         @metrics_aggregator.kill
         @metrics_aggregator = nil

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -23,6 +23,7 @@ require "sentry/background_worker"
 require "sentry/session_flusher"
 require "sentry/backpressure_monitor"
 require "sentry/cron/monitor_check_ins"
+require "sentry/metrics"
 
 [
   "sentry/rake",
@@ -76,6 +77,10 @@ module Sentry
     # @!attribute [r] backpressure_monitor
     #   @return [BackpressureMonitor, nil]
     attr_reader :backpressure_monitor
+
+    # @!attribute [r] metrics_aggregator
+    #   @return [Metrics::Aggregator, nil]
+    attr_reader :metrics_aggregator
 
     ##### Patch Registration #####
 
@@ -224,6 +229,7 @@ module Sentry
       @background_worker = Sentry::BackgroundWorker.new(config)
       @session_flusher = config.session_tracking? ? Sentry::SessionFlusher.new(config, client) : nil
       @backpressure_monitor = config.enable_backpressure_handling ? Sentry::BackpressureMonitor.new(config, client) : nil
+      @metrics_aggregator = config.enable_metrics ? Sentry::Metrics::Aggregator.new(config, client) : nil
       exception_locals_tp.enable if config.include_local_variables
       at_exit { close }
     end
@@ -242,6 +248,13 @@ module Sentry
       if @backpressure_monitor
         @backpressure_monitor.kill
         @backpressure_monitor = nil
+      end
+
+      if @metrics_aggregator
+        # TODO-neel-metrics force flush?
+        @metrics_aggregator.flush(force: true)
+        @metrics_aggregator.kill
+        @metrics_aggregator = nil
       end
 
       if client = get_current_client

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -254,6 +254,12 @@ module Sentry
     # @return [Boolean, nil]
     attr_reader :enable_tracing
 
+    # Enable metrics usage
+    # Starts a new {Sentry::Metrics::Aggregator} instance to aggregate metrics
+    # and a thread to aggregate flush every 5 seconds.
+    # @return [Boolean]
+    attr_accessor :enable_metrics
+
     # Send diagnostic client reports about dropped events, true by default
     # tries to attach to an existing envelope max once every 30s
     # @return [Boolean]
@@ -383,6 +389,7 @@ module Sentry
       self.rack_env_whitelist = RACK_ENV_WHITELIST_DEFAULT
       self.traces_sampler = nil
       self.enable_tracing = nil
+      self.enable_metrics = false
 
       @transport = Transport::Configuration.new
       @cron = Cron::Configuration.new

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -8,6 +8,7 @@ require "sentry/dsn"
 require "sentry/release_detector"
 require "sentry/transport/configuration"
 require "sentry/cron/configuration"
+require "sentry/metrics/configuration"
 require "sentry/linecache"
 require "sentry/interfaces/stacktrace_builder"
 
@@ -235,6 +236,10 @@ module Sentry
     # @return [Cron::Configuration]
     attr_reader :cron
 
+    # Metrics related configuration.
+    # @return [Metrics::Configuration]
+    attr_reader :metrics
+
     # Take a float between 0.0 and 1.0 as the sample rate for tracing events (transactions).
     # @return [Float, nil]
     attr_reader :traces_sample_rate
@@ -253,12 +258,6 @@ module Sentry
     # If set to true, will set traces_sample_rate to 1.0
     # @return [Boolean, nil]
     attr_reader :enable_tracing
-
-    # Enable metrics usage
-    # Starts a new {Sentry::Metrics::Aggregator} instance to aggregate metrics
-    # and a thread to aggregate flush every 5 seconds.
-    # @return [Boolean]
-    attr_accessor :enable_metrics
 
     # Send diagnostic client reports about dropped events, true by default
     # tries to attach to an existing envelope max once every 30s
@@ -389,10 +388,10 @@ module Sentry
       self.rack_env_whitelist = RACK_ENV_WHITELIST_DEFAULT
       self.traces_sampler = nil
       self.enable_tracing = nil
-      self.enable_metrics = false
 
       @transport = Transport::Configuration.new
       @cron = Cron::Configuration.new
+      @metrics = Metrics::Configuration.new
       @gem_specs = Hash[Gem::Specification.map { |spec| [spec.name, spec.version.to_s] }] if Gem::Specification.respond_to?(:map)
 
       run_post_initialization_callbacks

--- a/sentry-ruby/lib/sentry/envelope.rb
+++ b/sentry-ruby/lib/sentry/envelope.rb
@@ -7,11 +7,12 @@ module Sentry
       STACKTRACE_FRAME_LIMIT_ON_OVERSIZED_PAYLOAD = 500
       MAX_SERIALIZED_PAYLOAD_SIZE = 1024 * 1000
 
-      attr_accessor :headers, :payload
+      attr_accessor :headers, :payload, :is_json
 
-      def initialize(headers, payload)
+      def initialize(headers, payload, is_json: true)
         @headers = headers
         @payload = payload
+        @is_json = is_json
       end
 
       def type
@@ -19,7 +20,7 @@ module Sentry
       end
 
       def to_s
-        [JSON.generate(@headers), JSON.generate(@payload)].join("\n")
+        [JSON.generate(@headers), @is_json ? JSON.generate(@payload) : @payload].join("\n")
       end
 
       def serialize
@@ -78,8 +79,8 @@ module Sentry
       @items = []
     end
 
-    def add_item(headers, payload)
-      @items << Item.new(headers, payload)
+    def add_item(headers, payload, is_json: true)
+      @items << Item.new(headers, payload, is_json: is_json)
     end
 
     def item_types

--- a/sentry-ruby/lib/sentry/envelope.rb
+++ b/sentry-ruby/lib/sentry/envelope.rb
@@ -7,12 +7,11 @@ module Sentry
       STACKTRACE_FRAME_LIMIT_ON_OVERSIZED_PAYLOAD = 500
       MAX_SERIALIZED_PAYLOAD_SIZE = 1024 * 1000
 
-      attr_accessor :headers, :payload, :is_json
+      attr_accessor :headers, :payload
 
-      def initialize(headers, payload, is_json: true)
+      def initialize(headers, payload)
         @headers = headers
         @payload = payload
-        @is_json = is_json
       end
 
       def type
@@ -20,7 +19,7 @@ module Sentry
       end
 
       def to_s
-        [JSON.generate(@headers), @is_json ? JSON.generate(@payload) : @payload].join("\n")
+        [JSON.generate(@headers), @payload.is_a?(String) ? @payload : JSON.generate(@payload)].join("\n")
       end
 
       def serialize
@@ -79,8 +78,8 @@ module Sentry
       @items = []
     end
 
-    def add_item(headers, payload, is_json: true)
-      @items << Item.new(headers, payload, is_json: is_json)
+    def add_item(headers, payload)
+      @items << Item.new(headers, payload)
     end
 
     def item_types

--- a/sentry-ruby/lib/sentry/metrics.rb
+++ b/sentry-ruby/lib/sentry/metrics.rb
@@ -5,12 +5,27 @@ require 'sentry/metrics/counter_metric'
 require 'sentry/metrics/distribution_metric'
 require 'sentry/metrics/gauge_metric'
 require 'sentry/metrics/set_metric'
+require 'sentry/metrics/aggregator'
 
 module Sentry
   module Metrics
     class << self
       # TODO-neel-metrics define units, maybe symbols
-      def incr(key, value: 1.0, unit: 'none', tags: nil, timestamp: nil)
+
+      def incr(key, value = 1.0, unit = 'none', tags: {}, timestamp: nil)
+        Sentry.metrics_aggregator&.add(:c, key, value, unit, tags: tags, timestamp: timestamp)
+      end
+
+      def distribution(key, value, unit = 'none', tags: {}, timestamp: nil)
+        Sentry.metrics_aggregator&.add(:d, key, value, unit, tags: tags, timestamp: timestamp)
+      end
+
+      def set(key, value, unit = 'none', tags: {}, timestamp: nil)
+        Sentry.metrics_aggregator&.add(:s, key, value, unit, tags: tags, timestamp: timestamp)
+      end
+
+      def gauge(key, value, unit = 'none', tags: {}, timestamp: nil)
+        Sentry.metrics_aggregator&.add(:g, key, value, unit, tags: tags, timestamp: timestamp)
       end
     end
   end

--- a/sentry-ruby/lib/sentry/metrics.rb
+++ b/sentry-ruby/lib/sentry/metrics.rb
@@ -10,22 +10,20 @@ require 'sentry/metrics/aggregator'
 module Sentry
   module Metrics
     class << self
-      # TODO-neel-metrics define units, maybe symbols
-
-      def incr(key, value = 1.0, unit = 'none', tags: {}, timestamp: nil)
-        Sentry.metrics_aggregator&.add(:c, key, value, unit, tags: tags, timestamp: timestamp)
+      def incr(key, value = 1.0, unit: 'none', tags: {}, timestamp: nil)
+        Sentry.metrics_aggregator&.add(:c, key, value, unit: unit, tags: tags, timestamp: timestamp)
       end
 
-      def distribution(key, value, unit = 'none', tags: {}, timestamp: nil)
-        Sentry.metrics_aggregator&.add(:d, key, value, unit, tags: tags, timestamp: timestamp)
+      def distribution(key, value, unit: 'none', tags: {}, timestamp: nil)
+        Sentry.metrics_aggregator&.add(:d, key, value, unit: unit, tags: tags, timestamp: timestamp)
       end
 
-      def set(key, value, unit = 'none', tags: {}, timestamp: nil)
-        Sentry.metrics_aggregator&.add(:s, key, value, unit, tags: tags, timestamp: timestamp)
+      def set(key, value, unit: 'none', tags: {}, timestamp: nil)
+        Sentry.metrics_aggregator&.add(:s, key, value, unit: unit, tags: tags, timestamp: timestamp)
       end
 
-      def gauge(key, value, unit = 'none', tags: {}, timestamp: nil)
-        Sentry.metrics_aggregator&.add(:g, key, value, unit, tags: tags, timestamp: timestamp)
+      def gauge(key, value, unit: 'none', tags: {}, timestamp: nil)
+        Sentry.metrics_aggregator&.add(:g, key, value, unit: unit, tags: tags, timestamp: timestamp)
       end
     end
   end

--- a/sentry-ruby/lib/sentry/metrics.rb
+++ b/sentry-ruby/lib/sentry/metrics.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'sentry/metrics/metric'
+require 'sentry/metrics/counter_metric'
+require 'sentry/metrics/distribution_metric'
+require 'sentry/metrics/gauge_metric'
+require 'sentry/metrics/set_metric'
+
+module Sentry
+  module Metrics
+    class << self
+      # TODO-neel-metrics define units, maybe symbols
+      def incr(key, value: 1.0, unit: 'none', tags: nil, timestamp: nil)
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/metrics.rb
+++ b/sentry-ruby/lib/sentry/metrics.rb
@@ -10,7 +10,7 @@ require 'sentry/metrics/aggregator'
 module Sentry
   module Metrics
     class << self
-      def incr(key, value = 1.0, unit: 'none', tags: {}, timestamp: nil)
+      def increment(key, value = 1.0, unit: 'none', tags: {}, timestamp: nil)
         Sentry.metrics_aggregator&.add(:c, key, value, unit: unit, tags: tags, timestamp: timestamp)
       end
 

--- a/sentry-ruby/lib/sentry/metrics/aggregator.rb
+++ b/sentry-ruby/lib/sentry/metrics/aggregator.rb
@@ -165,11 +165,11 @@ module Sentry
       end
 
       def get_transaction_name
-        transaction = Sentry.get_current_scope&.get_transaction
-        return nil unless transaction
-        return nil if transaction.source_low_quality?
+        scope = Sentry.get_current_scope
+        return nil unless scope && scope.transaction_name
+        return nil if scope.transaction_source_low_quality?
 
-        transaction.name
+        scope.transaction_name
       end
 
       def get_updated_tags(tags)

--- a/sentry-ruby/lib/sentry/metrics/aggregator.rb
+++ b/sentry-ruby/lib/sentry/metrics/aggregator.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Sentry
+  module Metrics
+    class Aggregator
+      include LoggingHelper
+
+      FLUSH_INTERVAL = 5
+      ROLLUP_IN_SECONDS = 10
+
+      def initialize(configuration, client)
+        @client = client
+        @logger = configuration.logger
+        @release = configuration.release
+        @environment = configuration.environment
+
+        @thread = nil
+        @exited = false
+
+        @buckets = {}
+      end
+
+      def add(type,
+              key,
+              value,
+              unit,
+              tags: nil,
+              timestamp: nil)
+        return unless ensure_thread
+
+        timestamp = timestamp.to_i if timestamp.is_a?(Time)
+        timestamp ||= Sentry.utc_now.to_i
+
+        # this is integer division and thus takes the floor of the division
+        # and buckets into 10 second intervals
+        bucket_timestamp = (timestamp / ROLLUP_IN_SECONDS) * ROLLUP_IN_SECONDS
+        serialized_tags = serialize_tags(tags)
+        bucket_key = [type, key, unit, serialized_tags]
+
+        # TODO lock and add to bucket
+        42
+      end
+
+      def flush
+        # TODO
+      end
+
+      def kill
+        log_debug("[Metrics::Aggregator] killing thread")
+
+        @exited = true
+        @thread&.kill
+      end
+
+      private
+
+      def ensure_thread
+        return false if @exited
+        return true if @thread&.alive?
+
+        @thread = Thread.new do
+          loop do
+            # TODO use event for force flush later
+            sleep(FLUSH_INTERVAL)
+            flush
+          end
+        end
+
+        true
+      rescue ThreadError
+        log_debug("[Metrics::Aggregator] thread creation failed")
+        @exited = true
+        false
+      end
+
+      def serialize_tags(tags)
+        # TODO support array tags
+        return [] unless tags
+        tags.map { |k, v| [k.to_s, v.to_s] }
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/metrics/aggregator.rb
+++ b/sentry-ruby/lib/sentry/metrics/aggregator.rb
@@ -78,8 +78,7 @@ module Sentry
         envelope = Envelope.new
         envelope.add_item(
           { type: 'statsd', length: payload.bytesize },
-          payload,
-          is_json: false
+          payload
         )
 
         Sentry.background_worker.perform do

--- a/sentry-ruby/lib/sentry/metrics/configuration.rb
+++ b/sentry-ruby/lib/sentry/metrics/configuration.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Sentry
+  module Metrics
+    class Configuration
+      # Enable metrics usage
+      # Starts a new {Sentry::Metrics::Aggregator} instance to aggregate metrics
+      # and a thread to aggregate flush every 5 seconds.
+      # @return [Boolean]
+      attr_accessor :enabled
+
+      def initialize
+        @enabled = false
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/metrics/counter_metric.rb
+++ b/sentry-ruby/lib/sentry/metrics/counter_metric.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Sentry
+  module Metrics
+    class CounterMetric < Metric
+      attr_reader :value
+
+      def initialize(value)
+        @value = value.to_f
+      end
+
+      def add(value)
+        @value += value.to_f
+      end
+
+      def serialize
+        [value]
+      end
+
+      def weight
+        1
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/metrics/distribution_metric.rb
+++ b/sentry-ruby/lib/sentry/metrics/distribution_metric.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Sentry
+  module Metrics
+    class DistributionMetric < Metric
+      attr_reader :value
+
+      def initialize(value)
+        @value = [value.to_f]
+      end
+
+      def add(value)
+        @value << value.to_f
+      end
+
+      def serialize
+        value
+      end
+
+      def weight
+        value.size
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/metrics/gauge_metric.rb
+++ b/sentry-ruby/lib/sentry/metrics/gauge_metric.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Sentry
+  module Metrics
+    class GaugeMetric < Metric
+      attr_reader :last, :min, :max, :sum, :count
+
+      def initialize(value)
+        value = value.to_f
+        @last = value
+        @min = value
+        @max = value
+        @sum = value
+        @count = 1
+      end
+
+      def add(value)
+        value = value.to_f
+        @last = value
+        @min = [@min, value].min
+        @max = [@max, value].max
+        @sum += value
+        @count += 1
+      end
+
+      def serialize
+        [last, min, max, sum, count]
+      end
+
+      def weight
+        5
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/metrics/metric.rb
+++ b/sentry-ruby/lib/sentry/metrics/metric.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Sentry
+  module Metrics
+    class Metric
+      def add(value)
+        raise NotImplementedError
+      end
+
+      def serialize
+        raise NotImplementedError
+      end
+
+      def weight
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/metrics/set_metric.rb
+++ b/sentry-ruby/lib/sentry/metrics/set_metric.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'set'
+require 'zlib'
+
+module Sentry
+  module Metrics
+    class SetMetric < Metric
+      attr_reader :value
+
+      def initialize(value)
+        @value = Set[value.to_f]
+      end
+
+      def add(value)
+        @value << value
+      end
+
+      def serialize
+        value.map do |v|
+          x.is_a?(String) ? Zlib.crc32(x) : x.to_i
+        end
+      end
+
+      def weight
+        value.size
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/metrics/set_metric.rb
+++ b/sentry-ruby/lib/sentry/metrics/set_metric.rb
@@ -9,7 +9,7 @@ module Sentry
       attr_reader :value
 
       def initialize(value)
-        @value = Set[value.to_f]
+        @value = Set[value]
       end
 
       def add(value)
@@ -17,9 +17,7 @@ module Sentry
       end
 
       def serialize
-        value.map do |v|
-          x.is_a?(String) ? Zlib.crc32(x) : x.to_i
-        end
+        value.map { |x| x.is_a?(String) ? Zlib.crc32(x) : x.to_i }
       end
 
       def weight

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -252,6 +252,12 @@ module Sentry
       @transaction_sources.last
     end
 
+    # These are high cardinality and thus bad.
+    # @return [Boolean]
+    def transaction_source_low_quality?
+      transaction_source == :url
+    end
+
     # Returns the associated Transaction object.
     # @return [Transaction, nil]
     def get_transaction

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -302,6 +302,11 @@ module Sentry
       profiler.start
     end
 
+    # These are high cardinality and thus bad
+    def source_low_quality?
+      source == :url
+    end
+
     protected
 
     def init_span_recorder(limit = 1000)
@@ -335,11 +340,6 @@ module Sentry
 
       items.compact!
       @baggage = Baggage.new(items, mutable: false)
-    end
-
-    # These are high cardinality and thus bad
-    def source_low_quality?
-      source == :url
     end
 
     class SpanRecorder

--- a/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
@@ -1,0 +1,299 @@
+require 'spec_helper'
+
+RSpec.describe Sentry::Metrics::Aggregator do
+  let(:string_io) { StringIO.new }
+
+  # fix at 3 second offset to check rollup
+  let(:fake_time) { Time.new(2024, 1, 1, 1, 1, 3) }
+
+  before do
+    perform_basic_setup do |config|
+      config.enable_metrics = true
+      config.enable_tracing = true
+      config.release = 'test-release'
+      config.environment = 'test'
+      config.logger = Logger.new(string_io)
+    end
+  end
+
+  subject { Sentry.metrics_aggregator }
+
+  describe '#add' do
+    it 'spawns new thread' do
+      expect { subject.add(:c, 'incr', 1) }.to change { Thread.list.count }.by(1)
+      expect(subject.thread).to be_a(Thread)
+    end
+
+    it 'spawns only one thread' do
+      expect { subject.add(:c, 'incr', 1) }.to change { Thread.list.count }.by(1)
+
+      expect(subject.thread).to receive(:alive?).and_call_original
+      expect { subject.add(:c, 'incr', 1) }.to change { Thread.list.count }.by(0)
+    end
+
+    context 'when thread creation fails' do
+      before do
+        expect(Thread).to receive(:new).and_raise(ThreadError)
+      end
+
+      it 'does not create new thread' do
+        expect { subject.add(:c, 'incr', 1) }.to change { Thread.list.count }.by(0)
+      end
+
+      it 'noops' do
+        subject.add(:c, 'incr', 1)
+        expect(subject.buckets).to eq({})
+      end
+
+      it 'logs error' do
+        subject.add(:c, 'incr', 1)
+        expect(string_io.string).to match(/\[Metrics::Aggregator\] thread creation failed/)
+      end
+    end
+
+    context 'when killed' do
+      before { subject.kill }
+
+      it 'noops' do
+        subject.add(:c, 'incr', 1)
+        expect(subject.buckets).to eq({})
+      end
+
+      it 'does not create new thread' do
+        expect(Thread).not_to receive(:new)
+        expect { subject.add(:c, 'incr', 1) }.to change { Thread.list.count }.by(0)
+      end
+    end
+
+    it 'does not add unsupported metric type' do
+      subject.add(:foo, 'foo', 1)
+      expect(subject.buckets).to eq({})
+    end
+
+    it 'has the correct bucket timestamp key rolled up to 10 seconds' do
+      allow(Time).to receive(:now).and_return(fake_time)
+      subject.add(:c, 'incr', 1)
+      expect(subject.buckets.keys.first).to eq(fake_time.to_i - 3)
+    end
+
+    it 'has the correct bucket timestamp key rolled up to 10 seconds when passed explicitly' do
+      subject.add(:c, 'incr', 1, timestamp: fake_time + 9)
+      expect(subject.buckets.keys.first).to eq(fake_time.to_i + 7)
+    end
+
+    it 'has the correct type in the bucket metric key' do
+      subject.add(:c, 'incr', 1)
+      type, _, _, _ = subject.buckets.values.first.keys.first
+      expect(type).to eq(:c)
+    end
+
+    it 'has the correct key in the bucket metric key' do
+      subject.add(:c, 'incr', 1)
+      _, key, _, _ = subject.buckets.values.first.keys.first
+      expect(key).to eq('incr')
+    end
+
+    it 'has the default unit \'none\' in the bucket metric key' do
+      subject.add(:c, 'incr', 1)
+      _, _, unit, _ = subject.buckets.values.first.keys.first
+      expect(unit).to eq('none')
+    end
+
+    it 'has the correct custom unit in the bucket metric key' do
+      subject.add(:c, 'incr', 1, unit: 'second')
+      _, _, unit, _ = subject.buckets.values.first.keys.first
+      expect(unit).to eq('second')
+    end
+
+    it 'has the correct default tags serialized in the bucket metric key' do
+      subject.add(:c, 'incr', 1)
+      _, _, _, tags = subject.buckets.values.first.keys.first
+      expect(tags).to eq([['environment', 'test'], ['release', 'test-release']])
+    end
+
+    it 'has the correct custom tags serialized in the bucket metric key' do
+      subject.add(:c, 'incr', 1, tags: { foo: 42 })
+      _, _, _, tags = subject.buckets.values.first.keys.first
+      expect(tags).to include(['foo', '42'])
+    end
+
+    it 'has the correct array value tags serialized in the bucket metric key' do
+      subject.add(:c, 'incr', 1, tags: { foo: [42, 43] })
+      _, _, _, tags = subject.buckets.values.first.keys.first
+      expect(tags).to include(['foo', '42'], ['foo', '43'])
+    end
+
+    context 'with running transaction' do
+      let(:transaction) { Sentry.start_transaction(name: 'foo', source: :view) }
+      before { Sentry.get_current_scope.set_span(transaction) }
+
+      it 'has the transaction name in tags serialized in the bucket metric key' do
+        subject.add(:c, 'incr', 1)
+        _, _, _, tags = subject.buckets.values.first.keys.first
+        expect(tags).to include(['transaction', 'foo'])
+      end
+
+      it 'does not has the low quality transaction name in tags serialized in the bucket metric key' do
+        transaction.set_name('foo', source: :url)
+        subject.add(:c, 'incr', 1)
+        _, _, _, tags = subject.buckets.values.first.keys.first
+        expect(tags).not_to include(['transaction', 'foo'])
+      end
+    end
+
+    it 'creates a new CounterMetric instance if not existing' do
+      expect(Sentry::Metrics::CounterMetric).to receive(:new).and_call_original
+      subject.add(:c, 'incr', 1)
+
+      metric = subject.buckets.values.first.values.first
+      expect(metric).to be_a(Sentry::Metrics::CounterMetric)
+      expect(metric.value).to eq(1.0)
+    end
+
+    it 'reuses the existing CounterMetric instance' do
+      allow(Time).to receive(:now).and_return(fake_time)
+
+      subject.add(:c, 'incr', 1)
+      metric = subject.buckets.values.first.values.first
+      expect(metric.value).to eq(1.0)
+
+      expect(Sentry::Metrics::CounterMetric).not_to receive(:new)
+      expect(metric).to receive(:add).with(2).and_call_original
+      subject.add(:c, 'incr', 2)
+      expect(metric.value).to eq(3.0)
+    end
+
+    it 'creates a new DistributionMetric instance if not existing' do
+      expect(Sentry::Metrics::DistributionMetric).to receive(:new).and_call_original
+      subject.add(:d, 'dist', 1)
+
+      metric = subject.buckets.values.first.values.first
+      expect(metric).to be_a(Sentry::Metrics::DistributionMetric)
+      expect(metric.value).to eq([1.0])
+    end
+
+    it 'creates a new GaugeMetric instance if not existing' do
+      expect(Sentry::Metrics::GaugeMetric).to receive(:new).and_call_original
+      subject.add(:g, 'gauge', 1)
+
+      metric = subject.buckets.values.first.values.first
+      expect(metric).to be_a(Sentry::Metrics::GaugeMetric)
+      expect(metric.serialize).to eq([1.0, 1.0, 1.0, 1.0, 1])
+    end
+
+    it 'creates a new SetMetric instance if not existing' do
+      expect(Sentry::Metrics::SetMetric).to receive(:new).and_call_original
+      subject.add(:s, 'set', 1)
+
+      metric = subject.buckets.values.first.values.first
+      expect(metric).to be_a(Sentry::Metrics::SetMetric)
+      expect(metric.value).to eq(Set[1])
+    end
+  end
+
+  describe '#flush' do
+    context 'with empty buckets' do
+      it 'returns early and does nothing' do
+        expect(sentry_envelopes.count).to eq(0)
+        subject.flush
+      end
+
+      it 'returns early and does nothing with force' do
+        expect(sentry_envelopes.count).to eq(0)
+        subject.flush(force: true)
+      end
+    end
+
+    context 'with pending buckets' do
+      before do
+        allow(Time).to receive(:now).and_return(fake_time)
+        10.times { subject.add(:c, 'incr', 1) }
+        5.times { |i| subject.add(:d, 'dist', i, unit: 'second', tags: { "foö$-bar" => "snöwmän% 23{}" }) }
+
+        allow(Time).to receive(:now).and_return(fake_time + 9)
+        5.times { subject.add(:c, 'incr', 1) }
+        5.times { |i| subject.add(:d, 'dist', i + 5, unit: 'second', tags: { "foö$-bar" => "snöwmän% 23{}" }) }
+
+        expect(subject.buckets.keys).to eq([fake_time.to_i - 3, fake_time.to_i + 7])
+        expect(subject.buckets.values[0].length).to eq(2)
+        expect(subject.buckets.values[1].length).to eq(2)
+
+        # set the time such that the first set of metrics above are picked
+        allow(Time).to receive(:now).and_return(fake_time + 9 + subject.flush_shift)
+      end
+
+      context 'without force' do
+        it 'updates the pending buckets in place' do
+          subject.flush
+
+          expect(subject.buckets.keys).to eq([fake_time.to_i + 7])
+          expect(subject.buckets.values[0].length).to eq(2)
+        end
+
+        it 'calls the background worker' do
+          expect(Sentry.background_worker).to receive(:perform)
+          subject.flush
+        end
+
+        it 'sends the flushable buckets in statsd envelope item with correct payload' do
+          subject.flush
+
+          envelope = sentry_envelopes.first
+          expect(envelope.headers).to eq({})
+
+          item = envelope.items.first
+          expect(item.headers).to eq({ type: 'statsd', length: item.payload.bytesize })
+          expect(item.is_json).to eq(false)
+
+          incr, dist = item.payload.split("\n")
+          expect(incr).to eq("incr@none:10.0|c|#environment:test,release:test-release|T#{fake_time.to_i - 3}")
+          expect(dist).to eq("dist@second:0.0:1.0:2.0:3.0:4.0|d|" +
+                             "#environment:test,fo_-bar:snöwmän 23{},release:test-release|" +
+                             "T#{fake_time.to_i - 3}")
+        end
+      end
+
+      context 'with force' do
+        it 'empties the pending buckets in place' do
+          subject.flush(force: true)
+          expect(subject.buckets).to eq({})
+        end
+
+        it 'calls the background worker' do
+          expect(Sentry.background_worker).to receive(:perform)
+          subject.flush(force: true)
+        end
+
+        it 'sends all buckets in statsd envelope item with correct payload' do
+          subject.flush(force: true)
+
+          envelope = sentry_envelopes.first
+          expect(envelope.headers).to eq({})
+
+          item = envelope.items.first
+          expect(item.headers).to eq({ type: 'statsd', length: item.payload.bytesize })
+          expect(item.is_json).to eq(false)
+
+          incr1, dist1, incr2, dist2 = item.payload.split("\n")
+          expect(incr1).to eq("incr@none:10.0|c|#environment:test,release:test-release|T#{fake_time.to_i - 3}")
+          expect(dist1).to eq("dist@second:0.0:1.0:2.0:3.0:4.0|d|" +
+                             "#environment:test,fo_-bar:snöwmän 23{},release:test-release|" +
+                             "T#{fake_time.to_i - 3}")
+          expect(incr2).to eq("incr@none:5.0|c|#environment:test,release:test-release|T#{fake_time.to_i + 7}")
+          expect(dist2).to eq("dist@second:5.0:6.0:7.0:8.0:9.0|d|" +
+                             "#environment:test,fo_-bar:snöwmän 23{},release:test-release|" +
+                             "T#{fake_time.to_i + 7}")
+        end
+      end
+    end
+  end
+
+  describe '#kill' do
+    before { subject.add(:c, 'incr', 1) }
+    it 'logs message when killing the thread' do
+      expect(subject.thread).to receive(:kill)
+      subject.kill
+      expect(string_io.string).to match(/\[Metrics::Aggregator\] killing thread/)
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Sentry::Metrics::Aggregator do
 
   before do
     perform_basic_setup do |config|
-      config.enable_metrics = true
+      config.metrics.enabled = true
       config.enable_tracing = true
       config.release = 'test-release'
       config.environment = 'test'

--- a/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
@@ -124,17 +124,15 @@ RSpec.describe Sentry::Metrics::Aggregator do
     end
 
     context 'with running transaction' do
-      let(:transaction) { Sentry.start_transaction(name: 'foo', source: :view) }
-      before { Sentry.get_current_scope.set_span(transaction) }
-
       it 'has the transaction name in tags serialized in the bucket metric key' do
+        Sentry.get_current_scope.set_transaction_name('foo')
         subject.add(:c, 'incr', 1)
         _, _, _, tags = subject.buckets.values.first.keys.first
         expect(tags).to include(['transaction', 'foo'])
       end
 
       it 'does not has the low quality transaction name in tags serialized in the bucket metric key' do
-        transaction.set_name('foo', source: :url)
+        Sentry.get_current_scope.set_transaction_name('foo', source: :url)
         subject.add(:c, 'incr', 1)
         _, _, _, tags = subject.buckets.values.first.keys.first
         expect(tags).not_to include(['transaction', 'foo'])

--- a/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
@@ -241,7 +241,6 @@ RSpec.describe Sentry::Metrics::Aggregator do
 
           item = envelope.items.first
           expect(item.headers).to eq({ type: 'statsd', length: item.payload.bytesize })
-          expect(item.is_json).to eq(false)
 
           incr, dist = item.payload.split("\n")
           expect(incr).to eq("incr@none:10.0|c|#environment:test,release:test-release|T#{fake_time.to_i - 3}")
@@ -270,7 +269,6 @@ RSpec.describe Sentry::Metrics::Aggregator do
 
           item = envelope.items.first
           expect(item.headers).to eq({ type: 'statsd', length: item.payload.bytesize })
-          expect(item.is_json).to eq(false)
 
           incr1, dist1, incr2, dist2 = item.payload.split("\n")
           expect(incr1).to eq("incr@none:10.0|c|#environment:test,release:test-release|T#{fake_time.to_i - 3}")

--- a/sentry-ruby/spec/sentry/metrics/counter_metric_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/counter_metric_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe Sentry::Metrics::CounterMetric do
+  subject { described_class.new(1) }
+  before { subject.add(2) }
+
+  describe '#add' do
+    it 'adds float value' do
+      subject.add(3.0)
+      expect(subject.value).to eq(6.0)
+    end
+  end
+
+  describe '#serialize' do
+    it 'returns value in array' do
+      expect(subject.serialize).to eq([3.0])
+    end
+  end
+
+  describe '#weight' do
+    it 'returns fixed value of 1' do
+      expect(subject.weight).to eq(1)
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/metrics/distribution_metric_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/distribution_metric_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe Sentry::Metrics::DistributionMetric do
+  subject { described_class.new(1) }
+  before { subject.add(2) }
+
+  describe '#add' do
+    it 'appends float value to array' do
+      subject.add(3.0)
+      expect(subject.value).to eq([1.0, 2.0, 3.0])
+    end
+  end
+
+  describe '#serialize' do
+    it 'returns whole array' do
+      expect(subject.serialize).to eq([1.0, 2.0])
+    end
+  end
+
+  describe '#weight' do
+    it 'returns length of array' do
+      expect(subject.weight).to eq(2)
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/metrics/gauge_metric_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/gauge_metric_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe Sentry::Metrics::GaugeMetric do
+  subject { described_class.new(0) }
+  before { 9.times { |i| subject.add(i + 1) } }
+
+  describe '#add' do
+    it 'appends float value to array' do
+      subject.add(11)
+      expect(subject.last).to eq(11.0)
+      expect(subject.min).to eq(0.0)
+      expect(subject.max).to eq(11.0)
+      expect(subject.sum).to eq(56.0)
+      expect(subject.count).to eq(11)
+    end
+  end
+
+  describe '#serialize' do
+    it 'returns array of statistics' do
+      expect(subject.serialize).to eq([9.0, 0.0, 9.0, 45.0, 10])
+    end
+  end
+
+  describe '#weight' do
+    it 'returns fixed value of 5' do
+      expect(subject.weight).to eq(5)
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/metrics/metric_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/metric_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe Sentry::Metrics::Metric do
+  describe '#add' do
+    it 'raises not implemented error' do
+      expect { subject.add(1) }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#serialize' do
+    it 'raises not implemented error' do
+      expect { subject.serialize }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#weight' do
+    it 'raises not implemented error' do
+      expect { subject.weight }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/metrics/set_metric_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/set_metric_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe Sentry::Metrics::SetMetric do
+  subject { described_class.new('foo') }
+
+  before do
+    2.times { subject.add('foo') }
+    2.times { subject.add('bar') }
+    2.times { subject.add(42) }
+  end
+
+  describe '#add' do
+    it 'appends new value to set' do
+      subject.add('baz')
+      expect(subject.value).to eq(Set['foo', 'bar', 'baz', 42])
+    end
+  end
+
+  describe '#serialize' do
+    it 'returns array of hashed values' do
+      expect(subject.serialize).to eq([Zlib.crc32('foo'), Zlib.crc32('bar'), 42])
+    end
+  end
+
+  describe '#weight' do
+    it 'returns length of set' do
+      expect(subject.weight).to eq(3)
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/metrics_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+RSpec.describe Sentry::Metrics do
+  before do
+    perform_basic_setup do |config|
+      config.enable_metrics = true
+    end
+  end
+
+  let(:aggregator) { Sentry.metrics_aggregator }
+  let(:fake_time) { Time.new(2024, 1, 1, 1, 1, 3) }
+
+  describe '.incr' do
+    it 'passes default value of 1.0 with only key' do
+      expect(aggregator).to receive(:add).with(
+        :c,
+        'foo',
+        1.0,
+        unit: 'none',
+        tags: {},
+        timestamp: nil
+      )
+
+      described_class.incr('foo')
+    end
+
+    it 'passes through args to aggregator' do
+      expect(aggregator).to receive(:add).with(
+        :c,
+        'foo',
+        5.0,
+        unit: 'second',
+        tags: { fortytwo: 42 },
+        timestamp: fake_time
+      )
+
+      described_class.incr('foo', 5.0, unit: 'second', tags: { fortytwo: 42 }, timestamp: fake_time)
+    end
+  end
+
+  describe '.distribution' do
+    it 'passes through args to aggregator' do
+      expect(aggregator).to receive(:add).with(
+        :d,
+        'foo',
+        5.0,
+        unit: 'second',
+        tags: { fortytwo: 42 },
+        timestamp: fake_time
+      )
+
+      described_class.distribution('foo', 5.0, unit: 'second', tags: { fortytwo: 42 }, timestamp: fake_time)
+    end
+  end
+
+  describe '.set' do
+    it 'passes through args to aggregator' do
+      expect(aggregator).to receive(:add).with(
+        :s,
+        'foo',
+        'jane',
+        unit: 'none',
+        tags: { fortytwo: 42 },
+        timestamp: fake_time
+      )
+
+      described_class.set('foo', 'jane', tags: { fortytwo: 42 }, timestamp: fake_time)
+    end
+  end
+
+  describe '.gauge' do
+    it 'passes through args to aggregator' do
+      expect(aggregator).to receive(:add).with(
+        :g,
+        'foo',
+        5.0,
+        unit: 'second',
+        tags: { fortytwo: 42 },
+        timestamp: fake_time
+      )
+
+      described_class.gauge('foo', 5.0, unit: 'second', tags: { fortytwo: 42 }, timestamp: fake_time)
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/metrics_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Sentry::Metrics do
   before do
     perform_basic_setup do |config|
-      config.enable_metrics = true
+      config.metrics.enabled = true
     end
   end
 

--- a/sentry-ruby/spec/sentry/metrics_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Sentry::Metrics do
   let(:aggregator) { Sentry.metrics_aggregator }
   let(:fake_time) { Time.new(2024, 1, 1, 1, 1, 3) }
 
-  describe '.incr' do
+  describe '.increment' do
     it 'passes default value of 1.0 with only key' do
       expect(aggregator).to receive(:add).with(
         :c,
@@ -21,7 +21,7 @@ RSpec.describe Sentry::Metrics do
         timestamp: nil
       )
 
-      described_class.incr('foo')
+      described_class.increment('foo')
     end
 
     it 'passes through args to aggregator' do
@@ -34,7 +34,7 @@ RSpec.describe Sentry::Metrics do
         timestamp: fake_time
       )
 
-      described_class.incr('foo', 5.0, unit: 'second', tags: { fortytwo: 42 }, timestamp: fake_time)
+      described_class.increment('foo', 5.0, unit: 'second', tags: { fortytwo: 42 }, timestamp: fake_time)
     end
   end
 

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -651,4 +651,16 @@ RSpec.describe Sentry::Transaction do
       expect(subject.contexts).to eq({ foo: { bar: 42 } })
     end
   end
+
+  describe "#source_low_quality?" do
+    it "returns true when :url" do
+      subject.set_name('foo', source: :url)
+      expect(subject.source_low_quality?).to eq(true)
+    end
+
+    it "returns false otherwise" do
+      subject.set_name('foo', source: :view)
+      expect(subject.source_low_quality?).to eq(false)
+    end
+  end
 end

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -188,8 +188,7 @@ RSpec.describe Sentry::Transport do
         envelope = Sentry::Envelope.new
         envelope.add_item(
           { type: 'statsd', length: payload.bytesize },
-          payload,
-          is_json: false
+          payload
         )
         envelope
       end

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -178,6 +178,31 @@ RSpec.describe Sentry::Transport do
       end
     end
 
+    context "metrics/statsd item" do
+      let(:payload) do
+        "foo@none:10.0|c|#tag1:42,tag2:bar|T1709042970\n" +
+          "bar@second:0.3:0.1:0.9:49.8:100|g|#|T1709042980"
+      end
+
+      let(:envelope) do
+        envelope = Sentry::Envelope.new
+        envelope.add_item(
+          { type: 'statsd', length: payload.bytesize },
+          payload,
+          is_json: false
+        )
+        envelope
+      end
+
+      it "adds raw payload to envelope item" do
+        result, _ = subject.serialize_envelope(envelope)
+        item = result.split("\n", 2).last
+        item_header, item_payload = item.split("\n", 2)
+        expect(JSON.parse(item_header)).to eq({ 'type' => 'statsd', 'length' => 93 })
+        expect(item_payload).to eq(payload)
+      end
+    end
+
     context "oversized event" do
       context "due to breadcrumb" do
         let(:event) { client.event_from_message("foo") }

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -1048,6 +1048,14 @@ RSpec.describe Sentry do
         expect(described_class.backpressure_monitor).to eq(nil)
       end
 
+      it "flushes and kills metrics aggregator" do
+        perform_basic_setup { |c| c.enable_metrics = true }
+        expect(described_class.metrics_aggregator).to receive(:flush).with(force: true)
+        expect(described_class.metrics_aggregator).to receive(:kill)
+        described_class.close
+        expect(described_class.metrics_aggregator).to eq(nil)
+      end
+
       it "flushes transport" do
         expect(described_class.get_current_client.transport).to receive(:flush)
         described_class.close

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -1049,7 +1049,7 @@ RSpec.describe Sentry do
       end
 
       it "flushes and kills metrics aggregator" do
-        perform_basic_setup { |c| c.enable_metrics = true }
+        perform_basic_setup { |c| c.metrics.enabled = true }
         expect(described_class.metrics_aggregator).to receive(:flush).with(force: true)
         expect(described_class.metrics_aggregator).to receive(:kill)
         described_class.close


### PR DESCRIPTION
* new `Sentry::Metrics` module with 4 apis that map to the new 4 `Sentry::Metrics::Metric` classes
  * `increment` - simple counter
  * `distribution` -  array of observations
  * `gauge` - statistics (last/min/max/sum/count)
  * `set` - unique values
* new `Sentry::Metrics::Aggregator` that starts a thread that flushes pending metric buckets in 5 second intervals 
  * buckets are a nested hash of timestamp (rolled to 10 second intervals) -> metric keys -> actual metric instance
  * there is a random `flush_shift` once per startup to create jittering
  * flushable buckets are sent in a new `statsd` type envelope that is not json so made a small change to the `Envelope::Item`
  * tag key/values are sanitized for unicode/special characters according to the two regexes

Reference spec - https://develop.sentry.dev/sdk/metrics/

part of #2246 