### PR TITLE
Don't use array for transaction names and sources on scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 - Decrease the default number of background worker threads by half ([#2305](https://github.com/getsentry/sentry-ruby/pull/2305))
   - Fixes [#2297](https://github.com/getsentry/sentry-ruby/issues/2297)
 - Don't mutate `enabled_environments` when using `Sentry::TestHelper` ([#2317](https://github.com/getsentry/sentry-ruby/pull/2317))
+- Don't use array for transaction names and sources on scope ([#2324](https://github.com/getsentry/sentry-ruby/pull/2324))
+  - Fixes [#2257](https://github.com/getsentry/sentry-ruby/issues/2257)
 
 ### Internal
 

--- a/sentry-ruby/bin/console
+++ b/sentry-ruby/bin/console
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
+require "debug"
 require "sentry-ruby"
 
 # You can add fixtures and/or initialization code here to make experimenting

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -9,8 +9,8 @@ module Sentry
     include ArgumentCheckingHelper
 
     ATTRIBUTES = [
-      :transaction_names,
-      :transaction_sources,
+      :transaction_name,
+      :transaction_source,
       :contexts,
       :extra,
       :tags,
@@ -96,8 +96,8 @@ module Sentry
       copy.extra = extra.deep_dup
       copy.tags = tags.deep_dup
       copy.user = user.deep_dup
-      copy.transaction_names = transaction_names.dup
-      copy.transaction_sources = transaction_sources.dup
+      copy.transaction_name = transaction_name.dup
+      copy.transaction_source = transaction_source.dup
       copy.fingerprint = fingerprint.deep_dup
       copy.span = span.deep_dup
       copy.session = session.deep_dup
@@ -114,8 +114,8 @@ module Sentry
       self.extra = scope.extra
       self.tags = scope.tags
       self.user = scope.user
-      self.transaction_names = scope.transaction_names
-      self.transaction_sources = scope.transaction_sources
+      self.transaction_name = scope.transaction_name
+      self.transaction_source = scope.transaction_source
       self.fingerprint = scope.fingerprint
       self.span = scope.span
       self.propagation_context = scope.propagation_context
@@ -231,8 +231,8 @@ module Sentry
     # @param transaction_name [String]
     # @return [void]
     def set_transaction_name(transaction_name, source: :custom)
-      @transaction_names << transaction_name
-      @transaction_sources << source
+      @transaction_name = transaction_name
+      @transaction_source = source
     end
 
     # Sets the currently active session on the scope.
@@ -240,20 +240,6 @@ module Sentry
     # @return [void]
     def set_session(session)
       @session = session
-    end
-
-    # Returns current transaction name.
-    # The "transaction" here does not refer to `Transaction` objects.
-    # @return [String, nil]
-    def transaction_name
-      @transaction_names.last
-    end
-
-    # Returns current transaction source.
-    # The "transaction" here does not refer to `Transaction` objects.
-    # @return [String, nil]
-    def transaction_source
-      @transaction_sources.last
     end
 
     # These are high cardinality and thus bad.
@@ -311,8 +297,8 @@ module Sentry
       @user = {}
       @level = :error
       @fingerprint = []
-      @transaction_names = []
-      @transaction_sources = []
+      @transaction_name = nil
+      @transaction_source = nil
       @event_processors = []
       @rack_env = {}
       @span = nil

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
       event = last_sentry_event
       expect(event.transaction).to eq("/test")
       expect(event.to_hash.dig(:request, :url)).to eq("http://example.org/test")
-      expect(Sentry.get_current_scope.transaction_names).to be_empty
+      expect(Sentry.get_current_scope.transaction_name).to be_nil
       expect(Sentry.get_current_scope.rack_env).to eq({})
     end
 

--- a/sentry-ruby/spec/sentry/scope/setters_spec.rb
+++ b/sentry-ruby/spec/sentry/scope/setters_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Sentry::Scope do
   end
 
   describe "#set_transaction_name" do
-    it "pushes the transaction_name to transaction_names stack" do
+    it "sets the transaction name" do
       subject.set_transaction_name("WelcomeController#home")
 
       expect(subject.transaction_name).to eq("WelcomeController#home")

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Sentry::Scope do
       expect(subject.tags).to eq({})
       expect(subject.user).to eq({})
       expect(subject.fingerprint).to eq([])
-      expect(subject.transaction_names).to eq([])
-      expect(subject.transaction_sources).to eq([])
+      expect(subject.transaction_name).to eq(nil)
+      expect(subject.transaction_source).to eq(nil)
       expect(subject.propagation_context).to be_a(Sentry::PropagationContext)
     end
 
@@ -42,8 +42,7 @@ RSpec.describe Sentry::Scope do
       copy.extra.merge!(foo: "bar")
       copy.tags.merge!(foo: "bar")
       copy.user.merge!(foo: "bar")
-      copy.transaction_names << "foo"
-      copy.transaction_sources << :url
+      copy.set_transaction_name("foo", source: :url)
       copy.fingerprint << "bar"
 
       expect(subject.breadcrumbs.to_hash).to eq({ values: [] })
@@ -53,8 +52,8 @@ RSpec.describe Sentry::Scope do
       expect(subject.tags).to eq({})
       expect(subject.user).to eq({})
       expect(subject.fingerprint).to eq([])
-      expect(subject.transaction_names).to eq([])
-      expect(subject.transaction_sources).to eq([])
+      expect(subject.transaction_name).to eq(nil)
+      expect(subject.transaction_source).to eq(nil)
       expect(subject.span).to eq(nil)
     end
 
@@ -143,8 +142,8 @@ RSpec.describe Sentry::Scope do
       expect(subject.tags).to eq({})
       expect(subject.user).to eq({})
       expect(subject.fingerprint).to eq([])
-      expect(subject.transaction_names).to eq([])
-      expect(subject.transaction_sources).to eq([])
+      expect(subject.transaction_name).to eq(nil)
+      expect(subject.transaction_source).to eq(nil)
       expect(subject.span).to eq(nil)
     end
   end


### PR DESCRIPTION
closes #2257