### PR TITLE
Add child_spans for Sidekiq Queue instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Features
 
 - Add `include_sentry_event` matcher for RSpec [#2424](https://github.com/getsentry/sentry-ruby/pull/2424)
-- Add support for Sentry Cache instrumentation, when using Rails.cache [#2380](https://github.com/getsentry/sentry-ruby/pull/2380)
+- Add support for Sentry Cache instrumentation, when using Rails.cache ([#2380](https://github.com/getsentry/sentry-ruby/pull/2380)) (MemoryStore and FileStore require Rails 8.0+)
+- Add support for Queue Instrumentation for Sidekiq. [#2403](https://github.com/getsentry/sentry-ruby/pull/2403)
 
     Note: MemoryStore and FileStore require Rails 8.0+
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 - Add `include_sentry_event` matcher for RSpec [#2424](https://github.com/getsentry/sentry-ruby/pull/2424)
-- Add support for Sentry Cache instrumentation, when using Rails.cache ([#2380](https://github.com/getsentry/sentry-ruby/pull/2380)) (MemoryStore and FileStore require Rails 8.0+)
+- Add support for Sentry Cache instrumentation, when using Rails.cache ([#2380](https://github.com/getsentry/sentry-ruby/pull/2380))
 - Add support for Queue Instrumentation for Sidekiq. [#2403](https://github.com/getsentry/sentry-ruby/pull/2403)
 
     Note: MemoryStore and FileStore require Rails 8.0+

--- a/sentry-sidekiq/Gemfile
+++ b/sentry-sidekiq/Gemfile
@@ -25,4 +25,6 @@ end
 
 gem "rails", "> 5.0.0"
 
+gem "timecop"
+
 eval_gemfile File.expand_path("../Gemfile", __dir__)

--- a/sentry-sidekiq/lib/sentry/sidekiq/sentry_context_middleware.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/sentry_context_middleware.rb
@@ -37,7 +37,7 @@ module Sentry
 
             yield
           end
-        rescue => ex
+        rescue
           finish_transaction(transaction, 500)
           raise
         end

--- a/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
     it "adds a queue.process spans" do
       Timecop.freeze do
         execute_worker(processor, HappyWorker)
-        execute_worker(processor, HappyWorker, jid: '123456', timecop_delay: Time.now + 1.days)
+        execute_worker(processor, HappyWorker, jid: '123456', timecop_delay: Time.now + 1.day)
 
         expect(transport.events.count).to eq(2)
 
@@ -86,7 +86,7 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
         expect(transaction.spans.count).to eq(0)
         expect(transaction.contexts[:trace][:data]['messaging.message.id']).to eq('123456') # Explicitly set above.
         expect(transaction.contexts[:trace][:data]['messaging.destination.name']).to eq('default')
-        expect(transaction.contexts[:trace][:data]['messaging.message.receive.latency']).to eq(1.days.to_i * 1000)
+        expect(transaction.contexts[:trace][:data]['messaging.message.receive.latency']).to eq(1.day.to_i * 1000)
       end
     end
 

--- a/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
     it "adds a queue.process spans" do
       Timecop.freeze do
         execute_worker(processor, HappyWorker)
-        execute_worker(processor, HappyWorker, jid: '123456', timecop_delay: Time.now + 1.day)
+        execute_worker(processor, HappyWorker, jid: '123456', timecop_delay: Time.now + 1.days)
 
         expect(transport.events.count).to eq(2)
 
@@ -86,7 +86,7 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
         expect(transaction.spans.count).to eq(0)
         expect(transaction.contexts[:trace][:data]['messaging.message.id']).to eq('123456') # Explicitly set above.
         expect(transaction.contexts[:trace][:data]['messaging.destination.name']).to eq('default')
-        expect(transaction.contexts[:trace][:data]['messaging.message.receive.latency']).to eq(1.day.to_i * 1000)
+        expect(transaction.contexts[:trace][:data]['messaging.message.receive.latency']).to eq(1.days.to_i * 1000)
       end
     end
 

--- a/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
     it "adds a queue.process spans" do
       Timecop.freeze do
         execute_worker(processor, HappyWorker)
-        execute_worker(processor, HappyWorker, jid: '123456', timecop_delay: Time.now + 1.day)
+        execute_worker(processor, HappyWorker, jid: '123456', timecop_delay: Time.now + 86400)
 
         expect(transport.events.count).to eq(2)
 
@@ -86,7 +86,7 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
         expect(transaction.spans.count).to eq(0)
         expect(transaction.contexts[:trace][:data]['messaging.message.id']).to eq('123456') # Explicitly set above.
         expect(transaction.contexts[:trace][:data]['messaging.destination.name']).to eq('default')
-        expect(transaction.contexts[:trace][:data]['messaging.message.receive.latency']).to eq(1.day.to_i * 1000)
+        expect(transaction.contexts[:trace][:data]['messaging.message.receive.latency']).to eq(86400000)
       end
     end
 

--- a/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
         execute_worker(processor, HappyWorker, trace_propagation_headers: trace_propagation_headers)
 
         expect(transport.events.count).to eq(1)
+
         transaction = transport.events[0]
         expect(transaction).not_to be_nil
         expect(transaction.contexts.dig(:trace, :trace_id)).to eq(parent_transaction.trace_id)

--- a/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
@@ -73,17 +73,17 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
 
       transaction = transport.events[0]
       expect(transaction).not_to be_nil
-      expect(transaction.spans.count).to eq(1)
-      expect(transaction.spans[0][:data]['messaging.message.id']).to eq('123123') # Default defined in #execute_worker
-      expect(transaction.spans[0][:data]['messaging.destination.name']).to eq('default')
-      expect(transaction.spans[0][:data]['messaging.message.retry.count']).to eq(0)
+      expect(transaction.spans.count).to eq(0)
+      expect(transaction.contexts[:trace][:data]['messaging.message.id']).to eq('123123') # Default defined in #execute_worker
+      expect(transaction.contexts[:trace][:data]['messaging.destination.name']).to eq('default')
+      expect(transaction.contexts[:trace][:data]['messaging.message.retry.count']).to eq(0)
 
       transaction = transport.events[1]
       expect(transaction).not_to be_nil
-      expect(transaction.spans.count).to eq(1)
-      expect(transaction.spans[0][:data]['messaging.message.id']).to eq('123456') # Explicitly set above.
-      expect(transaction.spans[0][:data]['messaging.destination.name']).to eq('default')
-      expect(transaction.spans[0][:data]['messaging.message.retry.count']).to eq(0)
+      expect(transaction.spans.count).to eq(0)
+      expect(transaction.contexts[:trace][:data]['messaging.message.id']).to eq('123456') # Explicitly set above.
+      expect(transaction.contexts[:trace][:data]['messaging.destination.name']).to eq('default')
+      expect(transaction.contexts[:trace][:data]['messaging.message.retry.count']).to eq(0)
     end
 
     context "with trace_propagation_headers" do

--- a/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Sentry::Sidekiq do
       expect(transaction.contexts.dig(:trace, :trace_id)).to be_a(String)
       expect(transaction.contexts.dig(:trace, :span_id)).to be_a(String)
       expect(transaction.contexts.dig(:trace, :status)).to eq("ok")
-      expect(transaction.contexts.dig(:trace, :op)).to eq("queue.sidekiq")
+      expect(transaction.contexts.dig(:trace, :op)).to eq("queue.process")
     end
 
     it "records transaction with exception" do

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -234,7 +234,9 @@ def execute_worker(processor, klass, **options)
     options[k.to_sym] = v
   end
 
-  msg = Sidekiq.dump_json(created_at: Time.now.to_f, jid: "123123", class: klass, args: [], **options)
+  jid = options.delete(:jid) || "123123"
+
+  msg = Sidekiq.dump_json(created_at: Time.now.to_f, enqueued_at: Time.now.to_f, jid: jid, class: klass, args: [], **options)
   work = Sidekiq::BasicFetch::UnitOfWork.new('queue:default', msg)
   process_work(processor, work)
 end

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -229,13 +229,12 @@ end
 
 def execute_worker(processor, klass, **options)
   klass_options = klass.sidekiq_options_hash || {}
-
   # for Ruby < 2.6
   klass_options.each do |k, v|
     options[k.to_sym] = v
   end
 
-  msg = Sidekiq.dump_json(jid: "123123", class: klass, args: [], **options)
+  msg = Sidekiq.dump_json(created_at: Time.now.to_f, jid: "123123", class: klass, args: [], **options)
   work = Sidekiq::BasicFetch::UnitOfWork.new('queue:default', msg)
   process_work(processor, work)
 end

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -237,8 +237,11 @@ def execute_worker(processor, klass, **options)
   jid = options.delete(:jid) || "123123"
 
   msg = Sidekiq.dump_json(created_at: Time.now.to_f, enqueued_at: Time.now.to_f, jid: jid, class: klass, args: [], **options)
+  Timecop.freeze(options[:timecop_delay]) if options[:timecop_delay]
   work = Sidekiq::BasicFetch::UnitOfWork.new('queue:default', msg)
   process_work(processor, work)
+ensure
+  Timecop.return if options[:timecop_delay]
 end
 
 def process_work(processor, work)

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -235,13 +235,14 @@ def execute_worker(processor, klass, **options)
   end
 
   jid = options.delete(:jid) || "123123"
+  timecop_delay = options.delete(:timecop_delay)
 
   msg = Sidekiq.dump_json(created_at: Time.now.to_f, enqueued_at: Time.now.to_f, jid: jid, class: klass, args: [], **options)
-  Timecop.freeze(options[:timecop_delay]) if options[:timecop_delay]
+  Timecop.freeze(timecop_delay) if timecop_delay
   work = Sidekiq::BasicFetch::UnitOfWork.new('queue:default', msg)
   process_work(processor, work)
 ensure
-  Timecop.return if options[:timecop_delay]
+  Timecop.return if timecop_delay
 end
 
 def process_work(processor, work)


### PR DESCRIPTION
Implements #2322 for Sidekiq.

## Description
Adds support for Sentry Queues page (With predefined span `op` names)

https://docs.sentry.io/platforms/ruby/guides/sidekiq/tracing/instrumentation/custom-instrumentation/queues-module/

<img width="1248" alt="Screenshot 2024-09-16 at 15 45 15" src="https://github.com/user-attachments/assets/d784f634-8509-4185-a6d4-6e6b9a0d58f0">
