### PR TITLE
Don't throw error on arbitrary arguments being passed to `capture_event` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
   Rails users will be able to use `bin/rails generate sentry` to generate their `config/initializers/sentry.rb` file.
 
+### Bug Fixes
+
+- Don't throw error on arbitrary arguments being passed to `capture_event` options [#2301](https://github.com/getsentry/sentry-ruby/pull/2301)
+  - Fixes [#2299](https://github.com/getsentry/sentry-ruby/issues/2299)
+
 ## 5.17.3
 
 ### Internal

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -135,7 +135,8 @@ module Sentry
       tags: nil,
       user: nil,
       level: nil,
-      fingerprint: nil
+      fingerprint: nil,
+      **options
     )
       self.contexts.merge!(contexts) if contexts
       self.extra.merge!(extra) if extra

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -336,4 +336,30 @@ RSpec.describe Sentry::Scope do
       subject.generate_propagation_context(env)
     end
   end
+
+  describe '#update_from_options' do
+    it 'updates data from arguments' do
+      subject.update_from_options(
+        contexts: { context: 1 },
+        extra: { foo: 42 },
+        tags: { tag: 2 },
+        user: { name: 'jane' },
+        level: :info,
+        fingerprint: 'ABCD'
+      )
+
+      expect(subject.contexts).to include(context: 1)
+      expect(subject.extra).to eq({ foo: 42 })
+      expect(subject.tags).to eq({ tag: 2 })
+      expect(subject.user).to eq({ name: 'jane' })
+      expect(subject.level).to eq(:info)
+      expect(subject.fingerprint).to eq('ABCD')
+    end
+
+    it 'does not throw when arbitrary options passed' do
+      expect do
+        subject.update_from_options(foo: 42)
+      end.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
fixes #2299 