### PR TITLE
Fix mention of renamed attribute

### DIFF
--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -116,8 +116,8 @@ module Sentry
 
       # Rails catches exceptions in the ActionDispatch::ShowExceptions or
       # ActionDispatch::DebugExceptions middlewares, depending on the environment.
-      # When `rails_report_rescued_exceptions` is true (it is by default), Sentry
-      # will report exceptions even when they are rescued by these middlewares.
+      # When `report_rescued_exceptions` is true (it is by default), Sentry will
+      # report exceptions even when they are rescued by these middlewares.
       attr_accessor :report_rescued_exceptions
 
       # Some adapters, like sidekiq, already have their own sentry integration.


### PR DESCRIPTION
`rails_report_rescued_exceptions` was changed to `rails.report_rescued_exceptions` in #1070. The inline docuentation was copied without updating the attribute name.