### PR TITLE
Notify users when their custom options are discarded

### DIFF
--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -193,7 +193,12 @@ module Sentry
       elsif custom_scope = options[:scope]
         scope.update_from_scope(custom_scope)
       elsif !options.empty?
-        scope.update_from_options(**options)
+        unsupported_option_keys = scope.update_from_options(**options)
+
+        configuration.log_debug <<~MSG
+          Options #{unsupported_option_keys} are not supported and will not be applied to the event.
+          You may want to set them under the `extra` option.
+        MSG
       end
 
       event = current_client.capture_event(event, scope, hint)

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -128,7 +128,7 @@ module Sentry
     # @param user [Hash]
     # @param level [String, Symbol]
     # @param fingerprint [Array]
-    # @return [void]
+    # @return [Array]
     def update_from_options(
       contexts: nil,
       extra: nil,
@@ -144,6 +144,9 @@ module Sentry
       self.user = user if user
       self.level = level if level
       self.fingerprint = fingerprint if fingerprint
+
+      # Returns unsupported option keys so we can notify users.
+      options.keys
     end
 
     # Sets the scope's rack_env attribute.

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -342,6 +342,14 @@ RSpec.describe Sentry::Hub do
       end
     end
 
+    it "reminds users about unsupported options" do
+      expect do
+        subject.capture_event(event, unsupported: true)
+      end.not_to raise_error
+
+      expect(string_io.string).to include("Options [:unsupported] are not supported and will not be applied to the event.")
+    end
+
     context "when event is a transaction" do
       it "transaction.set_context merges and takes precedence over scope.set_context" do
         scope.set_context(:foo, { val: 42 })

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -339,7 +339,7 @@ RSpec.describe Sentry::Scope do
 
   describe '#update_from_options' do
     it 'updates data from arguments' do
-      subject.update_from_options(
+      result = subject.update_from_options(
         contexts: { context: 1 },
         extra: { foo: 42 },
         tags: { tag: 2 },
@@ -354,12 +354,12 @@ RSpec.describe Sentry::Scope do
       expect(subject.user).to eq({ name: 'jane' })
       expect(subject.level).to eq(:info)
       expect(subject.fingerprint).to eq('ABCD')
+      expect(result).to eq([])
     end
 
-    it 'does not throw when arbitrary options passed' do
-      expect do
-        subject.update_from_options(foo: 42)
-      end.not_to raise_error
+    it 'returns unsupported option keys' do
+      result = subject.update_from_options(foo: 42, bar: 43)
+      expect(result).to eq([:foo, :bar])
     end
   end
 end


### PR DESCRIPTION
This is a followup on #2301

It should save users from some debugging if we can tell them what options they pass are discarded and how they can fix it.

The warning is only enabled at debug level so it should not be too noisy.

