### PR TITLE
Verifies that client is available before sending breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for $SENTRY_DEBUG and $SENTRY_SPOTLIGHT ([#2374](https://github.com/getsentry/sentry-ruby/pull/2374))
 - Support human readable intervals in `sidekiq-cron` ([#2387](https://github.com/getsentry/sentry-ruby/pull/2387))
 - Set default app dirs pattern ([#2390](https://github.com/getsentry/sentry-ruby/pull/2390))
+- Verifies presence of client before adding a breadcrumb ([#2394](https://github.com/getsentry/sentry-ruby/pull/2394))
 
 ## 5.19.0
 

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -214,6 +214,7 @@ module Sentry
     end
 
     def add_breadcrumb(breadcrumb, hint: {})
+      return unless current_client
       return unless configuration.enabled_in_current_env?
 
       if before_breadcrumb = current_client.configuration.before_breadcrumb


### PR DESCRIPTION
## Description

During build, we have encountered situations where Sentry wants to send
a `breadcrumb` but it fails to accomplish the task because of
`NoMethodError: undefined method `configuration' for nil:NilClass`.
After one of this error is triggered, Sentry fails to work at all,
passing from 0 to several hundred errors in our pipeline, and then back
to zero once we start rebuilding.

Our pipeline tests using parallelism and there is a ton of concurrency,
so we believe that has something to do with it.

The backtrace points out to `Hub#add_breadcrumb` and inside of it to
`configuration`. It is possible that while the new "local" hub is
available, the client is not and fails to work.

We have observed that several other method have checks
in place to verify that the client is really available but not on
`add_breadcrumb` so we added a verification before starting the rest
of the process.


