### PR TITLE
Make sure isolated envelopes respect enabled_environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Bug Fixes
+
+- Make sure isolated envelopes respect `config.enabled_environments` [#2291](https://github.com/getsentry/sentry-ruby/pull/2291)
+  - Fixes [#2287](https://github.com/getsentry/sentry-ruby/issues/2287)
+
 ## 5.17.2
 
 ### Features

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -257,7 +257,7 @@ module Sentry
       end
 
       if client = get_current_client
-        client.transport.flush
+        client.flush
 
         if client.configuration.include_local_variables
           exception_locals_tp.disable

--- a/sentry-ruby/lib/sentry/metrics/aggregator.rb
+++ b/sentry-ruby/lib/sentry/metrics/aggregator.rb
@@ -23,7 +23,7 @@ module Sentry
       }
 
       # exposed only for testing
-      attr_reader :thread, :buckets, :flush_shift, :code_locations
+      attr_reader :client, :thread, :buckets, :flush_shift, :code_locations
 
       def initialize(configuration, client)
         @client = client
@@ -107,9 +107,7 @@ module Sentry
           end
         end
 
-        Sentry.background_worker.perform do
-          @client.transport.send_envelope(envelope)
-        end
+        @client.capture_envelope(envelope)
       end
 
       def kill

--- a/sentry-ruby/lib/sentry/session_flusher.rb
+++ b/sentry-ruby/lib/sentry/session_flusher.rb
@@ -20,12 +20,8 @@ module Sentry
 
     def flush
       return if @pending_aggregates.empty?
-      envelope = pending_envelope
 
-      Sentry.background_worker.perform do
-        @client.transport.send_envelope(envelope)
-      end
-
+      @client.capture_envelope(pending_envelope)
       @pending_aggregates = {}
     end
 

--- a/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
@@ -364,8 +364,8 @@ RSpec.describe Sentry::Metrics::Aggregator do
           expect(subject.code_locations).to eq({})
         end
 
-        it 'calls the background worker' do
-          expect(Sentry.background_worker).to receive(:perform)
+        it 'captures the envelope' do
+          expect(subject.client).to receive(:capture_envelope)
           subject.flush
         end
 
@@ -414,7 +414,7 @@ RSpec.describe Sentry::Metrics::Aggregator do
           expect(subject.buckets).to eq({})
         end
 
-        it 'calls the background worker' do
+        it 'captures the envelope' do
           expect(Sentry.background_worker).to receive(:perform)
           subject.flush(force: true)
         end

--- a/sentry-ruby/spec/sentry/session_flusher_spec.rb
+++ b/sentry-ruby/spec/sentry/session_flusher_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Sentry::SessionFlusher do
 
   let(:configuration) do
     Sentry::Configuration.new.tap do |config|
+      config.dsn = Sentry::TestHelper::DUMMY_DSN
       config.release = 'test-release'
       config.environment = 'test'
       config.transport.transport_class = Sentry::DummyTransport

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -1084,7 +1084,7 @@ RSpec.describe Sentry do
       end
 
       it "flushes transport" do
-        expect(described_class.get_current_client.transport).to receive(:flush)
+        expect(described_class.get_current_client).to receive(:flush)
         described_class.close
       end
 


### PR DESCRIPTION
Envelopes for metrics/sessions and so on were queued directly before and thus did not respect the config. This introduces a dedicated `capture_envelope` on the client to centralize these checks.

Closes #2287
