### PR TITLE
Fix: Get connection from connection_pool instead of ActiveRecord::Base.connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Don't instantiate connection in `ActiveRecordSubscriber` ([#2278](https://github.com/getsentry/sentry-ruby/pull/2278))
+
 ## 5.17.1
 
 ### Bug Fixes

--- a/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
@@ -21,8 +21,7 @@ module Sentry
                 span.set_data(:connection_id, payload[:connection_id])
 
                 # we fallback to the base connection on rails < 6.0.0 since the payload doesn't have it
-                base_connection = ActiveRecord::Base.connection
-                connection ||= base_connection if payload[:connection_id] == base_connection.object_id
+                connection ||= ActiveRecord::Base.connection_pool.connections.find { |conn| conn.object_id == payload[:connection_id] }
               end
 
               next unless connection


### PR DESCRIPTION
# Issue
When attempting to retrieve a connection in `ActiveRecordSubscriber`, a loop occurs, eventually leading to `ActiveRecord::ConnectionTimeoutError`.

In versions of Rails lower than 6, since the payload does not contain a connection, it tries to use `ActiveRecord::Base.connection` to get the current connection. However, it seems that this causes `subscribe!` to be called again.
I am not sure if this issue is specific to MySQL. Please refer to the following repository for a reproduction environment:
https://github.com/Iwaide/re_app_for_sentry/

# Fix
I have modified the code to search for and retrieve a connection from `ActiveRecord::Base.connection_pool.connections`.
I am not very familiar with connection management, so I am not entirely confident that this is the appropriate approach. Please make any necessary corrections.