### PR TITLE
Drop `Gem::Specification`'s usage so it doesn't break bundler standalone

### DIFF
--- a/.github/workflows/build_batch_release.yml
+++ b/.github/workflows/build_batch_release.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.3
     - name: Build gem source
       run:  ruby .scripts/batch_build.rb
     - name: Archive Artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Drop `Gem::Specification`'s usage so it doesn't break bundler standalone ([#2335](https://github.com/getsentry/sentry-ruby/pull/2335))
+
 ## 5.18.0
 
 ### Features

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -17,8 +17,7 @@ rails_version = Gem::Version.new(rails_version)
 if rails_version < Gem::Version.new("6.0.0")
   gem "sqlite3", "~> 1.3.0", platform: :ruby
 else
-  # 1.7.0 dropped support for ruby < 3.0, remove later after upgrading craft setup
-  gem "sqlite3", "1.6.9", platform: :ruby
+  gem "sqlite3", "~> 1.7.3", platform: :ruby
 end
 
 if rails_version >= Gem::Version.new("7.2.0.alpha")

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -16,8 +16,10 @@ rails_version = Gem::Version.new(rails_version)
 
 if rails_version < Gem::Version.new("6.0.0")
   gem "sqlite3", "~> 1.3.0", platform: :ruby
-else
+elsif RUBY_VERSION >= Gem::Version.new("2.7.0")
   gem "sqlite3", "~> 1.7.3", platform: :ruby
+else
+  gem "sqlite3", "~> 1.6.9", platform: :ruby
 end
 
 if rails_version >= Gem::Version.new("7.2.0.alpha")

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -16,10 +16,12 @@ rails_version = Gem::Version.new(rails_version)
 
 if rails_version < Gem::Version.new("6.0.0")
   gem "sqlite3", "~> 1.3.0", platform: :ruby
-elsif RUBY_VERSION >= Gem::Version.new("2.7.0")
-  gem "sqlite3", "~> 1.7.3", platform: :ruby
 else
-  gem "sqlite3", "~> 1.6.9", platform: :ruby
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0")
+    gem "sqlite3", "~> 1.7.3", platform: :ruby
+  else
+    gem "sqlite3", "~> 1.6.9", platform: :ruby
+  end
 end
 
 if rails_version >= Gem::Version.new("7.2.0.alpha")

--- a/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "sentry/rails/tracing/abstract_subscriber"
 
 module Sentry
@@ -5,19 +7,15 @@ module Sentry
     module Tracing
       class ActiveRecordSubscriber < AbstractSubscriber
         EVENT_NAMES = ["sql.active_record"].freeze
-        SPAN_PREFIX = "db.".freeze
-        SPAN_ORIGIN = "auto.db.rails".freeze
+        SPAN_PREFIX = "db."
+        SPAN_ORIGIN = "auto.db.rails"
         EXCLUDED_EVENTS = ["SCHEMA", "TRANSACTION"].freeze
 
         SUPPORT_SOURCE_LOCATION = ActiveSupport::BacktraceCleaner.method_defined?(:clean_frame)
 
         if SUPPORT_SOURCE_LOCATION
-          # Need to be specific down to the lib path so queries generated in specs don't get ignored
-          SENTRY_RUBY_PATH = File.join(Gem::Specification.find_by_name("sentry-ruby").full_gem_path, "lib")
-          SENTRY_RAILS_PATH = File.join(Gem::Specification.find_by_name("sentry-rails").full_gem_path, "lib")
-
           class_attribute :backtrace_cleaner, default: (ActiveSupport::BacktraceCleaner.new.tap do |cleaner|
-            cleaner.add_silencer { |line| line.include?(SENTRY_RUBY_PATH) || line.include?(SENTRY_RAILS_PATH) }
+            cleaner.add_silencer { |line| line.include?("sentry-ruby/lib") || line.include?("sentry-rails/lib") }
           end)
         end
 


### PR DESCRIPTION
Fixes #2329 

I also needed to bump `sqlite3` because `v1.6.9` doesn't run on Ruby 3.3, which is what I use in development.