### PR TITLE
Improve sidekiq-cron patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
+### Features
+
 - Add support for $SENTRY_DEBUG and $SENTRY_SPOTLIGHT ([#2374](https://github.com/getsentry/sentry-ruby/pull/2374))
+- Support human readable intervals in `sidekiq-cron` ([#2387](https://github.com/getsentry/sentry-ruby/pull/2387))
 
 ## 5.19.0
 

--- a/sentry-sidekiq/lib/sentry/sidekiq/cron/job.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/cron/job.rb
@@ -28,8 +28,8 @@ module Sentry
           unless klass_const.send(:ancestors).include?(Sentry::Cron::MonitorCheckIns)
             klass_const.send(:include, Sentry::Cron::MonitorCheckIns)
             klass_const.send(:sentry_monitor_check_ins,
-                             slug: name,
-                             monitor_config: Sentry::Cron::MonitorConfig.from_crontab(cron))
+                             slug: name.to_s,
+                             monitor_config: Sentry::Cron::MonitorConfig.from_crontab(parsed_cron.original))
           end
 
           true

--- a/sentry-sidekiq/spec/fixtures/sidekiq-cron-schedule.yml
+++ b/sentry-sidekiq/spec/fixtures/sidekiq-cron-schedule.yml
@@ -6,6 +6,10 @@ manual:
   cron: "* * * * *"
   class: "SadWorkerWithCron"
 
+human_readable_cron:
+  cron: "every 5 minutes"
+  class: HappyWorkerWithHumanReadableCron
+
 invalid_cron:
   cron: "not a crontab"
   class: "ReportingWorker"

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -139,6 +139,8 @@ class HappyWorkerForCron < HappyWorker; end
 class HappyWorkerForScheduler < HappyWorker; end
 class HappyWorkerForSchedulerWithTimezone < HappyWorker; end
 class EveryHappyWorker < HappyWorker; end
+class HappyWorkerWithHumanReadableCron < HappyWorker; end
+class HappyWorkerWithSymbolName < HappyWorker; end
 
 class HappyWorkerWithCron < HappyWorker
   include Sentry::Cron::MonitorCheckIns


### PR DESCRIPTION
## Description
Describe your changes:

I've added two changes:

1st `name.to_s` cause one may provide hash with symbols to `load_from_hash` and `name` ends up being a symbol, and then it ends up raising an error in `sentry-ruby/lib/sentry/hub.rb` cause it expects a string...
```ruby
    def capture_check_in(slug, status, **options)
      check_argument_type!(slug, ::String)
```

2nd change is much more important though, it's required to support natural-language-format, because the current version doesn't create a monitor successfully.  natural language format is something like `every 5 minutes` which gets translated to `'*/5 * * * *'` as you can see it in the tests

https://github.com/sidekiq-cron/sidekiq-cron?tab=readme-ov-file#natural-language-formats