### PR TITLE
`+=` instead of `<<`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   - Fixes [#2299](https://github.com/getsentry/sentry-ruby/issues/2299)
 - Decrease the default number of background worker threads by half ([#2305](https://github.com/getsentry/sentry-ruby/pull/2305))
   - Fixes [#2297](https://github.com/getsentry/sentry-ruby/issues/2297)
+- Don't mutate `enabled_environments` when using `Sentry::TestHelper` ([#2317](https://github.com/getsentry/sentry-ruby/pull/2317))
 
 ## 5.17.3
 

--- a/sentry-ruby/lib/sentry/test_helper.rb
+++ b/sentry-ruby/lib/sentry/test_helper.rb
@@ -20,7 +20,7 @@ module Sentry
       # set transport to DummyTransport, so we can easily intercept the captured events
       dummy_config.transport.transport_class = Sentry::DummyTransport
       # make sure SDK allows sending under the current environment
-      dummy_config.enabled_environments << dummy_config.environment unless dummy_config.enabled_environments.include?(dummy_config.environment)
+      dummy_config.enabled_environments += [dummy_config.environment] unless dummy_config.enabled_environments.include?(dummy_config.environment)
       # disble async event sending
       dummy_config.background_worker_threads = 0
 


### PR DESCRIPTION
[comment](https://github.com/getsentry/sentry-ruby/pull/2269#issuecomment-2002637738)

## Description
Describe your changes:
this pr creates a copy instead of mutating the original, which fixes the issue and my company's test suite
