### PR TITLE
Read time_zone.name instead of time_zone

### DIFF
--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -72,8 +72,8 @@ module Sentry
     end
 
     def configure_cron_timezone
-      tz_info = ::ActiveSupport::TimeZone.find_tzinfo(::Rails.application.config.time_zone)
-      Sentry.configuration.cron.default_timezone = tz_info.name
+      tz_info = ::ActiveSupport::TimeZone.find_tzinfo(::Rails.application.config.time_zone.name)
+      Sentry.configuration.cron.default_timezone = tz_info
     end
 
     def extend_controller_methods


### PR DESCRIPTION
## Description
Without adding time_zone.name, the returned value is considered invalid by tzdata.

Closes: #2249
