### PR TITLE
Add 5 min timeout to sentry_ruby_test workflow

### DIFF
--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -25,6 +25,7 @@ jobs:
         working-directory: sentry-ruby
     name: Ruby ${{ matrix.ruby_version }} & Rack ${{ matrix.rack_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Sometimes jruby jobs get stuck so it's a good idea to have a timeout.

#skip-changelog