### PR TITLE
Require `debug/prelude` in spec helper

### DIFF
--- a/sentry-delayed_job/spec/spec_helper.rb
+++ b/sentry-delayed_job/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "debug" if RUBY_VERSION.to_f >= 2.6 && RUBY_ENGINE == "ruby"
+require "debug" if RUBY_VERSION.to_f >= 2.7 && RUBY_ENGINE == "ruby"
 require "active_record"
 require "delayed_job"
 require "delayed_job_active_record"

--- a/sentry-delayed_job/spec/spec_helper.rb
+++ b/sentry-delayed_job/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 require "bundler/setup"
-require "debug" if RUBY_VERSION.to_f >= 2.7 && RUBY_ENGINE == "ruby"
+begin
+  require "debug/prelude"
+rescue LoadError
+end
 require "active_record"
 require "delayed_job"
 require "delayed_job_active_record"

--- a/sentry-opentelemetry/spec/spec_helper.rb
+++ b/sentry-opentelemetry/spec/spec_helper.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "debug" if RUBY_VERSION.to_f >= 2.7 && RUBY_ENGINE == "ruby"
+begin
+  require "debug/prelude"
+rescue LoadError
+end
 
 require 'simplecov'
 

--- a/sentry-opentelemetry/spec/spec_helper.rb
+++ b/sentry-opentelemetry/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "debug" if RUBY_VERSION.to_f >= 2.6 && RUBY_ENGINE == "ruby"
+require "debug" if RUBY_VERSION.to_f >= 2.7 && RUBY_ENGINE == "ruby"
 
 require 'simplecov'
 

--- a/sentry-rails/spec/spec_helper.rb
+++ b/sentry-rails/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "debug" if RUBY_VERSION.to_f >= 2.6 && RUBY_ENGINE == "ruby"
+require "debug" if RUBY_VERSION.to_f >= 2.7 && RUBY_ENGINE == "ruby"
 
 require "sentry-ruby"
 require 'rspec/retry'

--- a/sentry-rails/spec/spec_helper.rb
+++ b/sentry-rails/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 require "bundler/setup"
-require "debug" if RUBY_VERSION.to_f >= 2.7 && RUBY_ENGINE == "ruby"
+begin
+  require "debug/prelude"
+rescue LoadError
+end
 
 require "sentry-ruby"
 require 'rspec/retry'

--- a/sentry-resque/spec/spec_helper.rb
+++ b/sentry-resque/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 require "bundler/setup"
-require "debug" if RUBY_VERSION.to_f >= 2.7 && RUBY_ENGINE == "ruby"
+begin
+  require "debug/prelude"
+rescue LoadError
+end
 
 require "resque"
 require "resque-retry"

--- a/sentry-resque/spec/spec_helper.rb
+++ b/sentry-resque/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "debug" if RUBY_VERSION.to_f >= 2.6 && RUBY_ENGINE == "ruby"
+require "debug" if RUBY_VERSION.to_f >= 2.7 && RUBY_ENGINE == "ruby"
 
 require "resque"
 require "resque-retry"

--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 require "bundler/setup"
-require "debug" if RUBY_VERSION.to_f >= 2.7 && RUBY_ENGINE == "ruby"
+begin
+  require "debug/prelude"
+rescue LoadError
+end
 require "timecop"
 require "simplecov"
 require "rspec/retry"

--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "debug" if RUBY_VERSION.to_f >= 2.6 && RUBY_ENGINE == "ruby"
+require "debug" if RUBY_VERSION.to_f >= 2.7 && RUBY_ENGINE == "ruby"
 require "timecop"
 require "simplecov"
 require "rspec/retry"

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 require "bundler/setup"
-require "debug" if RUBY_VERSION.to_f >= 2.7 && RUBY_ENGINE == "ruby"
+begin
+  require "debug/prelude"
+rescue LoadError
+end
 
 # this enables sidekiq's server mode
 require "sidekiq/cli"

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "debug" if RUBY_VERSION.to_f >= 2.6 && RUBY_ENGINE == "ruby"
+require "debug" if RUBY_VERSION.to_f >= 2.7 && RUBY_ENGINE == "ruby"
 
 # this enables sidekiq's server mode
 require "sidekiq/cli"


### PR DESCRIPTION
Because the latest debug gem now requires Ruby >= 2.7, if we require `debug` in older Rubies, it'll require a very outdated debug lib instead.

Also, requiring `debug` activates the debugger even when no breakpoints are set. Requiring `debug/prelude` can avoid it while allowing the use of breakpoints like `binding.break` or `debugger`.

Closes #2266

#skip-changelog