### PR TITLE
Make links more specific in gemspecs

### DIFF
--- a/sentry-delayed_job/sentry-delayed_job.gemspec
+++ b/sentry-delayed_job/sentry-delayed_job.gemspec
@@ -7,16 +7,22 @@ Gem::Specification.new do |spec|
   spec.description = spec.summary = "A gem that provides DelayedJob integration for the Sentry error logger"
   spec.email = "accounts@sentry.io"
   spec.license = 'MIT'
-  spec.homepage = "https://github.com/getsentry/sentry-ruby"
 
   spec.platform = Gem::Platform::RUBY
   spec.required_ruby_version = '>= 2.4'
   spec.extra_rdoc_files = ["README.md", "LICENSE.txt"]
   spec.files = `git ls-files | grep -Ev '^(spec|benchmarks|examples)'`.split("\n")
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"
+  github_root_uri = 'https://github.com/getsentry/sentry-ruby'
+  spec.homepage = "#{github_root_uri}/tree/#{spec.version}/#{spec.name}"
+
+  spec.metadata = {
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => spec.homepage,
+    "changelog_uri" => "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md",
+    "bug_tracker_uri" => "#{github_root_uri}/issues",
+    "documentation_uri" => "http://www.rubydoc.info/gems/#{spec.name}/#{spec.version}"
+  }
 
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/sentry-delayed_job/sentry-delayed_job.gemspec
+++ b/sentry-delayed_job/sentry-delayed_job.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "homepage_uri" => spec.homepage,
     "source_code_uri" => spec.homepage,
-    "changelog_uri" => "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md",
+    "changelog_uri" => "#{github_root_uri}/blob/#{spec.version}/CHANGELOG.md",
     "bug_tracker_uri" => "#{github_root_uri}/issues",
     "documentation_uri" => "http://www.rubydoc.info/gems/#{spec.name}/#{spec.version}"
   }

--- a/sentry-opentelemetry/sentry-opentelemetry.gemspec
+++ b/sentry-opentelemetry/sentry-opentelemetry.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "homepage_uri" => spec.homepage,
     "source_code_uri" => spec.homepage,
-    "changelog_uri" => "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md",
+    "changelog_uri" => "#{github_root_uri}/blob/#{spec.version}/CHANGELOG.md",
     "bug_tracker_uri" => "#{github_root_uri}/issues",
     "documentation_uri" => "http://www.rubydoc.info/gems/#{spec.name}/#{spec.version}"
   }

--- a/sentry-opentelemetry/sentry-opentelemetry.gemspec
+++ b/sentry-opentelemetry/sentry-opentelemetry.gemspec
@@ -9,16 +9,22 @@ Gem::Specification.new do |spec|
   spec.description = spec.summary = "A gem that provides OpenTelemetry integration for the Sentry error logger"
   spec.email = "accounts@sentry.io"
   spec.license = 'MIT'
-  spec.homepage = "https://github.com/getsentry/sentry-ruby"
 
   spec.platform = Gem::Platform::RUBY
   spec.required_ruby_version = '>= 2.4'
   spec.extra_rdoc_files = ["README.md", "LICENSE.txt"]
   spec.files = `git ls-files | grep -Ev '^(spec|benchmarks|examples)'`.split("\n")
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"
+  github_root_uri = 'https://github.com/getsentry/sentry-ruby'
+  spec.homepage = "#{github_root_uri}/tree/#{spec.version}/#{spec.name}"
+
+  spec.metadata = {
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => spec.homepage,
+    "changelog_uri" => "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md",
+    "bug_tracker_uri" => "#{github_root_uri}/issues",
+    "documentation_uri" => "http://www.rubydoc.info/gems/#{spec.name}/#{spec.version}"
+  }
 
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/sentry-rails/sentry-rails.gemspec
+++ b/sentry-rails/sentry-rails.gemspec
@@ -15,9 +15,11 @@ Gem::Specification.new do |spec|
 
   spec.homepage = "https://github.com/getsentry/sentry-ruby/tree/#{spec.version}/#{spec.name}"
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md"
+  spec.metadata = {
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => spec.homepage,
+    "changelog_uri" => "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md"
+  }
 
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/sentry-rails/sentry-rails.gemspec
+++ b/sentry-rails/sentry-rails.gemspec
@@ -13,12 +13,15 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ["README.md", "LICENSE.txt"]
   spec.files = `git ls-files | grep -Ev '^(spec|benchmarks|examples)'`.split("\n")
 
-  spec.homepage = "https://github.com/getsentry/sentry-ruby/tree/#{spec.version}/#{spec.name}"
+  github_root_uri = 'https://github.com/getsentry/sentry-ruby'
+  spec.homepage = "#{github_root_uri}/tree/#{spec.version}/#{spec.name}"
 
   spec.metadata = {
     "homepage_uri" => spec.homepage,
     "source_code_uri" => spec.homepage,
-    "changelog_uri" => "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md"
+    "changelog_uri" => "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md",
+    "bug_tracker_uri" => "#{github_root_uri}/issues",
+    "documentation_uri" => "http://www.rubydoc.info/gems/#{spec.name}/#{spec.version}"
   }
 
   spec.bindir        = "exe"

--- a/sentry-rails/sentry-rails.gemspec
+++ b/sentry-rails/sentry-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "homepage_uri" => spec.homepage,
     "source_code_uri" => spec.homepage,
-    "changelog_uri" => "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md",
+    "changelog_uri" => "#{github_root_uri}/blob/#{spec.version}/CHANGELOG.md",
     "bug_tracker_uri" => "#{github_root_uri}/issues",
     "documentation_uri" => "http://www.rubydoc.info/gems/#{spec.name}/#{spec.version}"
   }

--- a/sentry-rails/sentry-rails.gemspec
+++ b/sentry-rails/sentry-rails.gemspec
@@ -7,16 +7,17 @@ Gem::Specification.new do |spec|
   spec.description = spec.summary = "A gem that provides Rails integration for the Sentry error logger"
   spec.email = "accounts@sentry.io"
   spec.license = 'MIT'
-  spec.homepage = "https://github.com/getsentry/sentry-ruby"
 
   spec.platform = Gem::Platform::RUBY
   spec.required_ruby_version = '>= 2.4'
   spec.extra_rdoc_files = ["README.md", "LICENSE.txt"]
   spec.files = `git ls-files | grep -Ev '^(spec|benchmarks|examples)'`.split("\n")
 
+  spec.homepage = "https://github.com/getsentry/sentry-ruby/tree/#{spec.version}/#{spec.name}"
+
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"
+  spec.metadata["changelog_uri"] = "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md"
 
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/sentry-resque/sentry-resque.gemspec
+++ b/sentry-resque/sentry-resque.gemspec
@@ -7,16 +7,22 @@ Gem::Specification.new do |spec|
   spec.description = spec.summary = "A gem that provides Resque integration for the Sentry error logger"
   spec.email = "accounts@sentry.io"
   spec.license = 'MIT'
-  spec.homepage = "https://github.com/getsentry/sentry-ruby"
 
   spec.platform = Gem::Platform::RUBY
   spec.required_ruby_version = '>= 2.4'
   spec.extra_rdoc_files = ["README.md", "LICENSE.txt"]
   spec.files = `git ls-files | grep -Ev '^(spec|benchmarks|examples)'`.split("\n")
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"
+  github_root_uri = 'https://github.com/getsentry/sentry-ruby'
+  spec.homepage = "#{github_root_uri}/tree/#{spec.version}/#{spec.name}"
+
+  spec.metadata = {
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => spec.homepage,
+    "changelog_uri" => "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md",
+    "bug_tracker_uri" => "#{github_root_uri}/issues",
+    "documentation_uri" => "http://www.rubydoc.info/gems/#{spec.name}/#{spec.version}"
+  }
 
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/sentry-resque/sentry-resque.gemspec
+++ b/sentry-resque/sentry-resque.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "homepage_uri" => spec.homepage,
     "source_code_uri" => spec.homepage,
-    "changelog_uri" => "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md",
+    "changelog_uri" => "#{github_root_uri}/blob/#{spec.version}/CHANGELOG.md",
     "bug_tracker_uri" => "#{github_root_uri}/issues",
     "documentation_uri" => "http://www.rubydoc.info/gems/#{spec.name}/#{spec.version}"
   }

--- a/sentry-ruby/sentry-ruby.gemspec
+++ b/sentry-ruby/sentry-ruby.gemspec
@@ -7,16 +7,22 @@ Gem::Specification.new do |spec|
   spec.description = spec.summary = "A gem that provides a client interface for the Sentry error logger"
   spec.email = "accounts@sentry.io"
   spec.license = 'MIT'
-  spec.homepage = "https://github.com/getsentry/sentry-ruby"
 
   spec.platform = Gem::Platform::RUBY
   spec.required_ruby_version = '>= 2.4'
   spec.extra_rdoc_files = ["README.md", "LICENSE.txt"]
   spec.files = `git ls-files | grep -Ev '^(spec|benchmarks|examples)'`.split("\n")
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"
+  github_root_uri = 'https://github.com/getsentry/sentry-ruby'
+  spec.homepage = "#{github_root_uri}/tree/#{spec.version}/#{spec.name}"
+
+  spec.metadata = {
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => spec.homepage,
+    "changelog_uri" => "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md",
+    "bug_tracker_uri" => "#{github_root_uri}/issues",
+    "documentation_uri" => "http://www.rubydoc.info/gems/#{spec.name}/#{spec.version}"
+  }
 
   spec.require_paths = ["lib"]
 

--- a/sentry-ruby/sentry-ruby.gemspec
+++ b/sentry-ruby/sentry-ruby.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "homepage_uri" => spec.homepage,
     "source_code_uri" => spec.homepage,
-    "changelog_uri" => "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md",
+    "changelog_uri" => "#{github_root_uri}/blob/#{spec.version}/CHANGELOG.md",
     "bug_tracker_uri" => "#{github_root_uri}/issues",
     "documentation_uri" => "http://www.rubydoc.info/gems/#{spec.name}/#{spec.version}"
   }

--- a/sentry-sidekiq/sentry-sidekiq.gemspec
+++ b/sentry-sidekiq/sentry-sidekiq.gemspec
@@ -7,16 +7,22 @@ Gem::Specification.new do |spec|
   spec.description = spec.summary = "A gem that provides Sidekiq integration for the Sentry error logger"
   spec.email = "accounts@sentry.io"
   spec.license = 'MIT'
-  spec.homepage = "https://github.com/getsentry/sentry-ruby"
 
   spec.platform = Gem::Platform::RUBY
   spec.required_ruby_version = '>= 2.4'
   spec.extra_rdoc_files = ["README.md", "LICENSE.txt"]
   spec.files = `git ls-files | grep -Ev '^(spec|benchmarks|examples)'`.split("\n")
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"
+  github_root_uri = 'https://github.com/getsentry/sentry-ruby'
+  spec.homepage = "#{github_root_uri}/tree/#{spec.version}/#{spec.name}"
+
+  spec.metadata = {
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => spec.homepage,
+    "changelog_uri" => "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md",
+    "bug_tracker_uri" => "#{github_root_uri}/issues",
+    "documentation_uri" => "http://www.rubydoc.info/gems/#{spec.name}/#{spec.version}"
+  }
 
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/sentry-sidekiq/sentry-sidekiq.gemspec
+++ b/sentry-sidekiq/sentry-sidekiq.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "homepage_uri" => spec.homepage,
     "source_code_uri" => spec.homepage,
-    "changelog_uri" => "#{spec.homepage.replace('/tree/', '/blob/')}/CHANGELOG.md",
+    "changelog_uri" => "#{github_root_uri}/blob/#{spec.version}/CHANGELOG.md",
     "bug_tracker_uri" => "#{github_root_uri}/issues",
     "documentation_uri" => "http://www.rubydoc.info/gems/#{spec.name}/#{spec.version}"
   }


### PR DESCRIPTION
> - Finally, please add an entry to the corresponding changelog

I'm not sure should I add an entry to the changelogs, and each of them or just one.

## Description

I believe each separate gem should have correct (direct, specific) links in its gemspec. In this architecture with single-repo it's achievable. Also it'll help us to list dependencies in our project without common duplicates to the root of the repo.

Additionally gems with specific version (such as  `5.17.3`) should point to documentation, changelog, sources, etc. of this version, not upstream (`master`).

Also links to `rubydoc.info` and GitHub issues were added.

#skip-changelog