### PR TITLE
Set default app dirs pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for $SENTRY_DEBUG and $SENTRY_SPOTLIGHT ([#2374](https://github.com/getsentry/sentry-ruby/pull/2374))
 - Support human readable intervals in `sidekiq-cron` ([#2387](https://github.com/getsentry/sentry-ruby/pull/2387))
+- Set default app dirs pattern ([#2390](https://github.com/getsentry/sentry-ruby/pull/2390))
 
 ## 5.19.0
 

--- a/sentry-ruby/lib/sentry/backtrace.rb
+++ b/sentry-ruby/lib/sentry/backtrace.rb
@@ -80,8 +80,6 @@ module Sentry
       end
     end
 
-    APP_DIRS_PATTERN = /(bin|exe|app|config|lib|test|spec)/.freeze
-
     # holder for an Array of Backtrace::Line instances
     attr_reader :lines
 
@@ -91,7 +89,7 @@ module Sentry
       ruby_lines = backtrace_cleanup_callback.call(ruby_lines) if backtrace_cleanup_callback
 
       in_app_pattern ||= begin
-        Regexp.new("^(#{project_root}/)?#{app_dirs_pattern || APP_DIRS_PATTERN}")
+        Regexp.new("^(#{project_root}/)?#{app_dirs_pattern}")
       end
 
       lines = ruby_lines.to_a.map do |unparsed_line|

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -23,6 +23,8 @@ module Sentry
     # have an `engines` dir at the root of your project, you may want
     # to set this to something like /(app|config|engines|lib)/
     #
+    # The default is value is /(bin|exe|app|config|lib|test|spec)/
+    #
     # @return [Regexp, nil]
     attr_accessor :app_dirs_pattern
 
@@ -336,6 +338,8 @@ module Sentry
 
     DEFAULT_PATCHES = %i[redis puma http].freeze
 
+    APP_DIRS_PATTERN = /(bin|exe|app|config|lib|test|spec)/.freeze
+
     class << self
       # Post initialization callbacks are called at the end of initialization process
       # allowing extending the configuration of sentry-ruby by multiple extensions
@@ -350,7 +354,7 @@ module Sentry
     end
 
     def initialize
-      self.app_dirs_pattern = nil
+      self.app_dirs_pattern = APP_DIRS_PATTERN
       self.debug = Sentry::Utils::EnvHelper.env_to_bool(ENV["SENTRY_DEBUG"])
       self.background_worker_threads = (processor_count / 2.0).ceil
       self.background_worker_max_queue = BackgroundWorker::DEFAULT_MAX_QUEUE

--- a/sentry-ruby/lib/sentry/profiler.rb
+++ b/sentry-ruby/lib/sentry/profiler.rb
@@ -21,7 +21,7 @@ module Sentry
       @profiling_enabled = defined?(StackProf) && configuration.profiling_enabled?
       @profiles_sample_rate = configuration.profiles_sample_rate
       @project_root = configuration.project_root
-      @app_dirs_pattern = configuration.app_dirs_pattern || Backtrace::APP_DIRS_PATTERN
+      @app_dirs_pattern = configuration.app_dirs_pattern
       @in_app_pattern = Regexp.new("^(#{@project_root}/)?#{@app_dirs_pattern}")
     end
 

--- a/sentry-ruby/spec/sentry/backtrace/lines_spec.rb
+++ b/sentry-ruby/spec/sentry/backtrace/lines_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Sentry::Backtrace::Line do
 
   let(:in_app_pattern) do
     project_root = Sentry.configuration.project_root&.to_s
-    Regexp.new("^(#{project_root}/)?#{Sentry::Backtrace::APP_DIRS_PATTERN}")
+    Regexp.new("^(#{project_root}/)?#{Sentry::Configuration::APP_DIRS_PATTERN}")
   end
 
   describe ".parse" do

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe Sentry::Transport do
 
         let(:in_app_pattern) do
           project_root = "/fake/project_root"
-          Regexp.new("^(#{project_root}/)?#{Sentry::Backtrace::APP_DIRS_PATTERN}")
+          Regexp.new("^(#{project_root}/)?#{Sentry::Configuration::APP_DIRS_PATTERN}")
         end
         let(:frame_list_limit) { 500 }
         let(:frame_list_size) { frame_list_limit * 20 }


### PR DESCRIPTION
Instead of falling back to the default app dirs pattern when `config.app_dirs_pattern` is `nil`, we can simply set it to `APP_DIRS_PATTERN` by default.

This means we don't need to always check if `config.app_dirs_pattern` is set and can simply use it.