### PR TITLE
Suppress the unnecessary “unsupported options notice”

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Use Concurrent.usable_processor_count when it is available ([#2339](https://github.com/getsentry/sentry-ruby/pull/2339))
 
+### Bug Fixes
+
+- Suppress the unnecessary “unsupported options notice” ([#2349](https://github.com/getsentry/sentry-ruby/pull/2349))
+
 ## 5.18.1
 
 ### Bug Fixes

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -195,10 +195,12 @@ module Sentry
       elsif !options.empty?
         unsupported_option_keys = scope.update_from_options(**options)
 
-        configuration.log_debug <<~MSG
-          Options #{unsupported_option_keys} are not supported and will not be applied to the event.
-          You may want to set them under the `extra` option.
-        MSG
+        unless unsupported_option_keys.empty?
+          configuration.log_debug <<~MSG
+            Options #{unsupported_option_keys} are not supported and will not be applied to the event.
+            You may want to set them under the `extra` option.
+          MSG
+        end
       end
 
       event = current_client.capture_event(event, scope, hint)

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -350,7 +350,7 @@ RSpec.describe Sentry::Hub do
       expect(string_io.string).to include("Options [:unsupported] are not supported and will not be applied to the event.")
     end
 
-    it "should not show the unsupported options notice even if it has a special parameter" do
+    it "does not warn about unsupported options if all passed options are supported" do
       expect do
         subject.capture_event(event, level: 'DEBUG')
       end.not_to raise_error

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -350,6 +350,14 @@ RSpec.describe Sentry::Hub do
       expect(string_io.string).to include("Options [:unsupported] are not supported and will not be applied to the event.")
     end
 
+    it "should not show the unsupported options notice even if it has a special parameter" do
+      expect do
+        subject.capture_event(event, level: 'DEBUG')
+      end.not_to raise_error
+
+      expect(string_io.string).not_to include("Options [] are not supported and will not be applied to the event.")
+    end
+
     context "when event is a transaction" do
       it "transaction.set_context merges and takes precedence over scope.set_context" do
         scope.set_context(:foo, { val: 42 })


### PR DESCRIPTION
A related change was introduced in #2303.

## Description

In `Scope#update_from_options()`, the method strips key-value pairs from the `options` according to its parameters. When all keys in `options` are supported, it still logs an “unsupported options notice” for an empty `unsupported_option_keys` value with empty array literal in `Sentry::Hub#capture_event`, like: "Options [] are not supported and will not be applied to the event."

**Example:**

When calling `subject.capture_event(event, level: 'DEBUG')`, the `capture_event` method should handle the options like this:

```ruby
# In this case, options == {:level=>'DEBUG'}
unsupported_option_keys = scope.update_from_options(**options)
# unsupported_option_keys should be [], but the following debug log will be shown
# like "Options [] are not supported and will not be applied to the event."
configuration.log_debug <<~MSG
  Options #{unsupported_option_keys} are not supported and will not be applied to the event.
  You may want to set them under the `extra` option.
MSG
```

This patch changes the logic to check whether `unsupported_option_keys` is empty before logging the notice, thus suppressing unnecessary logs.