### PR TITLE
Fix error events missing a DSC when there's an active span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Support human readable intervals in `sidekiq-cron` ([#2387](https://github.com/getsentry/sentry-ruby/pull/2387))
 - Set default app dirs pattern ([#2390](https://github.com/getsentry/sentry-ruby/pull/2390))
 
+### Bug Fixes
+
+- Fix error events missing a DSC when there's an active span ([#2408](https://github.com/getsentry/sentry-ruby/pull/2408))
+
 ## 5.19.0
 
 ### Features

--- a/sentry-ruby/lib/sentry/propagation_context.rb
+++ b/sentry-ruby/lib/sentry/propagation_context.rb
@@ -108,7 +108,7 @@ module Sentry
     end
 
     # Returns the Dynamic Sampling Context from the baggage.
-    # @return [String, nil]
+    # @return [Hash, nil]
     def get_dynamic_sampling_context
       get_baggage&.dynamic_sampling_context
     end

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -62,6 +62,7 @@ module Sentry
 
       if span
         event.contexts[:trace] ||= span.get_trace_context
+        event.dynamic_sampling_context ||= span.get_dynamic_sampling_context
       else
         event.contexts[:trace] ||= propagation_context.get_trace_context
         event.dynamic_sampling_context ||= propagation_context.get_dynamic_sampling_context

--- a/sentry-ruby/lib/sentry/span.rb
+++ b/sentry-ruby/lib/sentry/span.rb
@@ -160,6 +160,12 @@ module Sentry
       transaction.get_baggage&.serialize
     end
 
+    # Returns the Dynamic Sampling Context from the transaction baggage.
+    # @return [Hash, nil]
+    def get_dynamic_sampling_context
+      transaction.get_baggage&.dynamic_sampling_context
+    end
+
     # @return [Hash]
     def to_hash
       hash = {

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe Sentry::Scope do
       end
     end
 
-    it "sets trace context from span if there's a span" do
+    it "sets trace context and dynamic_sampling_context from span if there's a span" do
       transaction = Sentry::Transaction.new(op: "foo", hub: hub)
       subject.set_span(transaction)
 
@@ -301,6 +301,7 @@ RSpec.describe Sentry::Scope do
 
       expect(event.contexts[:trace]).to eq(transaction.get_trace_context)
       expect(event.contexts.dig(:trace, :op)).to eq("foo")
+      expect(event.dynamic_sampling_context).to eq(transaction.get_dynamic_sampling_context)
     end
 
     it "sets trace context and dynamic_sampling_context from propagation context if there's no span" do

--- a/sentry-ruby/spec/sentry/span_spec.rb
+++ b/sentry-ruby/spec/sentry/span_spec.rb
@@ -136,6 +136,35 @@ RSpec.describe Sentry::Span do
     end
   end
 
+  describe "#get_dynamic_sampling_context" do
+    before do
+      # because initializing transactions requires an active hub
+      perform_basic_setup
+    end
+
+    subject do
+      baggage = Sentry::Baggage.from_incoming_header(
+        "other-vendor-value-1=foo;bar;baz, "\
+        "sentry-trace_id=771a43a4192642f0b136d5159a501700, "\
+        "sentry-public_key=49d0f7386ad645858ae85020e393bef3, "\
+        "sentry-sample_rate=0.01337, "\
+        "sentry-user_id=Am%C3%A9lie,  "\
+        "other-vendor-value-2=foo;bar;"
+      )
+
+      Sentry::Transaction.new(hub: Sentry.get_current_hub, baggage: baggage).start_child
+    end
+
+    it "propagates sentry dynamic_sampling_context" do
+      expect(subject.get_dynamic_sampling_context).to eq({
+        "sample_rate" => "0.01337",
+        "public_key" => "49d0f7386ad645858ae85020e393bef3",
+        "trace_id" => "771a43a4192642f0b136d5159a501700",
+        "user_id" => "Amélie"
+      })
+    end
+  end
+
   describe "#start_child" do
     before do
       # because initializing transactions requires an active hub


### PR DESCRIPTION
We were actually missing the DSC in the envelope header in the case when we have a non-transaction event (like an error) being sent but with an active span/transaction on the scope.

fixes #2400 
