### PR TITLE
fix: Don't mutate original enabled_environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - Don't instantiate connection in `ActiveRecordSubscriber` ([#2278](https://github.com/getsentry/sentry-ruby/pull/2278))
+- Don't mutate original `enabled_environments` when using test helpers ([#2275](https://github.com/getsentry/sentry-ruby/pull/2275))
 
 ## 5.17.1
 

--- a/sentry-ruby/lib/sentry/test_helper.rb
+++ b/sentry-ruby/lib/sentry/test_helper.rb
@@ -20,7 +20,7 @@ module Sentry
       # set transport to DummyTransport, so we can easily intercept the captured events
       dummy_config.transport.transport_class = Sentry::DummyTransport
       # make sure SDK allows sending under the current environment
-      dummy_config.enabled_environments << dummy_config.environment unless dummy_config.enabled_environments.include?(dummy_config.environment)
+      dummy_config.enabled_environments |= [dummy_config.environment] unless dummy_config.enabled_environments.include?(dummy_config.environment)
       # disble async event sending
       dummy_config.background_worker_threads = 0
 


### PR DESCRIPTION
Ensure enabled_environments contains test environment without mutating original list. Otherwise it can cause unexpected spec failures in case original config has unfrozen Array, or fail in attempt to mutate said array.

Alternative approach would be to override `Sentry::Configuration#dup` to dup underlying arrays and hashes.

See: https://github.com/getsentry/sentry-ruby/pull/2269#issuecomment-2002637738