### PR TITLE
Use `Concurrent.available_processor_count` instead of `Concurrent.usable_processor_count`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- Use `Concurrent.available_processor_count` instead of `Concurrent.usable_processor_count` ([#2358](https://github.com/getsentry/sentry-ruby/pull/2358))
+
 - Support for tracing Faraday requests ([#2345](https://github.com/getsentry/sentry-ruby/pull/2345))
   - Closes [#1795](https://github.com/getsentry/sentry-ruby/issues/1795)
   - Please note that the Faraday instrumentation has some limitations in case of async requests: https://github.com/lostisland/faraday/issues/1381

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -656,11 +656,8 @@ module Sentry
     end
 
     def processor_count
-      if Concurrent.respond_to?(:usable_processor_count)
-        Concurrent.usable_processor_count
-      else
-        Concurrent.processor_count
-      end
+      available_processor_count = Concurrent.available_processor_count if Concurrent.respond_to?(:available_processor_count)
+      available_processor_count || Concurrent.processor_count
     end
   end
 end


### PR DESCRIPTION
## Description
- Fix https://github.com/getsentry/sentry-ruby/pull/2339 
- `Concurrent.usable_processor_count` changed to `Concurrent.available_processor_count` while code review so, we should use ``Concurrent.available_processor_count`.
- `Concurrent.available_processor_count` maybe return `nil`. In those cases, I think we should use `processor_count`. `aws-sdk-rails` adapted similar logic. https://github.com/aws/aws-sdk-rails/blob/38117a13edc13623e42be5c180bd7d25892faba5/lib/aws/rails/sqs_active_job/executor.rb#L12 
