### PR TITLE
Remove upper limit on graphql gem version

### DIFF
--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -15,7 +15,7 @@ gem "puma"
 gem "timecop"
 gem "stackprof" unless RUBY_PLATFORM == "java"
 
-gem "graphql", ">= 2.2.6", "< 2.3.11" if RUBY_VERSION.to_f >= 2.7
+gem "graphql", ">= 2.2.6" if RUBY_VERSION.to_f >= 2.7
 
 gem "benchmark-ips"
 gem "benchmark_driver"


### PR DESCRIPTION
The original issue should've been addressed in https://github.com/rmosolgo/graphql-ruby/pull/5052 and released in v2.3.12

(Found https://github.com/rmosolgo/graphql-ruby/issues/5050#issuecomment-2269122129 when checking #2360)

#skip-changelog