### PR TITLE
Specify what is creating a background worker

### DIFF
--- a/sentry-ruby/lib/sentry/background_worker.rb
+++ b/sentry-ruby/lib/sentry/background_worker.rb
@@ -31,7 +31,7 @@ module Sentry
           log_debug("config.background_worker_threads is set to 0, all events will be sent synchronously")
           Concurrent::ImmediateExecutor.new
         else
-          log_debug("Initializing the background worker with #{@number_of_threads} threads")
+          log_debug("Initializing the Sentry background worker with #{@number_of_threads} threads")
 
           executor = Concurrent::ThreadPoolExecutor.new(
             min_threads: 0,

--- a/sentry-ruby/spec/sentry/background_worker_spec.rb
+++ b/sentry-ruby/spec/sentry/background_worker_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Sentry::BackgroundWorker do
         expect(worker.number_of_threads).to eq(5)
 
         expect(string_io.string).to match(
-          /Initializing the background worker with 5 threads/
+          /Initializing the Sentry background worker with 5 threads/
         )
       end
     end


### PR DESCRIPTION
## Description
Describe your changes:

When running Rails tasks, I see something "initializing the background worker", e.g.:

```
> bin/rails c
Initializing the background worker with 5 threads
Loading development environment (Rails 7.0.8.1)
[1] pry(main)>
```

I thought it might be helpful if this message indicated what it is - Sentry - that is doing this:

```
> bin/rails c
Initializing the Sentry background worker with 5 threads
Loading development environment (Rails 7.0.8.1)
[1] pry(main)>
```

#skip-changelog