### PR TITLE
`teardown_sentry_test` helper should clear global even processors too

### DIFF
--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -26,6 +26,7 @@ jobs:
     name: Ruby ${{ matrix.ruby_version }} & Rack ${{ matrix.rack_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         rack_version: [2.0, 3.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Use Concurrent.usable_processor_count when it is available ([#2339](https://github.com/getsentry/sentry-ruby/pull/2339))
 
+### Bug Fixes
+
+- `teardown_sentry_test` helper should clear global even processors too ([#2342](https://github.com/getsentry/sentry-ruby/pull/2342))
+
 ## 5.18.1
 
 ### Bug Fixes

--- a/sentry-ruby/lib/sentry/test_helper.rb
+++ b/sentry-ruby/lib/sentry/test_helper.rb
@@ -50,6 +50,7 @@ module Sentry
       if Sentry.get_current_hub.instance_variable_get(:@stack).size > 1
         Sentry.get_current_hub.pop_scope
       end
+      Sentry::Scope.global_event_processors.clear
     end
 
     # @return [Transport]

--- a/sentry-ruby/spec/sentry/test_helper_spec.rb
+++ b/sentry-ruby/spec/sentry/test_helper_spec.rb
@@ -127,6 +127,12 @@ RSpec.describe Sentry::TestHelper do
       expect(Sentry.get_current_scope.tags).to eq({})
     end
 
+    it "clears global processors" do
+      Sentry.add_global_event_processor { |event| event }
+      teardown_sentry_test
+      expect(Sentry::Scope.global_event_processors).to eq([])
+    end
+
     context "when the configuration is mutated" do
       it "rolls back client changes" do
         Sentry.configuration.environment = "quack"


### PR DESCRIPTION
Closes #2051

When resetting the test environment with the `teardown_sentry_test` helper, global event processors should be cleared too.

(I also made sentry-ruby's tests not fail fast as they're quite flaky at times due to dependencies, request issues...etc.)