### PR TITLE
feat: allow to set custom status code for different exception classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   The feature is only activated in apps that use Ruby 3.2+ and Rails 7.1+. By default only queries that take longer than 100ms will have source recorded, which can be adjusted by updating the value of `config.rails.db_query_source_threshold_ms`.
 - Log envelope delivery message with debug instead of info ([#2320](https://github.com/getsentry/sentry-ruby/pull/2320))
 
+- Add `exception_status_code` configuration option that allows to specify which transaction status code should be used for exceptions ([#2333](https://github.com/getsentry/sentry-ruby/issues/2333))
+
 ### Bug Fixes
 
 - Don't throw error on arbitrary arguments being passed to `capture_event` options [#2301](https://github.com/getsentry/sentry-ruby/pull/2301)

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -473,6 +473,13 @@ module Sentry
       get_current_hub.start_transaction(**options)
     end
 
+    # Takes or initializes a new Sentry::Transaction and makes a sampling decision for it.
+    #
+    # @return [Transaction, nil]
+    def status_code_for_exception(exception)
+      get_current_hub.status_code_for_exception(exception)
+    end
+
     # Records the block's execution as a child of the current span.
     # If the current scope doesn't have a span, the block would still be executed but the yield param will be nil.
     # @param attributes [Hash] attributes for the child span.

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -268,6 +268,17 @@ module Sentry
     # @return [Boolean]
     attr_accessor :auto_session_tracking
 
+    # Take a Proc that controls the status code for various exceptions, e.g.
+    # @example
+    #   config.exception_status_code =  lambda do |exception|
+    #     # exception is the captured exception instance
+    #     # return 404 if exception.is_a?(ActiveRecord::RecordNotFound)
+    #
+    #     500 # default behavior
+    #   end
+    # @return [Proc]
+    attr_accessor :exception_status_code
+
     # Whether to downsample transactions automatically because of backpressure.
     # Starts a new monitor thread to check health of the SDK every 10 seconds.
     # Default is false
@@ -387,6 +398,7 @@ module Sentry
       self.before_send_transaction = nil
       self.rack_env_whitelist = RACK_ENV_WHITELIST_DEFAULT
       self.traces_sampler = nil
+      self.exception_status_code = nil
       self.enable_tracing = nil
 
       @transport = Transport::Configuration.new

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -95,6 +95,17 @@ module Sentry
       transaction
     end
 
+    def status_code_for_exception(exception)
+      case configuration.exception_status_code
+      when Numeric
+        configuration.exception_status_code
+      when Proc
+        configuration.exception_status_code.call(exception)
+      else
+        500
+      end
+    end
+
     def with_child_span(instrumenter: :sentry, **attributes, &block)
       return yield(nil) unless instrumenter == configuration.instrumenter
 

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -33,7 +33,8 @@ module Sentry
               raise # Don't capture Sentry errors
             rescue Exception => e
               capture_exception(e, env)
-              finish_transaction(transaction, 500)
+
+              finish_transaction(transaction, exception_status_code(e))
               raise
             end
 
@@ -48,6 +49,10 @@ module Sentry
       end
 
       private
+
+      def exception_status_code(exception)
+        Sentry.status_code_for_exception(exception)
+      end
 
       def collect_exception(env)
         env['rack.exception'] || env['sinatra.error']

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -375,6 +375,32 @@ RSpec.describe Sentry::Hub do
     end
   end
 
+  describe '#status_code_for_exception' do
+    subject(:status_code_for_exception) { described_class.new(client, scope).status_code_for_exception(exception) }
+
+    let(:exception) { Exception.new }
+
+    context 'when configuration exception_status_code is a number' do
+      before do
+        configuration.exception_status_code = 400
+      end
+
+      it { is_expected.to eq(400) }
+    end
+
+    context 'when configuration exception_status_code is a proc' do
+      before do
+        configuration.exception_status_code = ->(exception) { 355 }
+      end
+
+      it { is_expected.to eq(355) }
+    end
+
+    context 'when configuration exception_status_code is blank' do
+      it { is_expected.to eq(500) }
+    end
+  end
+
   describe "#with_scope" do
     it "builds a temporary scope" do
       inner_event = nil


### PR DESCRIPTION
Fixes #2333

## Description
This PR adds a new option to specify the status code for any unhandled exception during a transaction
