### PR TITLE
Update backtrace parsing regexp to support Ruby 3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix undefined method 'constantize' issue in `sentry-resque` ([#2248](https://github.com/getsentry/sentry-ruby/pull/2248))
 - Only instantiate SessionFlusher when the SDK is enabled under the current env [#2245](https://github.com/getsentry/sentry-ruby/pull/2245)
   - Fixes [#2234](https://github.com/getsentry/sentry-ruby/issues/2234)
+- Update backtrace parsing regexp to support Ruby 3.4 ([#2252](https://github.com/getsentry/sentry-ruby/pull/2252))
 
 ## 5.16.1
 

--- a/sentry-ruby/lib/sentry/backtrace.rb
+++ b/sentry-ruby/lib/sentry/backtrace.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rubygems"
+
 module Sentry
   # @api private
   class Backtrace
@@ -10,7 +12,7 @@ module Sentry
       RUBY_INPUT_FORMAT = /
         ^ \s* (?: [a-zA-Z]: | uri:classloader: )? ([^:]+ | <.*>):
         (\d+)
-        (?: :in \s `([^']+)')?$
+        (?: :in\s('|`)([^']+)')?$
       /x.freeze
 
       # org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
@@ -36,7 +38,7 @@ module Sentry
       def self.parse(unparsed_line, in_app_pattern)
         ruby_match = unparsed_line.match(RUBY_INPUT_FORMAT)
         if ruby_match
-          _, file, number, method = ruby_match.to_a
+          _, file, number, _, method = ruby_match.to_a
           file.sub!(/\.class$/, RB_EXTENSION)
           module_name = nil
         else

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -221,6 +221,10 @@ RSpec.describe Sentry::Client do
         version = Gem::Version.new(RUBY_VERSION)
 
         case
+        when version >= Gem::Version.new("3.4.0-dev")
+          expect(hash[:exception][:values][0][:value]).to eq(
+            "undefined method '[]' for nil (NoMethodError)\n\n          {}[:foo][:bar]\n                  ^^^^^^"
+          )
         when version >= Gem::Version.new("3.3.0-dev")
           expect(hash[:exception][:values][0][:value]).to eq(
             "undefined method `[]' for nil (NoMethodError)\n\n          {}[:foo][:bar]\n                  ^^^^^^"


### PR DESCRIPTION
In Ruby 3.4, the backtrace format has changed slightly. This commit updates the regular expression used to parse the backtrace to support Ruby 3.4.

See https://github.com/ruby/ruby/pull/9608 for more information.

(This is required to keep the CI green)
