### PR TITLE
Add a generic way for skipping specs

### DIFF
--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Sentry::Event do
     end
   end
 
-  context 'rack context specified', rack: true do
+  context 'rack context specified', when: :rack_available? do
     require 'stringio'
 
     before do

--- a/sentry-ruby/spec/sentry/profiler_spec.rb
+++ b/sentry-ruby/spec/sentry/profiler_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
-return unless defined?(StackProf)
-
-RSpec.describe Sentry::Profiler do
+RSpec.describe Sentry::Profiler, when: :stack_prof_installed? do
   before do
     perform_basic_setup do |config|
       config.traces_sample_rate = 1.0

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
-return unless defined?(Rack)
-
-RSpec.describe Sentry::Rack::CaptureExceptions, rack: true do
+RSpec.describe Sentry::Rack::CaptureExceptions, when: :rack_available? do
   let(:exception) { ZeroDivisionError.new("divided by 0") }
   let(:additional_headers) { {} }
   let(:env) { Rack::MockRequest.env_for("/test", additional_headers) }

--- a/sentry-ruby/spec/sentry/scope/setters_spec.rb
+++ b/sentry-ruby/spec/sentry/scope/setters_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Sentry::Scope do
     new_breadcrumb
   end
 
-  describe "#set_rack_env", rack: true do
+  describe "#set_rack_env", when: :rack_available? do
     let(:env) do
       Rack::MockRequest.env_for("/test", {})
     end

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe Sentry::Scope do
       expect(event.dynamic_sampling_context).to eq(subject.propagation_context.get_dynamic_sampling_context)
     end
 
-    context "with Rack", rack: true do
+    context "with Rack", when: :rack_available? do
       let(:env) do
         Rack::MockRequest.env_for("/test", {})
       end

--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -46,14 +46,26 @@ RSpec.configure do |config|
     ENV.delete('RACK_ENV')
   end
 
-  config.before(:each, rack: true) do
-    skip("skip rack related tests") unless defined?(Rack)
+  config.before(:each, when: true) do |example|
+    meth = example.metadata[:when]
+
+    skip("Skipping because `when: #{meth}` returned false") unless TestHelpers.public_send(meth, example)
   end
 
   RSpec::Matchers.define :have_recorded_lost_event do |reason, data_category, num: 1|
     match do |transport|
       expect(transport.discarded_events[[reason, data_category]]).to eq(num)
     end
+  end
+end
+
+module TestHelpers
+  def self.stack_prof_installed?(_example)
+    defined?(StackProf)
+  end
+
+  def self.rack_available?(_example)
+    defined?(Rack)
   end
 end
 


### PR DESCRIPTION
This makes skipping specs a bit better and more RSpec'y 

#skip-changelog