### PR TITLE
Fix rubocop setup (for some envs)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,4 +6,5 @@ Layout/SpaceInsideArrayLiteralBrackets:
 
 AllCops:
   Exclude:
-    - 'sentry-raven/**/*'
+    - "sentry-raven/**/*"
+    - "sentry-*/tmp/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,4 @@ gem "simplecov-cobertura", "~> 1.4"
 gem "rexml"
 
 gem "rubocop-rails-omakase"
+gem "rubocop-packaging"

--- a/sentry-delayed_job/.rubocop.yml
+++ b/sentry-delayed_job/.rubocop.yml
@@ -1,0 +1,1 @@
+../.rubocop.yml

--- a/sentry-opentelemetry/.rubocop.yml
+++ b/sentry-opentelemetry/.rubocop.yml
@@ -1,0 +1,1 @@
+../.rubocop.yml

--- a/sentry-opentelemetry/lib/sentry/opentelemetry/propagator.rb
+++ b/sentry-opentelemetry/lib/sentry/opentelemetry/propagator.rb
@@ -5,8 +5,8 @@ module Sentry
     class Propagator
       FIELDS = [SENTRY_TRACE_HEADER_NAME, BAGGAGE_HEADER_NAME].freeze
 
-      SENTRY_TRACE_KEY = ::OpenTelemetry::Context.create_key('sentry-trace')
-      SENTRY_BAGGAGE_KEY = ::OpenTelemetry::Context.create_key('sentry-baggage')
+      SENTRY_TRACE_KEY = ::OpenTelemetry::Context.create_key("sentry-trace")
+      SENTRY_BAGGAGE_KEY = ::OpenTelemetry::Context.create_key("sentry-baggage")
 
       def inject(
         carrier,
@@ -41,8 +41,8 @@ module Sentry
         trace_id, span_id, _parent_sampled = sentry_trace_data
 
         span_context = ::OpenTelemetry::Trace::SpanContext.new(
-          trace_id: [trace_id].pack('H*'),
-          span_id: [span_id].pack('H*'),
+          trace_id: [trace_id].pack("H*"),
+          span_id: [span_id].pack("H*"),
           # we simulate a sampled trace on the otel side and leave the sampling to sentry
           trace_flags: ::OpenTelemetry::Trace::TraceFlags::SAMPLED,
           remote: true

--- a/sentry-opentelemetry/lib/sentry/opentelemetry/span_processor.rb
+++ b/sentry-opentelemetry/lib/sentry/opentelemetry/span_processor.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'singleton'
+require "singleton"
 
 module Sentry
   module OpenTelemetry
@@ -151,14 +151,14 @@ module Sentry
         if (http_status_code = otel_span.attributes[SEMANTIC_CONVENTIONS::HTTP_STATUS_CODE])
           sentry_span.set_http_status(http_status_code)
         elsif (status_code = otel_span.status.code)
-          status = [0, 1].include?(status_code) ? 'ok' : 'unknown_error'
+          status = [0, 1].include?(status_code) ? "ok" : "unknown_error"
           sentry_span.set_status(status)
         end
       end
 
       def update_span_with_otel_data(sentry_span, otel_span)
         update_span_status(sentry_span, otel_span)
-        sentry_span.set_data('otel.kind', otel_span.kind)
+        sentry_span.set_data("otel.kind", otel_span.kind)
         otel_span.attributes&.each { |k, v| sentry_span.set_data(k, v) }
 
         op, description = parse_span_description(otel_span)

--- a/sentry-rails/.rubocop.yml
+++ b/sentry-rails/.rubocop.yml
@@ -1,0 +1,1 @@
+../.rubocop.yml

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -6,7 +6,7 @@ gemspec
 gem "sentry-ruby", path: "../sentry-ruby"
 
 platform :jruby do
-  gem 'activerecord-jdbcmysql-adapter'
+  gem "activerecord-jdbcmysql-adapter"
   gem "jdbc-sqlite3"
 end
 

--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -2,7 +2,7 @@ module Sentry
   module Rails
     class CaptureExceptions < Sentry::Rack::CaptureExceptions
       RAILS_7_1 = Gem::Version.new(::Rails.version) >= Gem::Version.new("7.1.0.alpha")
-      SPAN_ORIGIN = 'auto.http.rails'.freeze
+      SPAN_ORIGIN = "auto.http.rails".freeze
 
       def initialize(_)
         super

--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -31,20 +31,20 @@ module Sentry
 
   module Rails
     IGNORE_DEFAULT = [
-      'AbstractController::ActionNotFound',
-      'ActionController::BadRequest',
-      'ActionController::InvalidAuthenticityToken',
-      'ActionController::InvalidCrossOriginRequest',
-      'ActionController::MethodNotAllowed',
-      'ActionController::NotImplemented',
-      'ActionController::ParameterMissing',
-      'ActionController::RoutingError',
-      'ActionController::UnknownAction',
-      'ActionController::UnknownFormat',
-      'ActionDispatch::Http::MimeNegotiation::InvalidType',
-      'ActionController::UnknownHttpMethod',
-      'ActionDispatch::Http::Parameters::ParseError',
-      'ActiveRecord::RecordNotFound'
+      "AbstractController::ActionNotFound",
+      "ActionController::BadRequest",
+      "ActionController::InvalidAuthenticityToken",
+      "ActionController::InvalidCrossOriginRequest",
+      "ActionController::MethodNotAllowed",
+      "ActionController::NotImplemented",
+      "ActionController::ParameterMissing",
+      "ActionController::RoutingError",
+      "ActionController::UnknownAction",
+      "ActionController::UnknownFormat",
+      "ActionDispatch::Http::MimeNegotiation::InvalidType",
+      "ActionController::UnknownHttpMethod",
+      "ActionDispatch::Http::Parameters::ParseError",
+      "ActiveRecord::RecordNotFound"
     ].freeze
 
     ACTIVE_SUPPORT_LOGGER_SUBSCRIPTION_ITEMS_DEFAULT = {

--- a/sentry-rails/lib/sentry/rails/controller_transaction.rb
+++ b/sentry-rails/lib/sentry/rails/controller_transaction.rb
@@ -1,7 +1,7 @@
 module Sentry
   module Rails
     module ControllerTransaction
-      SPAN_ORIGIN = 'auto.view.rails'.freeze
+      SPAN_ORIGIN = "auto.view.rails".freeze
 
       def self.included(base)
         base.prepend_around_action(:sentry_around_action)

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -94,14 +94,14 @@ module Sentry
 
     def inject_breadcrumbs_logger
       if Sentry.configuration.breadcrumbs_logger.include?(:active_support_logger)
-        require 'sentry/rails/breadcrumb/active_support_logger'
+        require "sentry/rails/breadcrumb/active_support_logger"
         Sentry::Rails::Breadcrumb::ActiveSupportLogger.inject(Sentry.configuration.rails.active_support_logger_subscription_items)
       end
 
       if Sentry.configuration.breadcrumbs_logger.include?(:monotonic_active_support_logger)
         return warn "Usage of `monotonic_active_support_logger` require a version of Rails >= 6.1, please upgrade your Rails version or use another logger" if ::Rails.version.to_f < 6.1
 
-        require 'sentry/rails/breadcrumb/monotonic_active_support_logger'
+        require "sentry/rails/breadcrumb/monotonic_active_support_logger"
         Sentry::Rails::Breadcrumb::MonotonicActiveSupportLogger.inject
       end
     end

--- a/sentry-resque/.rubocop.yml
+++ b/sentry-resque/.rubocop.yml
@@ -1,0 +1,1 @@
+../.rubocop.yml

--- a/sentry-resque/lib/sentry/resque.rb
+++ b/sentry-resque/lib/sentry/resque.rb
@@ -40,14 +40,14 @@ module Sentry
 
               finish_transaction(transaction, 200)
             rescue Exception => exception
-              klass = if payload['class'].respond_to?(:constantize)
-                payload['class'].constantize
+              klass = if payload["class"].respond_to?(:constantize)
+                payload["class"].constantize
               else
-                Object.const_get(payload['class'])
+                Object.const_get(payload["class"])
               end
 
               raise if Sentry.configuration.resque.report_after_job_retries &&
-                       defined?(::Resque::Plugins::Retry) == 'constant' &&
+                       defined?(::Resque::Plugins::Retry) == "constant" &&
                        klass.is_a?(::Resque::Plugins::Retry) &&
                        !klass.retry_limit_reached?
 

--- a/sentry-sidekiq/.rubocop.yml
+++ b/sentry-sidekiq/.rubocop.yml
@@ -1,0 +1,1 @@
+../.rubocop.yml

--- a/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
@@ -1,4 +1,4 @@
-require 'sentry/sidekiq/context_filter'
+require "sentry/sidekiq/context_filter"
 
 module Sentry
   module Sidekiq

--- a/sentry-sidekiq/lib/sentry/sidekiq/sentry_context_middleware.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/sentry_context_middleware.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'sentry/sidekiq/context_filter'
+require "sentry/sidekiq/context_filter"
 
 module Sentry
   module Sidekiq


### PR DESCRIPTION
This makes it possible to use rubocop when working from inside a subdir.
It also fixes running rubocop from the root where it would actually use
the config that we have. Previously it would ignore it for some reason,
symlinking did the trick.

The rubocop-packaging was needed because something somewhere tries to
require it.

#skip-changelog