### PR TITLE
File/attachment uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
   - Closes [#1795](https://github.com/getsentry/sentry-ruby/issues/1795)
   - Please note that the Faraday instrumentation has some limitations in case of async requests: https://github.com/lostisland/faraday/issues/1381
 - Support for attachments ([#2357](https://github.com/getsentry/sentry-ruby/pull/2357))
+  Usage:
+
+  ```ruby
+  Sentry.add_attachment(path: '/foo/bar.txt')
+  Sentry.add_attachment(filename: 'payload.json', bytes: '{"value": 42}'))
+  ```
 
 ## 5.18.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Support for tracing Faraday requests ([#2345](https://github.com/getsentry/sentry-ruby/pull/2345))
   - Closes [#1795](https://github.com/getsentry/sentry-ruby/issues/1795)
   - Please note that the Faraday instrumentation has some limitations in case of async requests: https://github.com/lostisland/faraday/issues/1381
+- Support for attachments ([#2357](https://github.com/getsentry/sentry-ruby/pull/2357))
 
 ## 5.18.2
 

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -211,6 +211,13 @@ module Sentry
       get_current_scope.set_context(*args)
     end
 
+    # @!method add_attachment
+    #   @!macro add_attachment
+    def add_attachment(**opts)
+      return unless initialized?
+      get_current_scope.add_attachment(**opts)
+    end
+
     ##### Main APIs #####
 
     # Initializes the SDK with given configuration.

--- a/sentry-ruby/lib/sentry/attachment.rb
+++ b/sentry-ruby/lib/sentry/attachment.rb
@@ -14,7 +14,7 @@ module Sentry
     end
 
     def to_envelope_headers
-      { type: 'attachment', filename: filename }
+      { type: 'attachment', filename: filename, length: payload.bytesize }
     end
 
     def payload

--- a/sentry-ruby/lib/sentry/attachment.rb
+++ b/sentry-ruby/lib/sentry/attachment.rb
@@ -4,14 +4,13 @@ module Sentry
   class Attachment
     PathNotFoundError = Class.new(StandardError)
 
-    attr_reader :bytes, :filename, :path, :content_type, :add_to_transactions
+    attr_reader :bytes, :filename, :path, :content_type
 
-    def initialize(bytes: nil, filename: nil, content_type: nil, path: nil, add_to_transactions: false)
+    def initialize(bytes: nil, filename: nil, content_type: nil, path: nil)
       @bytes = bytes
       @filename = infer_filename(filename, path)
       @path = path
       @content_type = content_type
-      @add_to_transactions = add_to_transactions
     end
 
     def to_envelope_headers

--- a/sentry-ruby/lib/sentry/attachment.rb
+++ b/sentry-ruby/lib/sentry/attachment.rb
@@ -4,17 +4,18 @@ module Sentry
   class Attachment
     PathNotFoundError = Class.new(StandardError)
 
-    attr_reader :bytes, :filename, :path, :add_to_transactions
+    attr_reader :bytes, :filename, :path, :content_type, :add_to_transactions
 
-    def initialize(bytes: nil, filename: nil, path: nil, add_to_transactions: false)
+    def initialize(bytes: nil, filename: nil, content_type: nil, path: nil, add_to_transactions: false)
       @bytes = bytes
       @filename = infer_filename(filename, path)
       @path = path
+      @content_type = content_type
       @add_to_transactions = add_to_transactions
     end
 
     def to_envelope_headers
-      { type: 'attachment', filename: filename, length: payload.bytesize }
+      { type: 'attachment', filename: filename, content_type: content_type, length: payload.bytesize }
     end
 
     def payload

--- a/sentry-ruby/lib/sentry/attachment.rb
+++ b/sentry-ruby/lib/sentry/attachment.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Sentry
+  class Attachment
+    PathNotFoundError = Class.new(StandardError)
+
+    attr_reader :bytes, :filename, :path, :add_to_transactions
+
+    def initialize(bytes: nil, filename: nil, path: nil, add_to_transactions: false)
+      @bytes = bytes
+      @filename = infer_filename(filename, path)
+      @path = path
+      @add_to_transactions = add_to_transactions
+    end
+
+    def to_envelope_headers
+      { type: 'attachment', filename: filename }
+    end
+
+    def payload
+      @payload ||= if bytes
+        bytes
+      else
+        File.binread(path)
+      end
+    rescue Errno::ENOENT
+      raise PathNotFoundError, "Failed to read attachment file, file not found: #{path}"
+    end
+
+    private
+
+    def infer_filename(filename, path)
+      return filename if filename
+
+      if path
+        File.basename(path)
+      else
+        raise ArgumentError, "filename or path is required"
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -42,6 +42,9 @@ module Sentry
     # @return [Hash, nil]
     attr_accessor :dynamic_sampling_context
 
+    # @return [Array<Attachment>]
+    attr_accessor :attachments
+
     # @param configuration [Configuration]
     # @param integration_meta [Hash, nil]
     # @param message [String, nil]
@@ -57,6 +60,7 @@ module Sentry
       @extra         = {}
       @contexts      = {}
       @tags          = {}
+      @attachments   = []
 
       @fingerprint = []
       @dynamic_sampling_context = nil

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -2,6 +2,7 @@
 
 require "sentry/breadcrumb_buffer"
 require "sentry/propagation_context"
+require "sentry/attachment"
 require "etc"
 
 module Sentry
@@ -22,6 +23,7 @@ module Sentry
       :rack_env,
       :span,
       :session,
+      :attachments,
       :propagation_context
     ]
 
@@ -55,6 +57,7 @@ module Sentry
         event.level = level
         event.breadcrumbs = breadcrumbs
         event.rack_env = rack_env if rack_env
+        event.attachments = attachments
       end
 
       if span
@@ -283,6 +286,12 @@ module Sentry
       @propagation_context = PropagationContext.new(self, env)
     end
 
+    # Add a new attachment to the scope.
+    def add_attachment(**opts)
+      attachments << (attachment = Attachment.new(**opts))
+      attachment
+    end
+
     protected
 
     # for duplicating scopes internally
@@ -303,6 +312,7 @@ module Sentry
       @rack_env = {}
       @span = nil
       @session = nil
+      @attachments = []
       generate_propagation_context
       set_new_breadcrumb_buffer
     end

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -105,6 +105,7 @@ module Sentry
       copy.span = span.deep_dup
       copy.session = session.deep_dup
       copy.propagation_context = propagation_context.deep_dup
+      copy.attachments = attachments.dup
       copy
     end
 
@@ -122,6 +123,7 @@ module Sentry
       self.fingerprint = scope.fingerprint
       self.span = scope.span
       self.propagation_context = scope.propagation_context
+      self.attachments = scope.attachments
     end
 
     # Updates the scope's data from the given options.
@@ -131,6 +133,7 @@ module Sentry
     # @param user [Hash]
     # @param level [String, Symbol]
     # @param fingerprint [Array]
+    # @param attachments [Array<Attachment>]
     # @return [Array]
     def update_from_options(
       contexts: nil,
@@ -139,6 +142,7 @@ module Sentry
       user: nil,
       level: nil,
       fingerprint: nil,
+      attachments: nil,
       **options
     )
       self.contexts.merge!(contexts) if contexts

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -145,6 +145,12 @@ module Sentry
         )
       end
 
+      if event.is_a?(Event) && event.attachments.any?
+        event.attachments.each do |attachment|
+          envelope.add_item(attachment.to_envelope_headers, attachment.payload)
+        end
+      end
+
       client_report_headers, client_report_payload = fetch_pending_client_report
       envelope.add_item(client_report_headers, client_report_payload) if client_report_headers
 

--- a/sentry-ruby/sentry-ruby.gemspec
+++ b/sentry-ruby/sentry-ruby.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "concurrent-ruby", '~> 1.0', '>= 1.0.2'
+  spec.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
   spec.add_dependency "bigdecimal"
 end

--- a/sentry-ruby/spec/fixtures/attachment.txt
+++ b/sentry-ruby/spec/fixtures/attachment.txt
@@ -1,0 +1,1 @@
+hello world

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -435,6 +435,24 @@ RSpec.describe Sentry::Transport do
         end
       end
     end
+
+    context "event with attachments" do
+      let(:event) { client.event_from_exception(ZeroDivisionError.new("divided by 0")) }
+      let(:envelope) { subject.envelope_from_event(event) }
+
+      before do
+        event.attachments << Sentry::Attachment.new(filename: "test-1.txt", bytes: "test")
+        event.attachments << Sentry::Attachment.new(path: fixture_path("attachment.txt"))
+      end
+
+      it "sends the event and logs the action" do
+        expect(subject).to receive(:send_data)
+
+        subject.send_envelope(envelope)
+
+        expect(io.string).to match(/Sending envelope with items \[event, attachment, attachment\]/)
+      end
+    end
   end
 
   describe "#send_event" do

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -735,12 +735,13 @@ RSpec.describe Sentry do
     end
 
     it "adds a new attachment to the current scope favoring bytes over path" do
-      described_class.add_attachment(path: fixture_path("attachment.txt"), bytes: "test")
+      described_class.add_attachment(path: fixture_path("attachment.txt"), bytes: "test", content_type: "text/plain")
 
       expect(described_class.get_current_scope.attachments.size).to be(1)
 
       attachment = described_class.get_current_scope.attachments.first
       expect(attachment.filename).to eq("attachment.txt")
+      expect(attachment.content_type).to eq("text/plain")
       expect(attachment.payload).to eq("test")
     end
 

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -713,6 +713,56 @@ RSpec.describe Sentry do
     end
   end
 
+  describe ".add_attachment" do
+    it "adds a new attachment to the current scope with provided filename and bytes" do
+      described_class.add_attachment(filename: "test.txt", bytes: "test")
+
+      expect(described_class.get_current_scope.attachments.size).to be(1)
+
+      attachment = described_class.get_current_scope.attachments.first
+      expect(attachment.filename).to eq("test.txt")
+      expect(attachment.bytes).to eq("test")
+    end
+
+    it "adds a new attachment to the current scope with provided path to a file" do
+      described_class.add_attachment(path: fixture_path("attachment.txt"))
+
+      expect(described_class.get_current_scope.attachments.size).to be(1)
+
+      attachment = described_class.get_current_scope.attachments.first
+      expect(attachment.filename).to eq("attachment.txt")
+      expect(attachment.payload).to eq("hello world\n")
+    end
+
+    it "adds a new attachment to the current scope favoring bytes over path" do
+      described_class.add_attachment(path: fixture_path("attachment.txt"), bytes: "test")
+
+      expect(described_class.get_current_scope.attachments.size).to be(1)
+
+      attachment = described_class.get_current_scope.attachments.first
+      expect(attachment.filename).to eq("attachment.txt")
+      expect(attachment.payload).to eq("test")
+    end
+
+    it "raises meaningful error when path is invalid" do
+      described_class.add_attachment(path: "/not-here/oops")
+
+      expect(described_class.get_current_scope.attachments.size).to be(1)
+
+      attachment = described_class.get_current_scope.attachments.first
+
+      expect { attachment.payload }
+        .to raise_error(
+          Sentry::Attachment::PathNotFoundError,
+            "Failed to read attachment file, file not found: /not-here/oops"
+          )
+    end
+
+    it "requires either filename or path" do
+      expect { described_class.add_attachment(bytes: "test") }.to raise_error(ArgumentError, "filename or path is required")
+    end
+  end
+
   describe ".csp_report_uri" do
     it "returns the csp_report_uri generated from the main Configuration" do
       expect(Sentry.configuration).to receive(:csp_report_uri).and_call_original

--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -57,6 +57,14 @@ RSpec.configure do |config|
   end
 end
 
+def fixtures_root
+  @fixtures_root ||= Pathname(__dir__).join("fixtures")
+end
+
+def fixture_path(name)
+  fixtures_root.join(name).realpath
+end
+
 def build_exception_with_cause(cause = "exception a")
   begin
     raise cause


### PR DESCRIPTION
This adds support for attaching files to the scope like this:

```ruby
# Using path option
Sentry.add_attachment(path: "/your/attachment.txt")

# Using filename and bytes
Sentry.add_attachment(filename: "attachment.txt", bytes: File.read("/your/attachment.txt"))
```

<img width="1027" alt="Screenshot 2024-08-06 at 12 54 36" src="https://github.com/user-attachments/assets/054d8ed6-485d-457c-9acc-d132f3ee1360">

### TODO

- [x] Add `Sentry.add_attachment(**opts)`
- [x] Extend Transport and Envelope with support for sending attachments
- [x] Add support for `:path` option
- [x] Add support for figuring out `content_type` automatically based on `filename`
- [x] Ensure that either bytes or file content as a string are supported and that multi-line content is working

---

Closes #1548 