### PR TITLE
feat: Add support for $SENTRY_DEBUG and $SENTRY_SPOTLIGHT

### DIFF
--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -17,6 +17,7 @@ module Sentry
     include CustomInspection
     include LoggingHelper
     include ArgumentCheckingHelper
+    include EnvHelper
 
     # Directories to be recognized as part of your app. e.g. if you
     # have an `engines` dir at the root of your project, you may want
@@ -350,7 +351,7 @@ module Sentry
 
     def initialize
       self.app_dirs_pattern = nil
-      self.debug = false
+      self.debug = env_to_bool(ENV["SENTRY_DEBUG"])
       self.background_worker_threads = (processor_count / 2.0).ceil
       self.background_worker_max_queue = BackgroundWorker::DEFAULT_MAX_QUEUE
       self.backtrace_cleanup_callback = nil
@@ -377,7 +378,10 @@ module Sentry
       self.enable_backpressure_handling = false
       self.trusted_proxies = []
       self.dsn = ENV['SENTRY_DSN']
-      self.spotlight = false
+
+      spotlight_env = ENV['SENTRY_SPOTLIGHT']
+      spotlight_bool = env_to_bool(spotlight_env, true)
+      self.spotlight = spotlight_bool.ni? ? spotlight_env : spotlight_bool
       self.server_name = server_name_from_env
       self.instrumenter = :sentry
       self.trace_propagation_targets = [PROPAGATION_TARGETS_MATCH_ALL]

--- a/sentry-ruby/lib/sentry/utils/env_helper.rb
+++ b/sentry-ruby/lib/sentry/utils/env_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Sentry
+  module EnvHelper
+    TRUTHY_ENV_VALUES = %w(t true yes y 1 on).freeze
+    FALSY_ENV_VALUES = %w(f false no n 0 off).freeze
+
+    def env_to_bool(value, strict=false)
+      value = value.to_s
+      normalized = value.downcase
+
+      if FALSY_ENV_VALUES.include?(normalized)
+        return false
+      end
+
+      if TRUTHY_ENV_VALUES.include?(normalized)
+        return true
+      end
+
+      return strict ? nil : !(value.nil? || value.empty?)
+    end
+  end
+end


### PR DESCRIPTION
Part of getsentry/spotlight#482. Similar to sentry-python#3443 but it also adds support for `$SENTRY_DEBUG` which was lacking in the Ruby SDK.
