### PR TITLE
Skip concurrent threaded test on jruby

### DIFF
--- a/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
@@ -69,33 +69,35 @@ RSpec.describe "Sentry::Breadcrumbs::SentryLogger" do
     end
 
     # see https://github.com/getsentry/sentry-ruby/issues/1858
-    it "noops on thread with cloned hub" do
-      mutex = Mutex.new
-      cv = ConditionVariable.new
+    unless RUBY_PLATFORM == "java"
+      it "noops on thread with cloned hub" do
+        mutex = Mutex.new
+        cv = ConditionVariable.new
 
-      a = Thread.new do
-        expect(Sentry.get_current_hub).to be_a(Sentry::Hub)
+        a = Thread.new do
+          expect(Sentry.get_current_hub).to be_a(Sentry::Hub)
 
-        # close in another thread
-        b = Thread.new do
-          mutex.synchronize do
-            Sentry.close
-            cv.signal
+          # close in another thread
+          b = Thread.new do
+            mutex.synchronize do
+              Sentry.close
+              cv.signal
+            end
           end
+
+          mutex.synchronize do
+            # wait for other thread to close SDK
+            cv.wait(mutex)
+
+            expect(Sentry).not_to receive(:add_breadcrumb)
+            logger.info("foo")
+          end
+
+          b.join
         end
 
-        mutex.synchronize do
-          # wait for other thread to close SDK
-          cv.wait(mutex)
-
-          expect(Sentry).not_to receive(:add_breadcrumb)
-          logger.info("foo")
-        end
-
-        b.join
+        a.join
       end
-
-      a.join
     end
   end
 end


### PR DESCRIPTION
this is testing some really obscure threading logic and hangs often on jruby

#skip-changelog