### PR TITLE
Prevent Hub from having nil scope and client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 5.20.0
+## 5.20.0
 
 - Add support for `$SENTRY_DEBUG` and `$SENTRY_SPOTLIGHT` ([#2374](https://github.com/getsentry/sentry-ruby/pull/2374))
 - Support human readable intervals in `sidekiq-cron` ([#2387](https://github.com/getsentry/sentry-ruby/pull/2387))
@@ -10,6 +10,7 @@
 - Fix error events missing a DSC when there's an active span ([#2408](https://github.com/getsentry/sentry-ruby/pull/2408))
 - Verifies presence of client before adding a breadcrumb ([#2394](https://github.com/getsentry/sentry-ruby/pull/2394))
 - Fix `Net:HTTP` integration for non-ASCII URI's ([#2417](https://github.com/getsentry/sentry-ruby/pull/2417))
+- Prevent Hub from having nil scope and client ([#2402](https://github.com/getsentry/sentry-ruby/pull/2402))
 
 ## 5.19.0
 

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -73,7 +73,13 @@ module Sentry
     end
 
     def pop_scope
-      @stack.pop
+      if @stack.size > 1
+        @stack.pop
+      else
+        # We never want to enter a situation where we have no scope and no client
+        client = current_client
+        @stack = [Layer.new(client, Scope.new)]
+      end
     end
 
     def start_transaction(transaction: nil, custom_sampling_context: {}, instrumenter: :sentry, **options)


### PR DESCRIPTION
`Hub#pop_scope` currently can cause a Hub to have a nil scope and client, which would highly likely lead of errors. For example, `Hub#configuration` would simply cause `NoMethodError`.

This commit prevents that from ever happening by making sure that `Hub#pop_scope` would at least leave a brand new scope and the old client on the stack.
