### PR TITLE
fix: Unable to use sentry when URI contains non-ascii symbols on Net::HTTP traces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Fix error events missing a DSC when there's an active span ([#2408](https://github.com/getsentry/sentry-ruby/pull/2408))
 - Verifies presence of client before adding a breadcrumb ([#2394](https://github.com/getsentry/sentry-ruby/pull/2394))
+- Fix `Net:HTTP` integration for non-ASCII URI's ([#2417](https://github.com/getsentry/sentry-ruby/pull/2417))
 
 ## 5.19.0
 

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -66,7 +66,7 @@ module Sentry
         # IPv6 url could look like '::1/path', and that won't parse without
         # wrapping it in square brackets.
         hostname = address =~ Resolv::IPv6::Regex ? "[#{address}]" : address
-        uri = req.uri || URI.parse("#{use_ssl? ? 'https' : 'http'}://#{hostname}#{req.path}")
+        uri = req.uri || URI.parse(URI::DEFAULT_PARSER.escape("#{use_ssl? ? 'https' : 'http'}://#{hostname}#{req.path}"))
         url = "#{uri.scheme}://#{uri.host}#{uri.path}" rescue uri.to_s
 
         result = { method: req.method, url: url }

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -107,6 +107,22 @@ RSpec.describe Sentry::Net::HTTP do
       end
     end
 
+    it "supports non-ascii characters in the path" do
+      stub_normal_response
+
+      uri = URI('http://example.com')
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Get.new('/path?q=øgreyfoss&å=vær')
+
+      transaction = Sentry.start_transaction
+      Sentry.get_current_scope.set_span(transaction)
+
+
+      response = http.request(request)
+
+      expect(response.code).to eq("200")
+    end
+
     it "adds sentry-trace header to the request header" do
       uri = URI("http://example.com/path")
       http = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
## Description

Fixes #2418

Using URI::DEFAULT_PARSER.escape to properly escape the constructed URLs, which prevents issues with special characters that may cause errors during URI parsing.

## Changelog

- Added URI::DEFAULT_PARSER.escape to handle special characters in URL construction and prevent parsing errors on Net::HTTP traces.
