### PR TITLE
Support Rails 7.2 on CI

### DIFF
--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -43,6 +43,9 @@ jobs:
           - { ruby_version: "2.7", rails_version: 5.2.0 }
           - { ruby_version: "2.7", rails_version: 6.0.0 }
           - { ruby_version: "2.7", rails_version: 6.1.0 }
+          - { ruby_version: "3.1", rails_version: 7.2.0 }
+          - { ruby_version: "3.2", rails_version: 7.2.0 }
+          - { ruby_version: "3.3", rails_version: 7.2.0 }
           - { ruby_version: "jruby", rails_version: 6.1.0 }
           - {
               ruby_version: "3.2",

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -24,11 +24,14 @@ else
   end
 end
 
-if rails_version >= Gem::Version.new("7.2.0.alpha")
+if rails_version >= Gem::Version.new("8.0.0.alpha")
   gem "rails", github: "rails/rails"
+  gem "rspec-rails"
 elsif rails_version >= Gem::Version.new("7.1.0")
   gem "rails", "~> #{rails_version}"
+  gem "rspec-rails"
 else
+  gem "rspec-rails", "~> 4.0"
   gem "rails", "~> #{rails_version}"
   gem "psych", "~> 3.0.0"
 end
@@ -39,7 +42,6 @@ gem "sprockets-rails"
 
 gem "sidekiq"
 
-gem "rspec-rails", "~> 4.0"
 
 ruby_version = Gem::Version.new(RUBY_VERSION)
 

--- a/sentry-rails/spec/dummy/test_rails_app/app.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/app.rb
@@ -9,7 +9,7 @@ require "action_controller/railtie"
 
 require 'sentry/rails'
 
-ActiveSupport::Deprecation.silenced = true
+ActiveSupport::Deprecation.silenced = true if ActiveSupport::Deprecation.respond_to?(:silenced)
 ActiveRecord::Base.logger = Logger.new(nil)
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "db")
 
@@ -56,6 +56,13 @@ def make_basic_app(&block)
   app.config.logger = ActiveSupport::Logger.new(nil)
   app.config.eager_load = true
   app.config.active_job.queue_adapter = :test
+
+  # Eager load namespaces can be accumulated after repeated initializations and make initialization
+  # slower after each run
+  # This is especially obvious in Rails 7.2, because of https://github.com/rails/rails/pull/49987, but other constants's
+  # accumulation can also cause slowdown
+  # Because this is not necessary for the test, we can simply clear it here
+  app.config.eager_load_namespaces.clear
 
   configure_app(app)
 

--- a/sentry-rails/spec/dummy/test_rails_app/app.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/app.rb
@@ -9,7 +9,6 @@ require "action_controller/railtie"
 
 require 'sentry/rails'
 
-ActiveSupport::Deprecation.silenced = true if ActiveSupport::Deprecation.respond_to?(:silenced)
 ActiveRecord::Base.logger = Logger.new(nil)
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "db")
 
@@ -50,6 +49,7 @@ def make_basic_app(&block)
     end
   end
 
+  app.config.active_support.deprecation = :silence
   app.config.action_controller.view_paths = "spec/dummy/test_rails_app"
   app.config.hosts = nil
   app.config.secret_key_base = "test"

--- a/sentry-rails/spec/isolated/active_job_activation.rb
+++ b/sentry-rails/spec/isolated/active_job_activation.rb
@@ -2,6 +2,8 @@
 
 # for https://github.com/getsentry/sentry-ruby/issues/1249
 require "active_job/railtie"
+# Rails 7.2 added HealthCheckController, which requires ActionController
+require "action_controller/railtie"
 require "active_support/all"
 require "sentry/rails"
 require "minitest/autorun"

--- a/sentry-rails/spec/sentry/generator_spec.rb
+++ b/sentry-rails/spec/sentry/generator_spec.rb
@@ -4,8 +4,14 @@ require "fileutils"
 require "rails/generators/test_case"
 require "generators/sentry_generator"
 
+behavior_module = if defined?(Rails::Generators::Testing::Behaviour)
+  Rails::Generators::Testing::Behaviour
+else
+  Rails::Generators::Testing::Behavior
+end
+
 RSpec.describe SentryGenerator do
-  include ::Rails::Generators::Testing::Behaviour
+  include behavior_module
   include FileUtils
   self.destination File.expand_path('../../tmp', __dir__)
   self.generator_class = described_class

--- a/sentry-rails/spec/sentry/rails/client_spec.rb
+++ b/sentry-rails/spec/sentry/rails/client_spec.rb
@@ -5,8 +5,16 @@ RSpec.describe Sentry::Client, type: :request, retry: 3, skip: Gem::Version.new(
     Sentry.get_current_client.transport
   end
 
+  let(:expected_initial_active_record_connections_count) do
+    if Gem::Version.new(Rails.version) < Gem::Version.new('7.2.0')
+      1
+    else
+      0
+    end
+  end
+
   before do
-    expect(ActiveRecord::Base.connection_pool.stat[:busy]).to eq(1)
+    expect(ActiveRecord::Base.connection_pool.stat[:busy]).to eq(expected_initial_active_record_connections_count)
   end
 
   def send_events
@@ -35,7 +43,7 @@ RSpec.describe Sentry::Client, type: :request, retry: 3, skip: Gem::Version.new(
 
       expect(transport.events.count).to eq(5)
 
-      expect(ActiveRecord::Base.connection_pool.stat[:busy]).to eq(1)
+      expect(ActiveRecord::Base.connection_pool.stat[:busy]).to eq(expected_initial_active_record_connections_count)
     end
   end
 
@@ -53,7 +61,7 @@ RSpec.describe Sentry::Client, type: :request, retry: 3, skip: Gem::Version.new(
 
       expect(transport.events.count).to eq(5)
 
-      expect(ActiveRecord::Base.connection_pool.stat[:busy]).to eq(1)
+      expect(ActiveRecord::Base.connection_pool.stat[:busy]).to eq(expected_initial_active_record_connections_count)
     end
   end
 end


### PR DESCRIPTION
#skip-changelog

On my machine, running `sentry-rails`'s full test suite with `rake test` against Rails 7.1 takes less than 8 seconds. But it now takes ~33 seconds against Rails 7.2 even after I solved the slowdown issue caused by the eager load namespace accumulation issue. That said, I think we can start running tests against Rails 7.2 and optimize the test setup further in another PR.