### PR TITLE
Ignore Sidekiq::JobRetry::Handled exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- Ignore internal Sidekiq::JobRetry::Handled exception [#2337](https://github.com/getsentry/sentry-ruby/pull/2337)
 - Fix Vernier profiler not stopping when already stopped [#2429](https://github.com/getsentry/sentry-ruby/pull/2429)
 
 ## 5.21.0

--- a/sentry-sidekiq/lib/sentry/sidekiq/configuration.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/configuration.rb
@@ -13,7 +13,7 @@ module Sentry
   module Sidekiq
     IGNORE_DEFAULT = [
       "Sidekiq::JobRetry::Skip",
-      "Sidekiq::JobRetry::Handled",
+      "Sidekiq::JobRetry::Handled"
     ]
 
     class Configuration

--- a/sentry-sidekiq/lib/sentry/sidekiq/configuration.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/configuration.rb
@@ -11,7 +11,10 @@ module Sentry
   end
 
   module Sidekiq
-    IGNORE_DEFAULT = ["Sidekiq::JobRetry::Skip"]
+    IGNORE_DEFAULT = [
+      "Sidekiq::JobRetry::Skip",
+      "Sidekiq::JobRetry::Handled",
+    ]
 
     class Configuration
       # Set this option to true if you want Sentry to only capture the last job

--- a/sentry-sidekiq/spec/sentry/sidekiq/configuration_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/configuration_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe Sentry::Sidekiq::Configuration do
     expect(config.excluded_exceptions).to include("Sidekiq::JobRetry::Skip")
   end
 
+  it "adds Sidekiq::JobRetry::Handled to the ignore list" do
+    config = Sentry::Configuration.new
+
+    expect(config.excluded_exceptions).to include("Sidekiq::JobRetry::Handled")
+  end
+
   describe "#report_after_job_retries" do
     it "has correct default value" do
       expect(subject.report_after_job_retries).to eq(false)


### PR DESCRIPTION
Adds `Sidekiq::JobRetry::Handled` exception to default Sidekiq ignore list.

`Sidekiq::JobRetry::Skip` exceptions are currently ignored, however, since Sidekiq 7.3.0 shipped, I think `Sidekiq::JobRetry::Handled` exceptions also need to be ignored.

You can see the full diff between [7.2.4..7.3.0](https://github.com/sidekiq/sidekiq/compare/30786e082c70349ab27ffa9eccc42fb0c696164d...602d04640c7dd0c16222800f24bd3d3c32031a98) and I'd particularly like to draw your attention to the changes within `lib/sidekiq/job_retry.rb`. 

You can see in certain scenarios Sidekiq now raises [`Sidekiq::JobRetry::Handled`](https://github.com/sidekiq/sidekiq/blob/602d04640c7dd0c16222800f24bd3d3c32031a98/lib/sidekiq/job_retry.rb#L106) (7.3.0) instead of [`Sidekiq::JobRetry::Skip`](https://github.com/sidekiq/sidekiq/blob/30786e082c70349ab27ffa9eccc42fb0c696164d/lib/sidekiq/job_retry.rb#L132) (7.2.4).

Without this change, some customers will see the following in their Sentry Issues after upgrading to Sidekiq 7.3.0.

![Screenshot 2024-07-03 at 08 27 40](https://github.com/getsentry/sentry-ruby/assets/666397/b528038a-c4a0-4b0a-ba90-97c1ff23b09e)
