### PR TITLE
Use Concurrent.usable_processor_count when it is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Internal
+
+- Use Concurrent.usable_processor_count when it is available ([#2339](https://github.com/getsentry/sentry-ruby/pull/2339))
+
 ## 5.18.1
 
 ### Bug Fixes

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -351,7 +351,7 @@ module Sentry
     def initialize
       self.app_dirs_pattern = nil
       self.debug = false
-      self.background_worker_threads = (Concurrent.processor_count / 2.0).ceil
+      self.background_worker_threads = (processor_count / 2.0).ceil
       self.background_worker_max_queue = BackgroundWorker::DEFAULT_MAX_QUEUE
       self.backtrace_cleanup_callback = nil
       self.max_breadcrumbs = BreadcrumbBuffer::DEFAULT_SIZE
@@ -652,6 +652,14 @@ module Sentry
     def run_post_initialization_callbacks
       self.class.post_initialization_callbacks.each do |hook|
         instance_eval(&hook)
+      end
+    end
+
+    def processor_count
+      if Concurrent.respond_to?(:usable_processor_count)
+        Concurrent.usable_processor_count
+      else
+        Concurrent.processor_count
       end
     end
   end

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe Sentry::Configuration do
 
   describe "#background_worker_threads" do
     it "sets to have of the processors count" do
-      allow(Concurrent).to receive(:processor_count).and_return(8)
+      allow_any_instance_of(Sentry::Configuration).to receive(:processor_count).and_return(8)
       expect(subject.background_worker_threads).to eq(4)
     end
 
     it "sets to 1 with only 1 processor" do
-      allow(Concurrent).to receive(:processor_count).and_return(1)
+      allow_any_instance_of(Sentry::Configuration).to receive(:processor_count).and_return(1)
       expect(subject.background_worker_threads).to eq(1)
     end
   end


### PR DESCRIPTION
It's a new API introduced in concurrent-ruby 1.3.1, which works better in the container environment.

https://github.com/ruby-concurrency/concurrent-ruby/pull/1038

Since there are gems like sorbet-runtime that still use older versions of concurrent-ruby, we can't directly bump concurrent-ruby's requirement, but need to check if the method is available before calling it.

Big thanks to @trevorturk for [proposing this idea](https://github.com/getsentry/sentry-ruby/issues/2297#issuecomment-2137623858).