### PR TITLE
Decrease the default number of background worker threads by half

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Don't throw error on arbitrary arguments being passed to `capture_event` options [#2301](https://github.com/getsentry/sentry-ruby/pull/2301)
   - Fixes [#2299](https://github.com/getsentry/sentry-ruby/issues/2299)
+- Decrease the default number of background worker threads by half ([#2305](https://github.com/getsentry/sentry-ruby/pull/2305))
+  - Fixes [#2297](https://github.com/getsentry/sentry-ruby/issues/2297)
 
 ## 5.17.3
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -351,7 +351,7 @@ module Sentry
     def initialize
       self.app_dirs_pattern = nil
       self.debug = false
-      self.background_worker_threads = Concurrent.processor_count
+      self.background_worker_threads = (Concurrent.processor_count / 2.0).ceil
       self.background_worker_max_queue = BackgroundWorker::DEFAULT_MAX_QUEUE
       self.backtrace_cleanup_callback = nil
       self.max_breadcrumbs = BreadcrumbBuffer::DEFAULT_SIZE

--- a/sentry-ruby/spec/sentry/background_worker_spec.rb
+++ b/sentry-ruby/spec/sentry/background_worker_spec.rb
@@ -28,10 +28,11 @@ RSpec.describe Sentry::BackgroundWorker do
 
     context "when config.background_worker_threads is set" do
       it "initializes a background worker with correct number of threads and queue size" do
+        configuration.background_worker_threads = 4
         worker = described_class.new(configuration)
 
         expect(worker.max_queue).to eq(30)
-        expect(worker.number_of_threads).to eq(Concurrent.processor_count)
+        expect(worker.number_of_threads).to eq(4)
       end
     end
 

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe Sentry::Configuration do
     end
   end
 
+  describe "#background_worker_threads" do
+    it "sets to have of the processors count" do
+      allow(Concurrent).to receive(:processor_count).and_return(8)
+      expect(subject.background_worker_threads).to eq(4)
+    end
+
+    it "sets to 1 with only 1 processor" do
+      allow(Concurrent).to receive(:processor_count).and_return(1)
+      expect(subject.background_worker_threads).to eq(1)
+    end
+  end
+
   describe "#csp_report_uri" do
     it "returns nil if the dsn is not present" do
       expect(subject.csp_report_uri).to eq(nil)


### PR DESCRIPTION
See #2297 for the discussion.

Closes #2297
