### PR TITLE
Fix NoMethodError / Make session_tracking check consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix NoMethodError / Make session_tracking check consistent ([#2269](https://github.com/getsentry/sentry-ruby/pull/2269))
+
 ## 5.17.0
 
 ### Features

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -245,7 +245,7 @@ module Sentry
     end
 
     def with_session_tracking(&block)
-      return yield unless configuration.auto_session_tracking
+      return yield unless configuration.session_tracking?
 
       start_session
       yield


### PR DESCRIPTION
## Description
https://github.com/getsentry/sentry-ruby/pull/2245 (cc @st0012 ) introduced changes around checking if session_tracking is enabled or not.. However, it wasn't updated in all necessary places and make it inconsistent within the codebase. As result, when not `enabled_in_current_env?` we're getting a following error:

```
     NoMethodError:
       undefined method `add_session' for nil:NilClass
     # <REDACTED>/gems/sentry-ruby-5.17.0/lib/sentry/hub.rb:244:in `end_session'
     # <REDACTED>/gems/sentry-ruby-5.17.0/lib/sentry/hub.rb:253:in `with_session_tracking'
     # <REDACTED>/gems/sentry-ruby-5.17.0/lib/sentry-ruby.rb:403:in `with_session_tracking'
```
     
Affected version: `sentry-ruby 5.17.0`