### PR TITLE
Migrate from to_hash to to_h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Breaking Changes
 
 - Remove `config.async` [#1894](https://github.com/getsentry/sentry-ruby/pull/1894)
+- Migrate from to_hash to to_h ([#2351](https://github.com/getsentry/sentry-ruby/pull/2351))
 
 ## Unreleased
 

--- a/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
+++ b/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Sentry::DelayedJob do
     enqueued_job.invoke_job
 
     expect(transport.events.count).to eq(1)
-    event = transport.events.last.to_hash
+    event = transport.events.last.to_h
     expect(event[:message]).to eq("report")
     expect(event[:contexts][:"Delayed-Job"][:id]).to eq(enqueued_job.id.to_s)
     expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id.to_s, "delayed_job.queue" => nil })
@@ -66,7 +66,7 @@ RSpec.describe Sentry::DelayedJob do
     enqueued_job.invoke_job
 
     expect(transport.events.count).to eq(1)
-    event = transport.events.last.to_hash
+    event = transport.events.last.to_h
     expect(event[:message]).to eq("tagged report")
     expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id.to_s, "delayed_job.queue" => nil, number: 1 })
 
@@ -75,7 +75,7 @@ RSpec.describe Sentry::DelayedJob do
     enqueued_job.invoke_job
 
     expect(transport.events.count).to eq(2)
-    event = transport.events.last.to_hash
+    event = transport.events.last.to_h
     expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id.to_s, "delayed_job.queue" => nil })
   end
 
@@ -91,7 +91,7 @@ RSpec.describe Sentry::DelayedJob do
       end.to raise_error(ZeroDivisionError)
 
       expect(transport.events.count).to eq(1)
-      event = transport.events.last.to_hash
+      event = transport.events.last.to_h
 
       expect(event[:sdk]).to eq({ name: "sentry.ruby.delayed_job", version: described_class::VERSION })
       expect(event.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
@@ -107,7 +107,7 @@ RSpec.describe Sentry::DelayedJob do
       end.to raise_error(RuntimeError)
 
       expect(transport.events.count).to eq(1)
-      event = transport.events.last.to_hash
+      event = transport.events.last.to_h
 
       expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id.to_s, "delayed_job.queue" => nil, number: 1 })
       expect(Sentry.get_current_scope.extra).to eq({})
@@ -121,7 +121,7 @@ RSpec.describe Sentry::DelayedJob do
       end.to raise_error(ZeroDivisionError)
 
       expect(transport.events.count).to eq(2)
-      event = transport.events.last.to_hash
+      event = transport.events.last.to_h
       expect(event[:tags]).to eq({ "delayed_job.id" => enqueued_job.id.to_s, "delayed_job.queue" => nil })
       expect(Sentry.get_current_scope.extra).to eq({})
       expect(Sentry.get_current_scope.tags).to eq({})
@@ -226,7 +226,7 @@ RSpec.describe Sentry::DelayedJob do
       it "injects ActiveJob information to the event" do
         expect(transport.events.count).to eq(1)
 
-        event = transport.events.last.to_hash
+        event = transport.events.last.to_h
         expect(event[:message]).to eq("report from ActiveJob")
         expect(event[:tags]).to match({ "delayed_job.id" => anything, "delayed_job.queue" => "default", number: 1 })
         expect(event[:contexts][:"Active-Job"][:job_class]).to eq("ReportingJob")
@@ -253,7 +253,7 @@ RSpec.describe Sentry::DelayedJob do
       it "injects ActiveJob information to the event" do
         expect(transport.events.count).to eq(1)
 
-        event = transport.events.last.to_hash
+        event = transport.events.last.to_h
         expect(event.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
         expect(event[:tags]).to match({ "delayed_job.id" => anything, "delayed_job.queue" => "default", number: 2 })
         expect(event[:contexts][:"Active-Job"][:job_class]).to eq("FailedJob")

--- a/sentry-rails/spec/sentry/rails/activejob_spec.rb
+++ b/sentry-rails/spec/sentry/rails/activejob_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe "ActiveJob integration" do
         expect(transport.events.size).to eq(1)
 
         event = transport.events.first
-        exceptions_data = event.exception.to_hash[:values]
+        exceptions_data = event.exception.to_h[:values]
 
         expect(exceptions_data.count).to eq(2)
         expect(exceptions_data[0][:type]).to eq("FailedJob::TestError")
@@ -295,7 +295,7 @@ RSpec.describe "ActiveJob integration" do
         first = transport.events[0]
         check_in_id = first.check_in_id
         expect(first).to be_a(Sentry::CheckInEvent)
-        expect(first.to_hash).to include(
+        expect(first.to_h).to include(
           type: 'check_in',
           check_in_id: check_in_id,
           monitor_slug: "normaljobwithcron",
@@ -304,7 +304,7 @@ RSpec.describe "ActiveJob integration" do
 
         second = transport.events[1]
         expect(second).to be_a(Sentry::CheckInEvent)
-        expect(second.to_hash).to include(
+        expect(second.to_h).to include(
           :duration,
           type: 'check_in',
           check_in_id: check_in_id,
@@ -323,7 +323,7 @@ RSpec.describe "ActiveJob integration" do
         first = transport.events[0]
         check_in_id = first.check_in_id
         expect(first).to be_a(Sentry::CheckInEvent)
-        expect(first.to_hash).to include(
+        expect(first.to_h).to include(
           type: 'check_in',
           check_in_id: check_in_id,
           monitor_slug: "failed_job",
@@ -333,7 +333,7 @@ RSpec.describe "ActiveJob integration" do
 
         second = transport.events[1]
         expect(second).to be_a(Sentry::CheckInEvent)
-        expect(second.to_hash).to include(
+        expect(second.to_h).to include(
           :duration,
           type: 'check_in',
           check_in_id: check_in_id,

--- a/sentry-rails/spec/sentry/rails/breadcrumbs/active_support_logger_spec.rb
+++ b/sentry-rails/spec/sentry/rails/breadcrumbs/active_support_logger_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "Sentry::Breadcrumbs::ActiveSupportLogger", type: :request do
 
       expect(transport.events.count).to eq(1)
 
-      transaction = transport.events.last.to_hash
+      transaction = transport.events.last.to_h
       breadcrumbs = transaction[:breadcrumbs][:values]
       process_action_crumb = breadcrumbs.last
       expect(process_action_crumb[:category]).to eq("process_action.action_controller")

--- a/sentry-rails/spec/sentry/rails/breadcrumbs/monotonic_active_support_logger_spec.rb
+++ b/sentry-rails/spec/sentry/rails/breadcrumbs/monotonic_active_support_logger_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe "Sentry::Breadcrumbs::MonotonicActiveSupportLogger", type: :reque
 
         expect(transport.events.count).to eq(1)
 
-        transaction = transport.events.last.to_hash
+        transaction = transport.events.last.to_h
         breadcrumbs = transaction[:breadcrumbs][:values]
         process_action_crumb = breadcrumbs.last
         expect(process_action_crumb[:category]).to eq("process_action.action_controller")

--- a/sentry-rails/spec/sentry/rails/controller_methods_spec.rb
+++ b/sentry-rails/spec/sentry/rails/controller_methods_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Sentry::Rails::ControllerMethods do
       event = transport.events.last
       expect(event.message).to eq("foo")
       expect(event.tags).to eq({ new_tag: true })
-      expect(event.to_hash.dig(:request, :url)).to eq("http://example.org/test")
+      expect(event.to_h.dig(:request, :url)).to eq("http://example.org/test")
     end
   end
 
@@ -47,8 +47,8 @@ RSpec.describe Sentry::Rails::ControllerMethods do
 
       event = transport.events.last
       expect(event.tags).to eq({ new_tag: true })
-      expect(event.to_hash.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
-      expect(event.to_hash.dig(:request, :url)).to eq("http://example.org/test")
+      expect(event.to_h.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
+      expect(event.to_h.dig(:request, :url)).to eq("http://example.org/test")
     end
   end
 end

--- a/sentry-rails/spec/sentry/rails/event_spec.rb
+++ b/sentry-rails/spec/sentry/rails/event_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Sentry::Event do
   end
 
   it "sets right SDK information" do
-    event_hash = Sentry::Rails.capture_message("foo").to_hash
+    event_hash = Sentry::Rails.capture_message("foo").to_h
 
     expect(event_hash[:sdk]).to eq(name: "sentry.ruby.rails", version: Sentry::Rails::VERSION)
   end
@@ -25,7 +25,7 @@ RSpec.describe Sentry::Event do
       e
     end
 
-    let(:hash) { Sentry::Rails.capture_exception(exception).to_hash }
+    let(:hash) { Sentry::Rails.capture_exception(exception).to_h }
 
     it 'marks in_app correctly' do
       frames = hash[:exception][:values][0][:stacktrace][:frames]

--- a/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Sentry::Rails::Tracing::ActionControllerSubscriber, :subscriber, 
 
       expect(transport.events.count).to eq(1)
 
-      transaction = transport.events.first.to_hash
+      transaction = transport.events.first.to_h
       expect(transaction[:type]).to eq("transaction")
       expect(transaction[:spans].count).to eq(2)
 

--- a/sentry-rails/spec/sentry/rails/tracing/action_view_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_view_subscriber_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Sentry::Rails::Tracing::ActionViewSubscriber, :subscriber, type: 
 
       expect(transport.events.count).to eq(1)
 
-      transaction = transport.events.first.to_hash
+      transaction = transport.events.first.to_h
       expect(transaction[:type]).to eq("transaction")
       expect(transaction[:spans].count).to eq(2)
 

--- a/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
 
       expect(transport.events.count).to eq(1)
 
-      transaction = transport.events.first.to_hash
+      transaction = transport.events.first.to_h
       expect(transaction[:type]).to eq("transaction")
       expect(transaction[:spans].count).to eq(1)
 
@@ -65,7 +65,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
         it "doesn't record query's source location" do
           expect(transport.events.count).to eq(1)
 
-          transaction = transport.events.first.to_hash
+          transaction = transport.events.first.to_h
           expect(transaction[:type]).to eq("transaction")
           expect(transaction[:spans].count).to eq(1)
 
@@ -84,7 +84,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
         it "records query's source location" do
           expect(transport.events.count).to eq(1)
 
-          transaction = transport.events.first.to_hash
+          transaction = transport.events.first.to_h
           expect(transaction[:type]).to eq("transaction")
           expect(transaction[:spans].count).to eq(1)
 
@@ -102,7 +102,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
         it "doesn't record query's source location" do
           expect(transport.events.count).to eq(1)
 
-          transaction = transport.events.first.to_hash
+          transaction = transport.events.first.to_h
           expect(transaction[:type]).to eq("transaction")
           expect(transaction[:spans].count).to eq(1)
 
@@ -129,7 +129,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
 
       expect(transport.events.count).to eq(1)
 
-      transaction = transport.events.first.to_hash
+      transaction = transport.events.first.to_h
       expect(transaction[:type]).to eq("transaction")
       expect(transaction[:spans].count).to eq(2)
 

--- a/sentry-rails/spec/sentry/rails/tracing/active_storage_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_storage_subscriber_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveStorageSubscriber, :subscriber, typ
       expect(response).to have_http_status(:ok)
       expect(transport.events.count).to eq(2)
 
-      analysis_transaction = transport.events.first.to_hash
+      analysis_transaction = transport.events.first.to_h
       expect(analysis_transaction[:type]).to eq("transaction")
 
       if Rails.version.to_f > 6.1
@@ -38,7 +38,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveStorageSubscriber, :subscriber, typ
         expect(analysis_transaction[:spans][0][:origin]).to eq("auto.file.rails")
       end
 
-      request_transaction = transport.events.last.to_hash
+      request_transaction = transport.events.last.to_h
       expect(request_transaction[:type]).to eq("transaction")
       expect(request_transaction[:spans].count).to eq(2)
 

--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
       expect(response).to have_http_status(:internal_server_error)
       expect(transport.events.count).to eq(2)
 
-      event = transport.events.first.to_hash
-      transaction = transport.events.last.to_hash
+      event = transport.events.first.to_h
+      transaction = transport.events.last.to_h
 
       expect(event.dig(:contexts, :trace, :trace_id).length).to eq(32)
       expect(event.dig(:contexts, :trace, :trace_id)).to eq(transaction.dig(:contexts, :trace, :trace_id))
@@ -62,7 +62,7 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
       expect(response).to have_http_status(:ok)
       expect(transport.events.count).to eq(1)
 
-      transaction = transport.events.last.to_hash
+      transaction = transport.events.last.to_h
 
       expect(transaction[:type]).to eq("transaction")
       expect(transaction.dig(:contexts, :trace, :op)).to eq("http.server")
@@ -206,7 +206,7 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
 
       expect(transport.events.count).to eq(3)
 
-      transaction = transport.events.last.to_hash
+      transaction = transport.events.last.to_h
 
       expect(transaction[:type]).to eq("transaction")
       expect(transaction[:transaction]).to eq("PostsController#show")

--- a/sentry-resque/spec/sentry/resque_spec.rb
+++ b/sentry-resque/spec/sentry/resque_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Sentry::Resque do
     process_job(worker)
 
     expect(transport.events.count).to eq(1)
-    event = transport.events.last.to_hash
+    event = transport.events.last.to_h
     expect(event[:message]).to eq("report")
     expect(event[:tags]).to eq({ "resque.queue" => "default" })
     expect(event[:contexts][:"Resque"]).to include({ job_class: "MessageJob", arguments: ["report"], queue: "default" })
@@ -86,7 +86,7 @@ RSpec.describe Sentry::Resque do
     process_job(worker)
 
     expect(transport.events.count).to eq(1)
-    event = transport.events.last.to_hash
+    event = transport.events.last.to_h
     expect(event[:message]).to eq("tagged report")
     expect(event[:tags]).to include({ number: 1 })
 
@@ -95,7 +95,7 @@ RSpec.describe Sentry::Resque do
     process_job(worker)
 
     expect(transport.events.count).to eq(2)
-    event = transport.events.last.to_hash
+    event = transport.events.last.to_h
     expect(event[:tags]).to eq({ "resque.queue" => "default" })
   end
 
@@ -107,7 +107,7 @@ RSpec.describe Sentry::Resque do
       end.to change { Resque::Stat.get("failed") }.by(1)
 
       expect(transport.events.count).to eq(1)
-      event = transport.events.last.to_hash
+      event = transport.events.last.to_h
 
       expect(event[:sdk]).to eq({ name: "sentry.ruby.resque", version: described_class::VERSION })
       expect(event.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
@@ -121,7 +121,7 @@ RSpec.describe Sentry::Resque do
       end.to change { Resque::Stat.get("failed") }.by(1)
 
       expect(transport.events.count).to eq(1)
-      event = transport.events.last.to_hash
+      event = transport.events.last.to_h
 
       expect(event[:tags]).to eq({ "resque.queue" => "default", number: 1 })
       expect(Sentry.get_current_scope.extra).to eq({})
@@ -133,7 +133,7 @@ RSpec.describe Sentry::Resque do
       end.to change { Resque::Stat.get("failed") }.by(1)
 
       expect(transport.events.count).to eq(2)
-      event = transport.events.last.to_hash
+      event = transport.events.last.to_h
       expect(event[:tags]).to eq({ "resque.queue" => "default" })
       expect(Sentry.get_current_scope.extra).to eq({})
       expect(Sentry.get_current_scope.tags).to eq({})
@@ -159,7 +159,7 @@ RSpec.describe Sentry::Resque do
           end
         end.to change { transport.events.count }.by(1)
 
-        event = transport.events.last.to_hash
+        event = transport.events.last.to_h
 
         expect(event[:sdk]).to eq({ name: "sentry.ruby.resque", version: described_class::VERSION })
         expect(event.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
@@ -173,7 +173,7 @@ RSpec.describe Sentry::Resque do
         end.to change { Resque::Stat.get("failed") }.by(1)
            .and change { transport.events.count }.by(1)
 
-        event = transport.events.last.to_hash
+        event = transport.events.last.to_h
 
         expect(event[:sdk]).to eq({ name: "sentry.ruby.resque", version: described_class::VERSION })
         expect(event.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
@@ -199,7 +199,7 @@ RSpec.describe Sentry::Resque do
           end
         end.to change { transport.events.count }.by(3)
 
-        event = transport.events.last.to_hash
+        event = transport.events.last.to_h
 
         expect(event[:sdk]).to eq({ name: "sentry.ruby.resque", version: described_class::VERSION })
         expect(event.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
@@ -264,7 +264,7 @@ RSpec.describe Sentry::Resque do
       it "injects ActiveJob information to the event" do
         expect(transport.events.count).to eq(1)
 
-        event = transport.events.last.to_hash
+        event = transport.events.last.to_h
         expect(event[:message]).to eq("report from ActiveJob")
         expect(event[:tags]).to match({ "resque.queue" => "default", number: 1 })
         expect(event[:contexts][:"Active-Job"][:job_class]).to eq("AJMessageJob")
@@ -289,7 +289,7 @@ RSpec.describe Sentry::Resque do
       it "injects ActiveJob information to the event" do
         expect(transport.events.count).to eq(1)
 
-        event = transport.events.last.to_hash
+        event = transport.events.last.to_h
         expect(event.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
         expect(event[:tags]).to match({ "resque.queue" => "default", number: 2 })
         expect(event[:contexts][:"Active-Job"][:job_class]).to eq("AJFailedJob")

--- a/sentry-resque/spec/sentry/tracing_spec.rb
+++ b/sentry-resque/spec/sentry/tracing_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe Sentry::Resque do
     worker.work(0)
 
     expect(transport.events.count).to eq(2)
-    event = transport.events.first.to_hash
+    event = transport.events.first.to_h
     expect(event[:message]).to eq("report")
 
-    tracing_event = transport.events.last.to_hash
+    tracing_event = transport.events.last.to_h
     expect(tracing_event[:transaction]).to eq("MessageJob")
     expect(tracing_event[:transaction_info]).to eq({ source: :task })
     expect(tracing_event[:type]).to eq("transaction")
@@ -51,10 +51,10 @@ RSpec.describe Sentry::Resque do
     worker.work(0)
 
     expect(transport.events.count).to eq(2)
-    event = transport.events.first.to_hash
+    event = transport.events.first.to_h
     expect(event.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
 
-    tracing_event = transport.events.last.to_hash
+    tracing_event = transport.events.last.to_h
     expect(tracing_event[:transaction]).to eq("FailedJob")
     expect(tracing_event[:transaction_info]).to eq({ source: :task })
     expect(tracing_event[:type]).to eq("transaction")
@@ -76,7 +76,7 @@ RSpec.describe Sentry::Resque do
       worker.work(0)
 
       expect(transport.events.count).to eq(1)
-      event = transport.events.first.to_hash
+      event = transport.events.first.to_h
       expect(event[:message]).to eq("report")
     end
   end

--- a/sentry-ruby/lib/sentry/breadcrumb.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb.rb
@@ -33,7 +33,7 @@ module Sentry
     end
 
     # @return [Hash]
-    def to_hash
+    def to_h
       {
         category: @category,
         data: serialized_data,

--- a/sentry-ruby/lib/sentry/breadcrumb_buffer.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb_buffer.rb
@@ -48,9 +48,9 @@ module Sentry
     end
 
     # @return [Hash]
-    def to_hash
+    def to_h
       {
-        values: members.map(&:to_hash)
+        values: members.map(&:to_h)
       }
     end
 

--- a/sentry-ruby/lib/sentry/check_in_event.rb
+++ b/sentry-ruby/lib/sentry/check_in_event.rb
@@ -47,13 +47,13 @@ module Sentry
     end
 
     # @return [Hash]
-    def to_hash
+    def to_h
       data = super
       data[:check_in_id] = check_in_id
       data[:monitor_slug] = monitor_slug
       data[:status] = status
       data[:duration] = duration if duration
-      data[:monitor_config] = monitor_config.to_hash if monitor_config
+      data[:monitor_config] = monitor_config.to_h if monitor_config
       data
     end
   end

--- a/sentry-ruby/lib/sentry/cron/monitor_config.rb
+++ b/sentry-ruby/lib/sentry/cron/monitor_config.rb
@@ -40,9 +40,9 @@ module Sentry
         new(MonitorSchedule::Interval.new(num, unit), **options)
       end
 
-      def to_hash
+      def to_h
         {
-          schedule: schedule.to_hash,
+          schedule: schedule.to_h,
           checkin_margin: checkin_margin,
           max_runtime: max_runtime,
           timezone: timezone

--- a/sentry-ruby/lib/sentry/cron/monitor_schedule.rb
+++ b/sentry-ruby/lib/sentry/cron/monitor_schedule.rb
@@ -12,7 +12,7 @@ module Sentry
           @value = value
         end
 
-        def to_hash
+        def to_h
           { type: :crontab, value: value }
         end
       end
@@ -33,7 +33,7 @@ module Sentry
           @unit = unit
         end
 
-        def to_hash
+        def to_h
           { type: :interval, value: value, unit: unit }
         end
       end

--- a/sentry-ruby/lib/sentry/error_event.rb
+++ b/sentry-ruby/lib/sentry/error_event.rb
@@ -10,10 +10,10 @@ module Sentry
     attr_reader :threads
 
     # @return [Hash]
-    def to_hash
+    def to_h
       data = super
-      data[:threads] = threads.to_hash if threads
-      data[:exception] = exception.to_hash if exception
+      data[:threads] = threads.to_h if threads
+      data[:exception] = exception.to_h if exception
       data
     end
 

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -115,16 +115,16 @@ module Sentry
     end
 
     # @return [Hash]
-    def to_hash
+    def to_h
       data = serialize_attributes
-      data[:breadcrumbs] = breadcrumbs.to_hash if breadcrumbs
-      data[:request] = request.to_hash if request
+      data[:breadcrumbs] = breadcrumbs.to_h if breadcrumbs
+      data[:request] = request.to_h if request
       data
     end
 
     # @return [Hash]
     def to_json_compatible
-      JSON.parse(JSON.generate(to_hash))
+      JSON.parse(JSON.generate(to_h))
     end
 
     private

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -83,7 +83,7 @@ module Sentry
       transaction ||= Transaction.new(**options.merge(hub: self))
 
       sampling_context = {
-        transaction_context: transaction.to_hash,
+        transaction_context: transaction.to_h,
         parent_sampled: transaction.parent_sampled
       }
 

--- a/sentry-ruby/lib/sentry/interface.rb
+++ b/sentry-ruby/lib/sentry/interface.rb
@@ -3,7 +3,7 @@
 module Sentry
   class Interface
     # @return [Hash]
-    def to_hash
+    def to_h
       Hash[instance_variables.map { |name| [name[1..-1].to_sym, instance_variable_get(name)] }]
     end
   end

--- a/sentry-ruby/lib/sentry/interfaces/exception.rb
+++ b/sentry-ruby/lib/sentry/interfaces/exception.rb
@@ -13,9 +13,9 @@ module Sentry
     end
 
     # @return [Hash]
-    def to_hash
+    def to_h
       data = super
-      data[:values] = data[:values].map(&:to_hash) if data[:values]
+      data[:values] = data[:values].map(&:to_h) if data[:values]
       data
     end
 

--- a/sentry-ruby/lib/sentry/interfaces/single_exception.rb
+++ b/sentry-ruby/lib/sentry/interfaces/single_exception.rb
@@ -32,10 +32,10 @@ module Sentry
       @mechanism = mechanism
     end
 
-    def to_hash
+    def to_h
       data = super
-      data[:stacktrace] = data[:stacktrace].to_hash if data[:stacktrace]
-      data[:mechanism] = data[:mechanism].to_hash
+      data[:stacktrace] = data[:stacktrace].to_h if data[:stacktrace]
+      data[:mechanism] = data[:mechanism].to_h
       data
     end
 

--- a/sentry-ruby/lib/sentry/interfaces/stacktrace.rb
+++ b/sentry-ruby/lib/sentry/interfaces/stacktrace.rb
@@ -11,8 +11,8 @@ module Sentry
     end
 
     # @return [Hash]
-    def to_hash
-      { frames: @frames.map(&:to_hash) }
+    def to_h
+      { frames: @frames.map(&:to_h) }
     end
 
     # @return [String]
@@ -64,7 +64,7 @@ module Sentry
             linecache.get_file_context(abs_path, lineno, context_lines)
       end
 
-      def to_hash(*args)
+      def to_h(*args)
         data = super(*args)
         data.delete(:vars) unless vars && !vars.empty?
         data.delete(:pre_context) unless pre_context && !pre_context.empty?

--- a/sentry-ruby/lib/sentry/interfaces/stacktrace_builder.rb
+++ b/sentry-ruby/lib/sentry/interfaces/stacktrace_builder.rb
@@ -67,7 +67,7 @@ module Sentry
     def metrics_code_location(unparsed_line)
       parsed_line = Backtrace::Line.parse(unparsed_line)
       frame = convert_parsed_line_into_frame(parsed_line)
-      frame.to_hash.reject { |k, _| %i[project_root in_app].include?(k) }
+      frame.to_h.reject { |k, _| %i[project_root in_app].include?(k) }
     end
 
     private

--- a/sentry-ruby/lib/sentry/interfaces/threads.rb
+++ b/sentry-ruby/lib/sentry/interfaces/threads.rb
@@ -13,7 +13,7 @@ module Sentry
     end
 
     # @return [Hash]
-    def to_hash
+    def to_h
       {
         values: [
           {
@@ -21,7 +21,7 @@ module Sentry
             name: @name,
             crashed: @crashed,
             current: @current,
-            stacktrace: @stacktrace&.to_hash
+            stacktrace: @stacktrace&.to_h
           }
         ]
       }

--- a/sentry-ruby/lib/sentry/metrics/local_aggregator.rb
+++ b/sentry-ruby/lib/sentry/metrics/local_aggregator.rb
@@ -18,7 +18,7 @@ module Sentry
         end
       end
 
-      def to_hash
+      def to_h
         return nil if @buckets.empty?
 
         @buckets.map do |bucket_key, metric|

--- a/sentry-ruby/lib/sentry/profiler.rb
+++ b/sentry-ruby/lib/sentry/profiler.rb
@@ -73,7 +73,7 @@ module Sentry
       log('Discarding profile due to sampling decision') unless @sampled
     end
 
-    def to_hash
+    def to_h
       unless @sampled
         record_lost_event(:sample_rate)
         return {}

--- a/sentry-ruby/lib/sentry/span.rb
+++ b/sentry-ruby/lib/sentry/span.rb
@@ -161,7 +161,7 @@ module Sentry
     end
 
     # @return [Hash]
-    def to_hash
+    def to_h
       hash = {
         trace_id: @trace_id,
         span_id: @span_id,
@@ -301,7 +301,7 @@ module Sentry
     end
 
     def metrics_summary
-      @metrics_local_aggregator&.to_hash
+      @metrics_local_aggregator&.to_h
     end
   end
 end

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -139,7 +139,7 @@ module Sentry
     end
 
     # @return [Hash]
-    def to_hash
+    def to_h
       hash = super
 
       hash.merge!(

--- a/sentry-ruby/lib/sentry/transaction_event.rb
+++ b/sentry-ruby/lib/sentry/transaction_event.rb
@@ -35,7 +35,7 @@ module Sentry
       self.metrics_summary = transaction.metrics_summary
 
       finished_spans = transaction.span_recorder.spans.select { |span| span.timestamp && span != transaction }
-      self.spans = finished_spans.map(&:to_hash)
+      self.spans = finished_spans.map(&:to_h)
 
       populate_profile(transaction)
     end
@@ -48,9 +48,9 @@ module Sentry
     end
 
     # @return [Hash]
-    def to_hash
+    def to_h
       data = super
-      data[:spans] = @spans.map(&:to_hash) if @spans
+      data[:spans] = @spans.map(&:to_h) if @spans
       data[:start_timestamp] = @start_timestamp
       data[:measurements] = @measurements
       data[:_metrics_summary] = @metrics_summary if @metrics_summary
@@ -60,7 +60,7 @@ module Sentry
     private
 
     def populate_profile(transaction)
-      profile_hash = transaction.profiler.to_hash
+      profile_hash = transaction.profiler.to_h
       return if profile_hash.empty?
 
       profile_hash.merge!(

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -116,7 +116,7 @@ module Sentry
 
     def envelope_from_event(event)
       # Convert to hash
-      event_payload = event.to_hash
+      event_payload = event.to_h
       event_id = event_payload[:event_id] || event_payload["event_id"]
       item_type = event_payload[:type] || event_payload["type"]
 

--- a/sentry-ruby/spec/sentry/breadcrumb_buffer_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb_buffer_spec.rb
@@ -55,13 +55,13 @@ RSpec.describe Sentry::BreadcrumbBuffer do
     end
   end
 
-  describe "#to_hash" do
+  describe "#to_h" do
     it "doesn't break because of 1 problematic crumb" do
       subject.record(crumb_1)
       subject.record(crumb_2)
       subject.record(problematic_crumb)
 
-      result = subject.to_hash[:values]
+      result = subject.to_h[:values]
 
       expect(result[0][:category]).to eq("foo")
       expect(result[0][:data]).to eq({ "name" => "John", "age" => 25 })

--- a/sentry-ruby/spec/sentry/breadcrumb_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Sentry::Breadcrumb do
     end
   end
 
-  describe "#to_hash" do
+  describe "#to_h" do
     let(:problematic_crumb) do
       # circular reference
       a = []
@@ -70,7 +70,7 @@ RSpec.describe Sentry::Breadcrumb do
     end
 
     it "serializes data correctly" do
-      result = crumb.to_hash
+      result = crumb.to_h
 
       expect(result[:category]).to eq("foo")
       expect(result[:message]).to eq("crumb")
@@ -78,7 +78,7 @@ RSpec.describe Sentry::Breadcrumb do
     end
 
     it "rescues data serialization issue and ditch the data" do
-      result = problematic_crumb.to_hash
+      result = problematic_crumb.to_h
 
       expect(result[:category]).to eq("baz")
       expect(result[:message]).to eq("I cause issues")

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe Sentry::Client do
 
     it 'returns an event' do
       event = subject.event_from_message(message)
-      hash = event.to_hash
+      hash = event.to_h
 
       expect(event).to be_a(Sentry::ErrorEvent)
       expect(hash[:message]).to eq(message)
@@ -195,7 +195,7 @@ RSpec.describe Sentry::Client do
 
       t.name = "Thread 1"
       t.join
-      hash = event.to_hash
+      hash = event.to_h
 
       thread = hash[:threads][:values][0]
       expect(thread[:id]).to eq(t.object_id)
@@ -223,7 +223,7 @@ RSpec.describe Sentry::Client do
 
     it "initializes a correct event for the transaction" do
       event = subject.event_from_transaction(transaction)
-      event_hash = event.to_hash
+      event_hash = event.to_h
 
       expect(event_hash[:type]).to eq("transaction")
       expect(event_hash[:contexts][:trace]).to eq(transaction.get_trace_context)
@@ -278,7 +278,7 @@ RSpec.describe Sentry::Client do
     it 'adds metric summary on transaction if any' do
       key = [:c, 'incr', 'none', []]
       transaction.metrics_local_aggregator.add(key, 10)
-      hash = subject.event_from_transaction(transaction).to_hash
+      hash = subject.event_from_transaction(transaction).to_h
 
       expect(hash[:_metrics_summary]).to eq({
         'c:incr@none' => { count: 1, max: 10.0, min: 10.0, sum: 10.0, tags: {} }
@@ -290,7 +290,7 @@ RSpec.describe Sentry::Client do
     let(:message) { 'This is a message' }
     let(:exception) { Exception.new(message) }
     let(:event) { subject.event_from_exception(exception) }
-    let(:hash) { event.to_hash }
+    let(:hash) { event.to_h }
 
     it "sets the message to the exception's value and type" do
       expect(hash[:exception][:values][0][:type]).to eq("Exception")
@@ -339,7 +339,7 @@ RSpec.describe Sentry::Client do
         end
 
         event = subject.event_from_exception(NonStringMessageError.new)
-        hash = event.to_hash
+        hash = event.to_h
         expect(event).to be_a(Sentry::ErrorEvent)
         expect(hash[:exception][:values][0][:value]).to eq("{:foo=>\"bar\"}")
       end
@@ -355,7 +355,7 @@ RSpec.describe Sentry::Client do
       t.name = "Thread 1"
       t.join
 
-      event_hash = event.to_hash
+      event_hash = event.to_h
       thread = event_hash[:threads][:values][0]
 
       expect(thread[:id]).to eq(t.object_id)
@@ -376,7 +376,7 @@ RSpec.describe Sentry::Client do
     it 'returns an event' do
       event = subject.event_from_exception(ZeroDivisionError.new("divided by 0"))
       expect(event).to be_a(Sentry::ErrorEvent)
-      hash = event.to_hash
+      hash = event.to_h
       expect(hash[:exception][:values][0][:type]).to match("ZeroDivisionError")
       expect(hash[:exception][:values][0][:value]).to match("divided by 0")
     end
@@ -576,7 +576,7 @@ RSpec.describe Sentry::Client do
       context 'when the exception responds to sentry_context' do
         let(:hash) do
           event = subject.event_from_exception(ExceptionWithContext.new)
-          event.to_hash
+          event.to_h
         end
 
         it "merges the context into event's extra" do
@@ -654,7 +654,7 @@ RSpec.describe Sentry::Client do
       it 'has correct custom mechanism when passed' do
         mech = Sentry::Mechanism.new(type: 'custom', handled: false)
         event = subject.event_from_exception(exception, mechanism: mech)
-        hash = event.to_hash
+        hash = event.to_h
         mechanism = hash[:exception][:values][0][:mechanism]
         expect(mechanism).to eq({ type: 'custom', handled: false })
       end
@@ -669,7 +669,7 @@ RSpec.describe Sentry::Client do
       event = subject.event_from_check_in(slug, status)
       expect(event).to be_a(Sentry::CheckInEvent)
 
-      hash = event.to_hash
+      hash = event.to_h
       expect(hash[:monitor_slug]).to eq(slug)
       expect(hash[:status]).to eq(status)
       expect(hash[:check_in_id].length).to eq(32)
@@ -686,7 +686,7 @@ RSpec.describe Sentry::Client do
 
       expect(event).to be_a(Sentry::CheckInEvent)
 
-      hash = event.to_hash
+      hash = event.to_h
       expect(hash[:monitor_slug]).to eq(slug)
       expect(hash[:status]).to eq(status)
       expect(hash[:check_in_id]).to eq("xxx-yyy")
@@ -705,7 +705,7 @@ RSpec.describe Sentry::Client do
 
       expect(event).to be_a(Sentry::CheckInEvent)
 
-      hash = event.to_hash
+      hash = event.to_h
       expect(hash[:monitor_slug]).to eq(slug)
       expect(hash[:status]).to eq(status)
       expect(hash[:check_in_id]).to eq("xxx-yyy")

--- a/sentry-ruby/spec/sentry/cron/monitor_config_spec.rb
+++ b/sentry-ruby/spec/sentry/cron/monitor_config_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Sentry::Cron::MonitorConfig do
     end
   end
 
-  describe '#to_hash' do
+  describe '#to_h' do
     it 'returns hash with correct attributes for crontab' do
       subject = described_class.from_crontab(
         '5 * * * *',
@@ -52,7 +52,7 @@ RSpec.describe Sentry::Cron::MonitorConfig do
         timezone: 'Europe/Vienna'
       )
 
-      hash = subject.to_hash
+      hash = subject.to_h
       expect(hash).to eq({
         schedule: { type: :crontab, value: '5 * * * *' },
         checkin_margin: 10,
@@ -70,7 +70,7 @@ RSpec.describe Sentry::Cron::MonitorConfig do
         timezone: 'Europe/Vienna'
       )
 
-      hash = subject.to_hash
+      hash = subject.to_h
       expect(hash).to eq({
         schedule: { type: :interval, value: 5, unit: :hour },
         checkin_margin: 10,

--- a/sentry-ruby/spec/sentry/cron/monitor_schedule_spec.rb
+++ b/sentry-ruby/spec/sentry/cron/monitor_schedule_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Sentry::Cron::MonitorSchedule::Crontab do
     end
   end
 
-  describe '#to_hash' do
+  describe '#to_h' do
     it 'has correct attributes' do
-      expect(subject.to_hash).to eq({ type: :crontab, value: subject.value })
+      expect(subject.to_h).to eq({ type: :crontab, value: subject.value })
     end
   end
 end
@@ -31,9 +31,9 @@ RSpec.describe Sentry::Cron::MonitorSchedule::Interval do
     end
   end
 
-  describe '#to_hash' do
+  describe '#to_h' do
     it 'has correct attributes' do
-      expect(subject.to_hash).to eq({ type: :interval, value: subject.value, unit: subject.unit })
+      expect(subject.to_h).to eq({ type: :interval, value: subject.value, unit: subject.unit })
     end
   end
 end

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -97,14 +97,14 @@ RSpec.describe Sentry::Event do
       it "filters out pii data" do
         scope.apply_to_event(event)
 
-        expect(event.to_hash[:request]).to eq(
+        expect(event.to_h[:request]).to eq(
           env: { 'SERVER_NAME' => 'localhost', 'SERVER_PORT' => '80' },
           headers: { 'Host' => 'localhost', 'X-Request-Id' => 'abcd-1234-abcd-1234' },
           method: 'POST',
           url: 'http://localhost/lol',
         )
-        expect(event.to_hash[:tags][:request_id]).to eq("abcd-1234-abcd-1234")
-        expect(event.to_hash[:user][:ip_address]).to eq(nil)
+        expect(event.to_h[:tags][:request_id]).to eq("abcd-1234-abcd-1234")
+        expect(event.to_h[:user][:ip_address]).to eq(nil)
       end
 
       it "removes ip address headers" do
@@ -127,7 +127,7 @@ RSpec.describe Sentry::Event do
       it "adds correct data" do
         Sentry.get_current_scope.apply_to_event(event)
 
-        expect(event.to_hash[:request]).to eq(
+        expect(event.to_h[:request]).to eq(
           data: { 'foo' => 'bar' },
           env: { 'SERVER_NAME' => 'localhost', 'SERVER_PORT' => '80', "REMOTE_ADDR" => "192.168.1.1" },
           headers: { 'Host' => 'localhost', "X-Forwarded-For" => "1.1.1.1, 2.2.2.2", "X-Request-Id" => "abcd-1234-abcd-1234" },
@@ -137,8 +137,8 @@ RSpec.describe Sentry::Event do
           cookies: {}
         )
 
-        expect(event.to_hash[:tags][:request_id]).to eq("abcd-1234-abcd-1234")
-        expect(event.to_hash[:user][:ip_address]).to eq("2.2.2.2")
+        expect(event.to_h[:tags][:request_id]).to eq("abcd-1234-abcd-1234")
+        expect(event.to_h[:user][:ip_address]).to eq("2.2.2.2")
       end
 
       context "with config.trusted_proxies = [\"2.2.2.2\"]" do
@@ -149,7 +149,7 @@ RSpec.describe Sentry::Event do
         it "calculates the correct ip address" do
           Sentry.get_current_scope.apply_to_event(event)
 
-          expect(event.to_hash[:request]).to eq(
+          expect(event.to_h[:request]).to eq(
             data: { "foo"=>"bar" },
             env: { 'SERVER_NAME' => 'localhost', 'SERVER_PORT' => '80', "REMOTE_ADDR" => "192.168.1.1" },
             headers: { 'Host' => 'localhost', "X-Forwarded-For" => "1.1.1.1, 2.2.2.2", "X-Request-Id" => "abcd-1234-abcd-1234" },
@@ -159,8 +159,8 @@ RSpec.describe Sentry::Event do
             cookies: {}
           )
 
-          expect(event.to_hash[:tags][:request_id]).to eq("abcd-1234-abcd-1234")
-          expect(event.to_hash[:user][:ip_address]).to eq("1.1.1.1")
+          expect(event.to_h[:tags][:request_id]).to eq("abcd-1234-abcd-1234")
+          expect(event.to_h[:user][:ip_address]).to eq("1.1.1.1")
         end
       end
     end

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Sentry::Hub do
 
     it "takes backtrace option" do
       event = subject.capture_message(message, backtrace: ["#{__FILE__}:10:in `foo'"])
-      event_hash = event.to_hash
+      event_hash = event.to_h
       expect(event_hash.dig(:threads, :values, 0, :stacktrace, :frames, 0, :function)).to eq("foo")
     end
 
@@ -159,7 +159,7 @@ RSpec.describe Sentry::Hub do
 
     it "assigns default backtrace with caller" do
       event = subject.capture_message(message)
-      event_hash = event.to_hash
+      event_hash = event.to_h
       expect(event_hash.dig(:threads, :values, 0, :stacktrace, :frames, 0, :function)).to eq("<main>")
     end
 
@@ -211,7 +211,7 @@ RSpec.describe Sentry::Hub do
         monitor_config: Sentry::Cron::MonitorConfig.from_crontab("* * * * *")
       )
 
-      event = transport.events.last.to_hash
+      event = transport.events.last.to_h
       expect(event).to include(
         monitor_slug: slug,
         status: :ok,

--- a/sentry-ruby/spec/sentry/interface_spec.rb
+++ b/sentry-ruby/spec/sentry/interface_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe Sentry::Interface do
     interface = TestInterface.new
     interface.some_attr = "test"
 
-    expect(interface.to_hash).to eq(some_attr: "test")
+    expect(interface.to_h).to eq(some_attr: "test")
   end
 end

--- a/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Sentry::RequestInterface do
       let(:additional_headers) { { "HTTP_FOO" => "Tekirda\xC4" } }
 
       it "doesn't cause any issue" do
-        json = JSON.generate(subject.to_hash)
+        json = JSON.generate(subject.to_h)
 
         expect(JSON.parse(json)["headers"]).to include("Foo"=>"Tekirda�")
       end
@@ -192,7 +192,7 @@ RSpec.describe Sentry::RequestInterface do
       env.merge!(::Rack::RACK_INPUT => StringIO.new("あ"))
 
       expect do
-        JSON.generate(subject.to_hash)
+        JSON.generate(subject.to_h)
       end.not_to raise_error
     end
 

--- a/sentry-ruby/spec/sentry/metrics/local_aggregator_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/local_aggregator_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe Sentry::Metrics::LocalAggregator do
     end
   end
 
-  describe '#to_hash' do
+  describe '#to_h' do
     it 'returns nil if empty buckets' do
-      expect(subject.to_hash).to eq(nil)
+      expect(subject.to_h).to eq(nil)
     end
 
     context 'with filled buckets' do
@@ -50,28 +50,28 @@ RSpec.describe Sentry::Metrics::LocalAggregator do
       end
 
       it 'has the correct payload keys in the hash' do
-        expect(subject.to_hash.keys).to eq([
+        expect(subject.to_h.keys).to eq([
           'c:incr@second',
           's:set@none'
         ])
       end
 
       it 'has the tags deserialized correctly with array values' do
-        expect(subject.to_hash['c:incr@second'][:tags]).to eq({
+        expect(subject.to_h['c:incr@second'][:tags]).to eq({
           'foo' => [1, 2],
           'bar' => 'baz'
         })
       end
 
       it 'has the correct gauge metric values' do
-        expect(subject.to_hash['c:incr@second']).to include({
+        expect(subject.to_h['c:incr@second']).to include({
           min: 10.0,
           max: 20.0,
           count: 2,
           sum: 30.0
         })
 
-        expect(subject.to_hash['s:set@none']).to include({
+        expect(subject.to_h['s:set@none']).to include({
           min: 1.0,
           max: 1.0,
           count: 1,

--- a/sentry-ruby/spec/sentry/profiler_spec.rb
+++ b/sentry-ruby/spec/sentry/profiler_spec.rb
@@ -150,25 +150,25 @@ RSpec.describe Sentry::Profiler do
     end
   end
 
-  describe '#to_hash' do
+  describe '#to_h' do
     let (:transport) { Sentry.get_current_client.transport }
 
     context 'when not sampled' do
       before { subject.set_initial_sample_decision(false) }
 
       it 'returns nil' do
-        expect(subject.to_hash).to eq({})
+        expect(subject.to_h).to eq({})
       end
 
       it 'records lost event' do
         expect(transport).to receive(:record_lost_event).with(:sample_rate, 'profile')
-        subject.to_hash
+        subject.to_h
       end
     end
 
     it 'returns nil unless started' do
       subject.set_initial_sample_decision(true)
-      expect(subject.to_hash).to eq({})
+      expect(subject.to_h).to eq({})
     end
 
     context 'with empty results' do
@@ -180,12 +180,12 @@ RSpec.describe Sentry::Profiler do
 
       it 'returns empty' do
         expect(StackProf).to receive(:results).and_call_original
-        expect(subject.to_hash).to eq({})
+        expect(subject.to_h).to eq({})
       end
 
       it 'records lost event' do
         expect(transport).to receive(:record_lost_event).with(:insufficient_data, 'profile')
-        subject.to_hash
+        subject.to_h
       end
     end
 
@@ -205,12 +205,12 @@ RSpec.describe Sentry::Profiler do
       end
 
       it 'returns empty' do
-        expect(subject.to_hash).to eq({})
+        expect(subject.to_h).to eq({})
       end
 
       it 'records lost event' do
         expect(transport).to receive(:record_lost_event).with(:insufficient_data, 'profile')
-        subject.to_hash
+        subject.to_h
       end
     end
 
@@ -223,7 +223,7 @@ RSpec.describe Sentry::Profiler do
       end
 
       it 'has correct attributes' do
-        hash = subject.to_hash
+        hash = subject.to_h
 
         expect(hash[:event_id]).to eq(subject.event_id)
         expect(hash[:platform]).to eq('ruby')
@@ -232,7 +232,7 @@ RSpec.describe Sentry::Profiler do
       end
 
       it 'has correct frames' do
-        frames = subject.to_hash[:profile][:frames]
+        frames = subject.to_h[:profile][:frames]
 
         foo_frame = frames.find { |f| f[:function] =~ /foo/ }
         expect(foo_frame[:function]).to eq('Foo.foo')
@@ -268,7 +268,7 @@ RSpec.describe Sentry::Profiler do
       end
 
       it 'has correct stacks' do
-        profile = subject.to_hash[:profile]
+        profile = subject.to_h[:profile]
         frames = profile[:frames]
         stacks = profile[:stacks]
 
@@ -282,7 +282,7 @@ RSpec.describe Sentry::Profiler do
       end
 
       it 'has correct samples' do
-        profile = subject.to_hash[:profile]
+        profile = subject.to_h[:profile]
         num_stacks = profile[:stacks].size
         samples = profile[:samples]
         last_elapsed = 0

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
 
       expect { stack.call(env) }.to raise_error(ZeroDivisionError)
 
-      event = last_sentry_event.to_hash
+      event = last_sentry_event.to_h
       expect(event.dig(:request, :url)).to eq("http://example.org/test")
       expect(env["sentry.error_event_id"]).to eq(event[:event_id])
       last_frame = event.dig(:exception, :values, 0, :stacktrace, :frames).last
@@ -31,7 +31,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
 
       expect { stack.call(env) }.to raise_error(ZeroDivisionError)
 
-      event = last_sentry_event.to_hash
+      event = last_sentry_event.to_h
       mechanism = event.dig(:exception, :values, 0, :mechanism)
       expect(mechanism).to eq({ type: 'rack', handled: false })
     end
@@ -49,7 +49,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
 
       event = last_sentry_event
       expect(env["sentry.error_event_id"]).to eq(event.event_id)
-      expect(event.to_hash.dig(:request, :url)).to eq("http://example.org/test")
+      expect(event.to_h.dig(:request, :url)).to eq("http://example.org/test")
     end
 
     it 'captures the exception from sinatra.error' do
@@ -64,7 +64,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
       end.to change { sentry_events.count }.by(1)
 
       event = last_sentry_event
-      expect(event.to_hash.dig(:request, :url)).to eq("http://example.org/test")
+      expect(event.to_h.dig(:request, :url)).to eq("http://example.org/test")
     end
 
     it 'sets the transaction and rack env' do
@@ -78,7 +78,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
 
       event = last_sentry_event
       expect(event.transaction).to eq("/test")
-      expect(event.to_hash.dig(:request, :url)).to eq("http://example.org/test")
+      expect(event.to_h.dig(:request, :url)).to eq("http://example.org/test")
       expect(Sentry.get_current_scope.transaction_name).to be_nil
       expect(Sentry.get_current_scope.rack_env).to eq({})
     end
@@ -115,7 +115,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
 
         expect { stack.call(env) }.to raise_error(ZeroDivisionError)
 
-        event = last_sentry_event.to_hash
+        event = last_sentry_event.to_h
         expect(event.dig(:request, :url)).to eq("http://example.org/test")
         last_frame = event.dig(:exception, :values, 0, :stacktrace, :frames).last
         expect(last_frame[:vars]).to include({ a: "1", b: "0" })
@@ -139,7 +139,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
 
         expect { stack.call(env) }.to raise_error(ZeroDivisionError)
 
-        event = last_sentry_event.to_hash
+        event = last_sentry_event.to_h
         expect(event.dig(:request, :url)).to eq("http://example.org/test")
         last_frame = event.dig(:exception, :values, 0, :stacktrace, :frames).last
         expect(last_frame[:vars]).to include({ a: "1", b: "0", f: "[ignored due to error]" })
@@ -157,7 +157,7 @@ RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
 
         expect { stack.call(env) }.to raise_error(ZeroDivisionError)
 
-        event = last_sentry_event.to_hash
+        event = last_sentry_event.to_h
         expect(event.dig(:request, :url)).to eq("http://example.org/test")
         last_frame = event.dig(:exception, :values, 0, :stacktrace, :frames).last
         expect(last_frame[:vars]).to include({ a: "1", b: "0", long: "*" * 1024 + "..." })

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Sentry::Scope do
       copy.set_transaction_name("foo", source: :url)
       copy.fingerprint << "bar"
 
-      expect(subject.breadcrumbs.to_hash).to eq({ values: [] })
+      expect(subject.breadcrumbs.to_h).to eq({ values: [] })
       expect(subject.contexts[:os].keys).to match_array([:name, :version, :build, :kernel_version, :machine])
       expect(subject.contexts.dig(:runtime, :version)).to match(/ruby/)
       expect(subject.extra).to eq({})
@@ -318,7 +318,7 @@ RSpec.describe Sentry::Scope do
       it "sets the request info the Event" do
         subject.apply_to_event(event)
 
-        expect(event.to_hash.dig(:request, :url)).to eq("http://example.org/test")
+        expect(event.to_h.dig(:request, :url)).to eq("http://example.org/test")
       end
     end
   end

--- a/sentry-ruby/spec/sentry/span_spec.rb
+++ b/sentry-ruby/spec/sentry/span_spec.rb
@@ -54,14 +54,14 @@ RSpec.describe Sentry::Span do
     end
   end
 
-  describe "#to_hash" do
+  describe "#to_h" do
     before do
       subject.set_data("controller", "WelcomeController")
       subject.set_tag("foo", "bar")
     end
 
     it "returns correct data" do
-      hash = subject.to_hash
+      hash = subject.to_h
 
       expect(hash[:op]).to eq("sql.query")
       expect(hash[:description]).to eq("SELECT * FROM users;")
@@ -77,7 +77,7 @@ RSpec.describe Sentry::Span do
       key = [:c, 'incr', 'none', []]
       subject.metrics_local_aggregator.add(key, 10)
 
-      hash = subject.to_hash
+      hash = subject.to_h
       expect(hash[:_metrics_summary]).to eq({
         'c:incr@none' => { count: 1, max: 10.0, min: 10.0, sum: 10.0, tags: {} }
       })

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -390,9 +390,9 @@ RSpec.describe Sentry::Transaction do
     end
   end
 
-  describe "#to_hash" do
+  describe "#to_h" do
     it "returns correct data" do
-      hash = subject.to_hash
+      hash = subject.to_h
 
       expect(hash[:op]).to eq("sql.query")
       expect(hash[:description]).to eq("SELECT * FROM users;")
@@ -419,7 +419,7 @@ RSpec.describe Sentry::Transaction do
       subject.finish
 
       expect(events.count).to eq(1)
-      event = events.last.to_hash
+      event = events.last.to_h
 
       # don't contain itself
       expect(event[:spans]).to be_empty
@@ -429,7 +429,7 @@ RSpec.describe Sentry::Transaction do
       subject.finish
 
       expect(events.count).to eq(1)
-      event = events.last.to_hash
+      event = events.last.to_h
 
       expect(event[:transaction]).to eq("foo")
     end
@@ -439,7 +439,7 @@ RSpec.describe Sentry::Transaction do
       subject.finish(end_timestamp: timestamp)
 
       expect(events.count).to eq(1)
-      event = events.last.to_hash
+      event = events.last.to_h
 
       expect(event[:timestamp]).to eq(timestamp)
     end
@@ -452,7 +452,7 @@ RSpec.describe Sentry::Transaction do
       subject.finish
 
       expect(events.count).to eq(1)
-      event = events.last.to_hash
+      event = events.last.to_h
 
       expect(event[:tags]).to eq({ foo: 'bar', name: "apple" })
     end
@@ -532,7 +532,7 @@ RSpec.describe Sentry::Transaction do
         subject.set_measurement("metric.foo", 0.5, "second")
         subject.finish
 
-        transaction = events.last.to_hash
+        transaction = events.last.to_h
         expect(transaction[:measurements]).to eq(
           { "metric.foo" => { value: 0.5, unit: "second" } }
         )

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Sentry::Transport do
           '{"type":"event","content_type":"application/json"}'
         )
 
-        expect(item).to eq(event.to_hash.to_json)
+        expect(item).to eq(event.to_h.to_json)
       end
     end
 
@@ -89,7 +89,7 @@ RSpec.describe Sentry::Transport do
           '{"type":"transaction","content_type":"application/json"}'
         )
 
-        expect(item).to eq(event.to_hash.to_json)
+        expect(item).to eq(event.to_h.to_json)
       end
 
       context "with profiling on transaction" do
@@ -212,7 +212,7 @@ RSpec.describe Sentry::Transport do
           1000.times do |i|
             event.breadcrumbs.record Sentry::Breadcrumb.new(category: i.to_s, message: "x" * Sentry::Event::MAX_MESSAGE_SIZE_IN_BYTES)
           end
-          serialized_result = JSON.generate(event.to_hash)
+          serialized_result = JSON.generate(event.to_h)
           expect(serialized_result.bytesize).to be > Sentry::Envelope::Item::MAX_SERIALIZED_PAYLOAD_SIZE
         end
 
@@ -265,7 +265,7 @@ RSpec.describe Sentry::Transport do
           )
           single_exception.instance_variable_set(:@stacktrace, new_stacktrace)
 
-          serialized_result = JSON.generate(event.to_hash)
+          serialized_result = JSON.generate(event.to_h)
           expect(serialized_result.bytesize).to be > Sentry::Envelope::Item::MAX_SERIALIZED_PAYLOAD_SIZE
         end
 
@@ -375,7 +375,7 @@ RSpec.describe Sentry::Transport do
         1000.times do |i|
           event.breadcrumbs.record Sentry::Breadcrumb.new(category: i.to_s, message: "x" * Sentry::Event::MAX_MESSAGE_SIZE_IN_BYTES)
         end
-        serialized_result = JSON.generate(event.to_hash)
+        serialized_result = JSON.generate(event.to_h)
         expect(serialized_result.bytesize).to be > Sentry::Envelope::Item::MAX_SERIALIZED_PAYLOAD_SIZE
       end
 

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe Sentry do
           described_class.capture_exception(e)
         end
 
-        event = last_sentry_event.to_hash
+        event = last_sentry_event.to_h
         last_frame = event.dig(:exception, :values, 0, :stacktrace, :frames).last
         expect(last_frame[:vars]).to eq(nil)
       end
@@ -305,7 +305,7 @@ RSpec.describe Sentry do
           described_class.capture_exception(e)
         end
 
-        event = last_sentry_event.to_hash
+        event = last_sentry_event.to_h
         last_frame = event.dig(:exception, :values, 0, :stacktrace, :frames).last
         expect(last_frame[:vars]).to include({ a: "1", b: "0" })
       end

--- a/sentry-sidekiq/spec/sentry/sidekiq-scheduler/scheduler_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq-scheduler/scheduler_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Sentry::SidekiqScheduler::Scheduler do
     expect(EveryHappyWorker.sentry_monitor_slug).to eq('regularly_happy')
     expect(EveryHappyWorker.sentry_monitor_config).to be_a(Sentry::Cron::MonitorConfig)
     expect(EveryHappyWorker.sentry_monitor_config.schedule).to be_a(Sentry::Cron::MonitorSchedule::Interval)
-    expect(EveryHappyWorker.sentry_monitor_config.schedule.to_hash).to eq({ value: 10, type: :interval, unit: :minute })
+    expect(EveryHappyWorker.sentry_monitor_config.schedule.to_h).to eq({ value: 10, type: :interval, unit: :minute })
   end
 
   it "does not add monitors for a one-off job" do

--- a/sentry-sidekiq/spec/sentry/sidekiq/error_handler_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/error_handler_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Sentry::Sidekiq::ErrorHandler do
       processor.fire_event(:startup)
     end
 
-    event = transport.events.last.to_hash
+    event = transport.events.last.to_h
     expect(event[:exception][:values][0][:type]).to eq("RuntimeError")
     expect(event[:exception][:values][0][:value]).to match("Uhoh!")
     expect(event[:transaction]).to eq "Sidekiq/startup"
@@ -51,7 +51,7 @@ RSpec.describe Sentry::Sidekiq::ErrorHandler do
     subject.call(exception, context)
 
     expect(transport.events.count).to eq(1)
-    event = transport.events.first.to_hash
+    event = transport.events.first.to_h
     expect(event[:contexts][:sidekiq]).to eq(context)
   end
 
@@ -67,7 +67,7 @@ RSpec.describe Sentry::Sidekiq::ErrorHandler do
     subject.call(exception, aj_context)
 
     expect(transport.events.count).to eq(1)
-    event = transport.events.first.to_hash
+    event = transport.events.first.to_h
     expect(event[:contexts][:sidekiq]).to eq(expected_context)
   end
 
@@ -80,7 +80,7 @@ RSpec.describe Sentry::Sidekiq::ErrorHandler do
       subject.call(exception, context)
 
       expect(transport.events.count).to eq(1)
-      event = transport.events.first.to_hash
+      event = transport.events.first.to_h
       expect(event[:transaction]).to eq("Sidekiq/HardWorker")
     end
   end

--- a/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Sentry::Sidekiq do
   it "captures exception raised in the worker" do
     expect { execute_worker(processor, SadWorker) }.to change { transport.events.size }.by(1)
 
-    event = transport.events.last.to_hash
+    event = transport.events.last.to_h
     expect(event[:sdk]).to eq({ name: "sentry.ruby.sidekiq", version: described_class::VERSION })
     expect(event[:exception][:values][0][:type]).to eq("RuntimeError")
     expect(event[:exception][:values][0][:value]).to match("I'm sad!")
@@ -61,7 +61,7 @@ RSpec.describe Sentry::Sidekiq do
   it "doesn't store the private `_config` context", skip: !WITH_SIDEKIQ_7 do
     expect { execute_worker(processor, SadWorker) }.to change { transport.events.size }.by(1)
 
-    event = transport.events.last.to_hash
+    event = transport.events.last.to_h
     expect(event[:contexts][:sidekiq].keys.map(&:to_s)).not_to include("_config")
   end
 
@@ -266,7 +266,7 @@ RSpec.describe Sentry::Sidekiq do
       first = transport.events[0]
       check_in_id = first.check_in_id
       expect(first).to be_a(Sentry::CheckInEvent)
-      expect(first.to_hash).to include(
+      expect(first.to_h).to include(
         type: 'check_in',
         check_in_id: check_in_id,
         monitor_slug: "happyworkerwithcron",
@@ -275,7 +275,7 @@ RSpec.describe Sentry::Sidekiq do
 
       second = transport.events[1]
       expect(second).to be_a(Sentry::CheckInEvent)
-      expect(second.to_hash).to include(
+      expect(second.to_h).to include(
         :duration,
         type: 'check_in',
         check_in_id: check_in_id,
@@ -291,7 +291,7 @@ RSpec.describe Sentry::Sidekiq do
       first = transport.events[0]
       check_in_id = first.check_in_id
       expect(first).to be_a(Sentry::CheckInEvent)
-      expect(first.to_hash).to include(
+      expect(first.to_h).to include(
         type: 'check_in',
         check_in_id: check_in_id,
         monitor_slug: "failed_job",
@@ -301,7 +301,7 @@ RSpec.describe Sentry::Sidekiq do
 
       second = transport.events[1]
       expect(second).to be_a(Sentry::CheckInEvent)
-      expect(second.to_hash).to include(
+      expect(second.to_h).to include(
         :duration,
         type: 'check_in',
         check_in_id: check_in_id,


### PR DESCRIPTION
As @solnic pointed out in https://github.com/getsentry/sentry-ruby/pull/2350#discussion_r1686820195 `to_hash` has special meaning in Ruby and could be called implicitly in contexts like double splatting argument. So we should switch to `to_h` to avoid potential issues.

Additionally, Matz also [explained](https://bugs.ruby-lang.org/issues/10180#note-1) that in the explicit conversion usages (which is the case for the SDK), `to_h` should be used.

### Compatibility Concern

Since this PR changes the serialization interface of almost all SDK's internal components, if users/libs relied on patching `to_hash` to extend/modify the data, this could become a breaking change for them. And because `to_hash` has been that interface since the old `sentry-raven` SDK (for at least [12 years](https://github.com/getsentry/sentry-ruby/commit/5c045f80b49bd52831f3f37af5c121749a4e4bb1)), I think we can assume at least some legacy apps had built customization on top of it.

For this reason, maybe this should be shipped in 6.0?

(In cases where `Configuration#async` is set, we use `Event#to_json_compatible` instead, so they won't be affected)