### PR TITLE
Log envelope delivery message with debug instead of info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add query source support to `sentry-rails` ([#2313](https://github.com/getsentry/sentry-ruby/pull/2313))
 
   The feature is only activated in apps that use Ruby 3.2+ and Rails 7.1+. By default only queries that take longer than 100ms will have source recorded, which can be adjusted by updating the value of `config.rails.db_query_source_threshold_ms`.
+- Log envelope delivery message with debug instead of info ([#2320](https://github.com/getsentry/sentry-ruby/pull/2320))
 
 ### Bug Fixes
 

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -61,7 +61,7 @@ module Sentry
       data, serialized_items = serialize_envelope(envelope)
 
       if data
-        log_info("[Transport] Sending envelope with items [#{serialized_items.map(&:type).join(', ')}] #{envelope.event_id} to Sentry")
+        log_debug("[Transport] Sending envelope with items [#{serialized_items.map(&:type).join(', ')}] #{envelope.event_id} to Sentry")
         send_data(data)
       end
     end

--- a/sentry-ruby/lib/sentry/utils/logging_helper.rb
+++ b/sentry-ruby/lib/sentry/utils/logging_helper.rb
@@ -11,10 +11,6 @@ module Sentry
       end
     end
 
-    def log_info(message)
-      @logger.info(LOGGER_PROGNAME) { message }
-    end
-
     def log_debug(message)
       @logger.debug(LOGGER_PROGNAME) { message }
     end

--- a/sentry-ruby/spec/sentry/rake_spec.rb
+++ b/sentry-ruby/spec/sentry/rake_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "rake auto-reporting" do
       message = `cd spec/support && bundle exec rake raise_exception_without_rake_integration 2>&1`
     end.join
 
-    expect(message).not_to match(/Sentry/)
+    expect(message).not_to match(/Sending envelope with items/)
   end
 
   it "run rake task with original arguments" do

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -460,7 +460,7 @@ RSpec.describe Sentry::Transport do
         expect(subject.send_event(event)).to eq(event)
 
         expect(io.string).to match(
-          /INFO -- sentry: \[Transport\] Sending envelope with items \[event\] #{event.event_id} to Sentry/
+          /DEBUG -- sentry: \[Transport\] Sending envelope with items \[event\] #{event.event_id} to Sentry/
         )
       end
     end

--- a/sentry-ruby/spec/support/Rakefile.rb
+++ b/sentry-ruby/spec/support/Rakefile.rb
@@ -4,6 +4,7 @@ require "sentry-ruby"
 Sentry.init do |config|
   config.dsn = 'http://12345:67890@sentry.localdomain/sentry/42'
   config.background_worker_threads = 0
+  config.logger.level = Logger::DEBUG
 end
 
 task :raise_exception do


### PR DESCRIPTION
This reduces the noise for most users.

Also deletes the `log_info` helper as now it's not used anymore.

#closes #2315