### PR TITLE
Consistent string freezing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ Layout/EmptyLineAfterMagicComment:
 Style/FrozenStringLiteralComment:
   Enabled: true
 
+Style/RedundantFreeze:
+  Enabled: true
+
 AllCops:
   Exclude:
     - "sentry-raven/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,14 @@ inherit_gem:
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: false
 
+Layout/EmptyLineAfterMagicComment:
+  Enabled: true
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+
 AllCops:
   Exclude:
     - "sentry-raven/**/*"
     - "sentry-*/tmp/**/*"
+    - "sentry-*/examples/**/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Internal
 
 - Profile items have bigger size limit now ([#2421](https://github.com/getsentry/sentry-ruby/pull/2421))
+- Consistent string freezing ([#2422](https://github.com/getsentry/sentry-ruby/pull/2422))
 
 ## 5.20.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 git_source(:github) { |name| "https://github.com/#{name}.git" }
 

--- a/sentry-delayed_job/Gemfile
+++ b/sentry-delayed_job/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 git_source(:github) { |name| "https://github.com/#{name}.git" }
 

--- a/sentry-delayed_job/Rakefile
+++ b/sentry-delayed_job/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 

--- a/sentry-delayed_job/bin/console
+++ b/sentry-delayed_job/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "sentry/ruby"

--- a/sentry-delayed_job/example/Gemfile
+++ b/sentry-delayed_job/example/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "rails"

--- a/sentry-delayed_job/example/app.rb
+++ b/sentry-delayed_job/example/app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_job"
 require "active_record"
 require "delayed_job"

--- a/sentry-delayed_job/lib/sentry-delayed_job.rb
+++ b/sentry-delayed_job/lib/sentry-delayed_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "delayed_job"
 require "sentry-ruby"
 require "sentry/integrable"

--- a/sentry-delayed_job/lib/sentry/delayed_job/configuration.rb
+++ b/sentry-delayed_job/lib/sentry/delayed_job/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   class Configuration
     attr_reader :delayed_job

--- a/sentry-delayed_job/lib/sentry/delayed_job/version.rb
+++ b/sentry-delayed_job/lib/sentry/delayed_job/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module DelayedJob
     VERSION = "5.20.1"

--- a/sentry-delayed_job/sentry-delayed_job.gemspec
+++ b/sentry-delayed_job/sentry-delayed_job.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/sentry/delayed_job/version"
 
 Gem::Specification.new do |spec|

--- a/sentry-delayed_job/spec/sentry/delayed_job/configuration_spec.rb
+++ b/sentry-delayed_job/spec/sentry/delayed_job/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::DelayedJob::Configuration do

--- a/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
+++ b/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::DelayedJob do

--- a/sentry-delayed_job/spec/spec_helper.rb
+++ b/sentry-delayed_job/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 begin
   require "debug/prelude"

--- a/sentry-opentelemetry/Gemfile
+++ b/sentry-opentelemetry/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 git_source(:github) { |name| "https://github.com/#{name}.git" }
 

--- a/sentry-opentelemetry/Rakefile
+++ b/sentry-opentelemetry/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 git_source(:github) { |name| "https://github.com/#{name}.git" }
 

--- a/sentry-rails/Rakefile
+++ b/sentry-rails/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 

--- a/sentry-rails/app/jobs/sentry/send_event_job.rb
+++ b/sentry-rails/app/jobs/sentry/send_event_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if defined?(ActiveJob)
   module Sentry
     parent_job =

--- a/sentry-rails/benchmarks/allocation_comparison.rb
+++ b/sentry-rails/benchmarks/allocation_comparison.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/memory'
 require "sentry-ruby"
 require "sentry/benchmarks/benchmark_transport"

--- a/sentry-rails/benchmarks/allocation_report.rb
+++ b/sentry-rails/benchmarks/allocation_report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/ipsa'
 require "sentry-ruby"
 require "sentry/benchmarks/benchmark_transport"

--- a/sentry-rails/benchmarks/application.rb
+++ b/sentry-rails/benchmarks/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/all"
 require "action_controller"
 require_relative "../spec/support/test_rails_app/app"

--- a/sentry-rails/bin/console
+++ b/sentry-rails/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "sentry/ruby"

--- a/sentry-rails/lib/generators/sentry_generator.rb
+++ b/sentry-rails/lib/generators/sentry_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails/generators/base"
 
 class SentryGenerator < ::Rails::Generators::Base

--- a/sentry-rails/lib/sentry-rails.rb
+++ b/sentry-rails/lib/sentry-rails.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require "sentry/rails/version"
 require "sentry/rails"

--- a/sentry-rails/lib/sentry/rails.rb
+++ b/sentry-rails/lib/sentry/rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails"
 require "sentry-ruby"
 require "sentry/integrable"

--- a/sentry-rails/lib/sentry/rails/action_cable.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable.rb
@@ -4,7 +4,7 @@ module Sentry
   module Rails
     module ActionCableExtensions
       class ErrorHandler
-        OP_NAME = "websocket.server".freeze
+        OP_NAME = "websocket.server"
         SPAN_ORIGIN = "auto.http.rails.actioncable"
 
         class << self

--- a/sentry-rails/lib/sentry/rails/action_cable.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Rails
     module ActionCableExtensions

--- a/sentry-rails/lib/sentry/rails/active_job.rb
+++ b/sentry-rails/lib/sentry/rails/active_job.rb
@@ -18,8 +18,8 @@ module Sentry
       end
 
       class SentryReporter
-        OP_NAME = "queue.active_job".freeze
-        SPAN_ORIGIN = "auto.queue.active_job".freeze
+        OP_NAME = "queue.active_job"
+        SPAN_ORIGIN = "auto.queue.active_job"
 
         class << self
           def record(job, &block)

--- a/sentry-rails/lib/sentry/rails/active_job.rb
+++ b/sentry-rails/lib/sentry/rails/active_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Rails
     module ActiveJobExtensions

--- a/sentry-rails/lib/sentry/rails/background_worker.rb
+++ b/sentry-rails/lib/sentry/rails/background_worker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   class BackgroundWorker
     def _perform(&block)

--- a/sentry-rails/lib/sentry/rails/backtrace_cleaner.rb
+++ b/sentry-rails/lib/sentry/rails/backtrace_cleaner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/backtrace_cleaner"
 require "active_support/core_ext/string/access"
 

--- a/sentry-rails/lib/sentry/rails/backtrace_cleaner.rb
+++ b/sentry-rails/lib/sentry/rails/backtrace_cleaner.rb
@@ -6,8 +6,8 @@ require "active_support/core_ext/string/access"
 module Sentry
   module Rails
     class BacktraceCleaner < ActiveSupport::BacktraceCleaner
-      APP_DIRS_PATTERN = /\A(?:\.\/)?(?:app|config|lib|test|\(\w*\))/.freeze
-      RENDER_TEMPLATE_PATTERN = /:in `.*_\w+_{2,3}\d+_\d+'/.freeze
+      APP_DIRS_PATTERN = /\A(?:\.\/)?(?:app|config|lib|test|\(\w*\))/
+      RENDER_TEMPLATE_PATTERN = /:in `.*_\w+_{2,3}\d+_\d+'/
 
       def initialize
         super

--- a/sentry-rails/lib/sentry/rails/breadcrumb/active_support_logger.rb
+++ b/sentry-rails/lib/sentry/rails/breadcrumb/active_support_logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Rails
     module Breadcrumb

--- a/sentry-rails/lib/sentry/rails/breadcrumb/monotonic_active_support_logger.rb
+++ b/sentry-rails/lib/sentry/rails/breadcrumb/monotonic_active_support_logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "sentry/rails/instrument_payload_cleanup_helper"
 
 module Sentry

--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Rails
     class CaptureExceptions < Sentry::Rack::CaptureExceptions

--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -4,7 +4,7 @@ module Sentry
   module Rails
     class CaptureExceptions < Sentry::Rack::CaptureExceptions
       RAILS_7_1 = Gem::Version.new(::Rails.version) >= Gem::Version.new("7.1.0.alpha")
-      SPAN_ORIGIN = "auto.http.rails".freeze
+      SPAN_ORIGIN = "auto.http.rails"
 
       def initialize(_)
         super
@@ -22,7 +22,7 @@ module Sentry
       end
 
       def transaction_op
-        "http.server".freeze
+        "http.server"
       end
 
       def capture_exception(exception, env)

--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "sentry/rails/tracing/action_controller_subscriber"
 require "sentry/rails/tracing/action_view_subscriber"
 require "sentry/rails/tracing/active_record_subscriber"

--- a/sentry-rails/lib/sentry/rails/controller_methods.rb
+++ b/sentry-rails/lib/sentry/rails/controller_methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Rails
     module ControllerMethods

--- a/sentry-rails/lib/sentry/rails/controller_transaction.rb
+++ b/sentry-rails/lib/sentry/rails/controller_transaction.rb
@@ -3,7 +3,7 @@
 module Sentry
   module Rails
     module ControllerTransaction
-      SPAN_ORIGIN = "auto.view.rails".freeze
+      SPAN_ORIGIN = "auto.view.rails"
 
       def self.included(base)
         base.prepend_around_action(:sentry_around_action)

--- a/sentry-rails/lib/sentry/rails/controller_transaction.rb
+++ b/sentry-rails/lib/sentry/rails/controller_transaction.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Rails
     module ControllerTransaction

--- a/sentry-rails/lib/sentry/rails/engine.rb
+++ b/sentry-rails/lib/sentry/rails/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   class Engine < ::Rails::Engine
     isolate_namespace Sentry

--- a/sentry-rails/lib/sentry/rails/error_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/error_subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Rails
     # This is not a user-facing class. You should use it with Rails 7.0's error reporter feature and its interfaces.

--- a/sentry-rails/lib/sentry/rails/instrument_payload_cleanup_helper.rb
+++ b/sentry-rails/lib/sentry/rails/instrument_payload_cleanup_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Rails
     module InstrumentPayloadCleanupHelper

--- a/sentry-rails/lib/sentry/rails/overrides/streaming_reporter.rb
+++ b/sentry-rails/lib/sentry/rails/overrides/streaming_reporter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Rails
     module Overrides

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "sentry/rails/capture_exceptions"
 require "sentry/rails/rescued_exception_interceptor"
 require "sentry/rails/backtrace_cleaner"

--- a/sentry-rails/lib/sentry/rails/rescued_exception_interceptor.rb
+++ b/sentry-rails/lib/sentry/rails/rescued_exception_interceptor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Rails
     class RescuedExceptionInterceptor

--- a/sentry-rails/lib/sentry/rails/tracing.rb
+++ b/sentry-rails/lib/sentry/rails/tracing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Rails
     module Tracing

--- a/sentry-rails/lib/sentry/rails/tracing/abstract_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/abstract_subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Rails
     module Tracing

--- a/sentry-rails/lib/sentry/rails/tracing/action_controller_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/action_controller_subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "sentry/rails/tracing/abstract_subscriber"
 require "sentry/rails/instrument_payload_cleanup_helper"
 

--- a/sentry-rails/lib/sentry/rails/tracing/action_controller_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/action_controller_subscriber.rb
@@ -10,8 +10,8 @@ module Sentry
         extend InstrumentPayloadCleanupHelper
 
         EVENT_NAMES = ["process_action.action_controller"].freeze
-        OP_NAME = "view.process_action.action_controller".freeze
-        SPAN_ORIGIN = "auto.view.rails".freeze
+        OP_NAME = "view.process_action.action_controller"
+        SPAN_ORIGIN = "auto.view.rails"
 
         def self.subscribe!
           Sentry.logger.warn <<~MSG

--- a/sentry-rails/lib/sentry/rails/tracing/action_view_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/action_view_subscriber.rb
@@ -7,8 +7,8 @@ module Sentry
     module Tracing
       class ActionViewSubscriber < AbstractSubscriber
         EVENT_NAMES = ["render_template.action_view"].freeze
-        SPAN_PREFIX = "template.".freeze
-        SPAN_ORIGIN = "auto.template.rails".freeze
+        SPAN_PREFIX = "template."
+        SPAN_ORIGIN = "auto.template.rails"
 
         def self.subscribe!
           subscribe_to_event(EVENT_NAMES) do |event_name, duration, payload|

--- a/sentry-rails/lib/sentry/rails/tracing/action_view_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/action_view_subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "sentry/rails/tracing/abstract_subscriber"
 
 module Sentry

--- a/sentry-rails/lib/sentry/rails/tracing/active_storage_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/active_storage_subscriber.rb
@@ -21,12 +21,12 @@ module Sentry
           analyze.active_storage
         ].freeze
 
-        SPAN_ORIGIN = "auto.file.rails".freeze
+        SPAN_ORIGIN = "auto.file.rails"
 
         def self.subscribe!
           subscribe_to_event(EVENT_NAMES) do |event_name, duration, payload|
             record_on_current_span(
-              op: "file.#{event_name}".freeze,
+              op: "file.#{event_name}",
               origin: SPAN_ORIGIN,
               start_timestamp: payload[START_TIMESTAMP_NAME],
               description: payload[:service],

--- a/sentry-rails/lib/sentry/rails/tracing/active_storage_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/active_storage_subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "sentry/rails/tracing/abstract_subscriber"
 
 module Sentry

--- a/sentry-rails/lib/sentry/rails/version.rb
+++ b/sentry-rails/lib/sentry/rails/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Rails
     VERSION = "5.20.1"

--- a/sentry-rails/sentry-rails.gemspec
+++ b/sentry-rails/sentry-rails.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/sentry/rails/version"
 
 Gem::Specification.new do |spec|

--- a/sentry-rails/spec/dummy/test_rails_app/app.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV["RAILS_ENV"] = "test"
 
 require "rails"

--- a/sentry-rails/spec/dummy/test_rails_app/apps/5-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/5-0.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ActiveRecord::Schema.define do
   create_table :posts, force: true do |t|
   end

--- a/sentry-rails/spec/dummy/test_rails_app/apps/5-2.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/5-2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ActiveRecord::Schema.define do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false

--- a/sentry-rails/spec/dummy/test_rails_app/apps/6-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/6-0.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ActiveRecord::Schema.define do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false

--- a/sentry-rails/spec/dummy/test_rails_app/apps/6-1.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/6-1.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ActiveRecord::Schema.define do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false

--- a/sentry-rails/spec/dummy/test_rails_app/apps/7-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/7-0.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ActiveRecord::Schema.define do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false

--- a/sentry-rails/spec/dummy/test_rails_app/apps/7-1.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/apps/7-1.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ActiveRecord::Schema.define do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false

--- a/sentry-rails/spec/dummy/test_rails_app/configs/5-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/5-0.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def run_pre_initialize_cleanup; end
 
 def configure_app(app); end

--- a/sentry-rails/spec/dummy/test_rails_app/configs/5-2.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/5-2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_storage/engine"
 
 def run_pre_initialize_cleanup; end

--- a/sentry-rails/spec/dummy/test_rails_app/configs/6-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/6-0.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_storage/engine"
 require "action_cable/engine"
 

--- a/sentry-rails/spec/dummy/test_rails_app/configs/6-1.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/6-1.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_storage/engine"
 require "action_cable/engine"
 

--- a/sentry-rails/spec/dummy/test_rails_app/configs/7-0.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/7-0.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_storage/engine"
 require "action_cable/engine"
 

--- a/sentry-rails/spec/dummy/test_rails_app/configs/7-1.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/7-1.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_storage/engine"
 require "action_cable/engine"
 require "sentry/rails/error_subscriber"

--- a/sentry-rails/spec/dummy/test_rails_app/configs/7-2.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/configs/7-2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_storage/engine"
 require "action_cable/engine"
 require "sentry/rails/error_subscriber"

--- a/sentry-rails/spec/sentry/rails/action_cable_spec.rb
+++ b/sentry-rails/spec/sentry/rails/action_cable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
   require "spec_helper"
   require "action_cable/engine"

--- a/sentry-rails/spec/sentry/rails/activejob_spec.rb
+++ b/sentry-rails/spec/sentry/rails/activejob_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "active_job/railtie"
 

--- a/sentry-rails/spec/sentry/rails/breadcrumbs/active_support_logger_spec.rb
+++ b/sentry-rails/spec/sentry/rails/breadcrumbs/active_support_logger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Sentry::Breadcrumbs::ActiveSupportLogger", type: :request do

--- a/sentry-rails/spec/sentry/rails/breadcrumbs/monotonic_active_support_logger_spec.rb
+++ b/sentry-rails/spec/sentry/rails/breadcrumbs/monotonic_active_support_logger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 

--- a/sentry-rails/spec/sentry/rails/client_spec.rb
+++ b/sentry-rails/spec/sentry/rails/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Client, type: :request, retry: 3, skip: Gem::Version.new(Rails.version) < Gem::Version.new('5.1.0') do

--- a/sentry-rails/spec/sentry/rails/configuration_spec.rb
+++ b/sentry-rails/spec/sentry/rails/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Rails::Configuration do

--- a/sentry-rails/spec/sentry/rails/controller_methods_spec.rb
+++ b/sentry-rails/spec/sentry/rails/controller_methods_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require "sentry/rails/controller_methods"
 

--- a/sentry-rails/spec/sentry/rails/error_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/error_subscriber_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'sentry/rails/error_subscriber'
 

--- a/sentry-rails/spec/sentry/rails/event_spec.rb
+++ b/sentry-rails/spec/sentry/rails/event_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Event do

--- a/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Rails::Tracing::ActionControllerSubscriber, :subscriber, type: :request do

--- a/sentry-rails/spec/sentry/rails/tracing/action_view_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_view_subscriber_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Rails::Tracing::ActionViewSubscriber, :subscriber, type: :request do

--- a/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do

--- a/sentry-rails/spec/sentry/rails/tracing/active_storage_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_storage_subscriber_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Rails::Tracing::ActiveStorageSubscriber, :subscriber, type: :request, skip: Rails.version.to_f <= 5.2 do

--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Rails::Tracing, type: :request do

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Rails, type: :request do

--- a/sentry-rails/spec/sentry/send_event_job_spec.rb
+++ b/sentry-rails/spec/sentry/send_event_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_job"
 require "spec_helper"
 

--- a/sentry-rails/spec/spec_helper.rb
+++ b/sentry-rails/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 begin
   require "debug/prelude"

--- a/sentry-resque/Gemfile
+++ b/sentry-resque/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 git_source(:github) { |name| "https://github.com/#{name}.git" }
 

--- a/sentry-resque/Gemfile_with_rails.rb
+++ b/sentry-resque/Gemfile_with_rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 eval_gemfile File.expand_path("Gemfile", __dir__)
 
 gem "sentry-rails", path: "../sentry-rails"

--- a/sentry-resque/Rakefile
+++ b/sentry-resque/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 

--- a/sentry-resque/bin/console
+++ b/sentry-resque/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "sentry/ruby"

--- a/sentry-resque/example/Gemfile
+++ b/sentry-resque/example/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "rails"

--- a/sentry-resque/example/app.rb
+++ b/sentry-resque/example/app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_job"
 require "resque"
 require "sentry-resque"

--- a/sentry-resque/lib/sentry-resque.rb
+++ b/sentry-resque/lib/sentry-resque.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "resque"
 require "sentry-ruby"
 require "sentry/integrable"

--- a/sentry-resque/lib/sentry/resque/configuration.rb
+++ b/sentry-resque/lib/sentry/resque/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   class Configuration
     attr_reader :resque

--- a/sentry-resque/lib/sentry/resque/version.rb
+++ b/sentry-resque/lib/sentry/resque/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Resque
     VERSION = "5.20.1"

--- a/sentry-resque/sentry-resque.gemspec
+++ b/sentry-resque/sentry-resque.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/sentry/resque/version"
 
 Gem::Specification.new do |spec|

--- a/sentry-resque/spec/sentry/resque/configuration_spec.rb
+++ b/sentry-resque/spec/sentry/resque/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Resque::Configuration do

--- a/sentry-resque/spec/sentry/resque_spec.rb
+++ b/sentry-resque/spec/sentry/resque_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 def process_job(worker)

--- a/sentry-resque/spec/sentry/tracing_spec.rb
+++ b/sentry-resque/spec/sentry/tracing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Resque do

--- a/sentry-resque/spec/spec_helper.rb
+++ b/sentry-resque/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 begin
   require "debug/prelude"

--- a/sentry-ruby/.rubocop.yml
+++ b/sentry-ruby/.rubocop.yml
@@ -1,0 +1,1 @@
+../.rubocop.yml

--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 git_source(:github) { |name| "https://github.com/#{name}.git" }
 

--- a/sentry-ruby/Rakefile
+++ b/sentry-ruby/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rake/clean"
 CLOBBER.include "pkg"
 

--- a/sentry-ruby/benchmarks/allocation_comparison.rb
+++ b/sentry-ruby/benchmarks/allocation_comparison.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/memory'
 require "sentry-ruby"
 require "sentry/benchmarks/benchmark_transport"

--- a/sentry-ruby/benchmarks/allocation_report.rb
+++ b/sentry-ruby/benchmarks/allocation_report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/ipsa'
 require "sentry-ruby"
 require "sentry/benchmarks/benchmark_transport"

--- a/sentry-ruby/benchmarks/exception_locals_capturing.rb
+++ b/sentry-ruby/benchmarks/exception_locals_capturing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/ips'
 
 def raise_n_exceptions(n, with_sleep: false)

--- a/sentry-ruby/bin/console
+++ b/sentry-ruby/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "debug"

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -42,11 +42,11 @@ module Sentry
 
   CAPTURED_SIGNATURE = :@__sentry_captured
 
-  LOGGER_PROGNAME = "sentry".freeze
+  LOGGER_PROGNAME = "sentry"
 
-  SENTRY_TRACE_HEADER_NAME = "sentry-trace".freeze
+  SENTRY_TRACE_HEADER_NAME = "sentry-trace"
 
-  BAGGAGE_HEADER_NAME = "baggage".freeze
+  BAGGAGE_HEADER_NAME = "baggage"
 
   THREAD_LOCAL = :sentry_hub
 

--- a/sentry-ruby/lib/sentry/backtrace.rb
+++ b/sentry-ruby/lib/sentry/backtrace.rb
@@ -13,10 +13,10 @@ module Sentry
         ^ \s* (?: [a-zA-Z]: | uri:classloader: )? ([^:]+ | <.*>):
         (\d+)
         (?: :in\s('|`)([^']+)')?$
-      /x.freeze
+      /x
 
       # org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
-      JAVA_INPUT_FORMAT = /^(.+)\.([^\.]+)\(([^\:]+)\:(\d+)\)$/.freeze
+      JAVA_INPUT_FORMAT = /^(.+)\.([^\.]+)\(([^\:]+)\:(\d+)\)$/
 
       # The file portion of the line (such as app/models/user.rb)
       attr_reader :file

--- a/sentry-ruby/lib/sentry/baggage.rb
+++ b/sentry-ruby/lib/sentry/baggage.rb
@@ -6,7 +6,7 @@ module Sentry
   # A {https://www.w3.org/TR/baggage W3C Baggage Header} implementation.
   class Baggage
     SENTRY_PREFIX = "sentry-"
-    SENTRY_PREFIX_REGEX = /^sentry-/.freeze
+    SENTRY_PREFIX_REGEX = /^sentry-/
 
     # @return [Hash]
     attr_reader :items

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -335,19 +335,19 @@ module Sentry
     ].freeze
 
     HEROKU_DYNO_METADATA_MESSAGE = "You are running on Heroku but haven't enabled Dyno Metadata. For Sentry's "\
-    "release detection to work correctly, please run `heroku labs:enable runtime-dyno-metadata`".freeze
+    "release detection to work correctly, please run `heroku labs:enable runtime-dyno-metadata`"
 
-    LOG_PREFIX = "** [Sentry] ".freeze
-    MODULE_SEPARATOR = "::".freeze
+    LOG_PREFIX = "** [Sentry] "
+    MODULE_SEPARATOR = "::"
     SKIP_INSPECTION_ATTRIBUTES = [:@linecache, :@stacktrace_builder]
 
     INSTRUMENTERS = [:sentry, :otel]
 
-    PROPAGATION_TARGETS_MATCH_ALL = /.*/.freeze
+    PROPAGATION_TARGETS_MATCH_ALL = /.*/
 
     DEFAULT_PATCHES = %i[redis puma http].freeze
 
-    APP_DIRS_PATTERN = /(bin|exe|app|config|lib|test|spec)/.freeze
+    APP_DIRS_PATTERN = /(bin|exe|app|config|lib|test|spec)/
 
     class << self
       # Post initialization callbacks are called at the end of initialization process

--- a/sentry-ruby/lib/sentry/cron/monitor_check_ins.rb
+++ b/sentry-ruby/lib/sentry/cron/monitor_check_ins.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Cron
     module MonitorCheckIns

--- a/sentry-ruby/lib/sentry/interfaces/single_exception.rb
+++ b/sentry-ruby/lib/sentry/interfaces/single_exception.rb
@@ -7,8 +7,8 @@ module Sentry
     include CustomInspection
 
     SKIP_INSPECTION_ATTRIBUTES = [:@stacktrace]
-    PROBLEMATIC_LOCAL_VALUE_REPLACEMENT = "[ignored due to error]".freeze
-    OMISSION_MARK = "...".freeze
+    PROBLEMATIC_LOCAL_VALUE_REPLACEMENT = "[ignored due to error]"
+    OMISSION_MARK = "..."
     MAX_LOCAL_BYTES = 1024
 
     attr_reader :type, :module, :thread_id, :stacktrace, :mechanism

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -54,7 +54,7 @@ module Sentry
       end
 
       def transaction_op
-        "http.server".freeze
+        "http.server"
       end
 
       def capture_exception(exception, env)

--- a/sentry-ruby/lib/sentry/test_helper.rb
+++ b/sentry-ruby/lib/sentry/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module TestHelper
     DUMMY_DSN = "http://12345:67890@sentry.localdomain/sentry/42"

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -9,7 +9,7 @@ module Sentry
     # @deprecated Use Sentry::PropagationContext::SENTRY_TRACE_REGEXP instead.
     SENTRY_TRACE_REGEXP = PropagationContext::SENTRY_TRACE_REGEXP
 
-    UNLABELD_NAME = "<unlabeled transaction>".freeze
+    UNLABELD_NAME = "<unlabeled transaction>"
     MESSAGE_PREFIX = "[Tracing]"
 
     # https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations

--- a/sentry-ruby/sentry-ruby-core.gemspec
+++ b/sentry-ruby/sentry-ruby-core.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/sentry/version"
 
 Gem::Specification.new do |spec|

--- a/sentry-ruby/sentry-ruby.gemspec
+++ b/sentry-ruby/sentry-ruby.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/sentry/version"
 
 Gem::Specification.new do |spec|

--- a/sentry-ruby/spec/contexts/with_request_mock.rb
+++ b/sentry-ruby/spec/contexts/with_request_mock.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # because our patch on Net::HTTP is relatively low-level, we need to stub methods on socket level
 # which is not supported by most of the http mocking library
 # so we need to put something together ourselves

--- a/sentry-ruby/spec/initialization_check_spec.rb
+++ b/sentry-ruby/spec/initialization_check_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "with uninitialized SDK" do

--- a/sentry-ruby/spec/isolated/puma_spec.rb
+++ b/sentry-ruby/spec/isolated/puma_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "puma"
 require_relative "../spec_helper"
 

--- a/sentry-ruby/spec/sentry/background_worker_spec.rb
+++ b/sentry-ruby/spec/sentry/background_worker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::BackgroundWorker do

--- a/sentry-ruby/spec/sentry/backpressure_monitor_spec.rb
+++ b/sentry-ruby/spec/sentry/backpressure_monitor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::BackpressureMonitor do

--- a/sentry-ruby/spec/sentry/backtrace/lines_spec.rb
+++ b/sentry-ruby/spec/sentry/backtrace/lines_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Backtrace::Line do

--- a/sentry-ruby/spec/sentry/backtrace_spec.rb
+++ b/sentry-ruby/spec/sentry/backtrace_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Backtrace do

--- a/sentry-ruby/spec/sentry/baggage_spec.rb
+++ b/sentry-ruby/spec/sentry/baggage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Baggage do

--- a/sentry-ruby/spec/sentry/breadcrumb/http_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/http_logger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require 'contexts/with_request_mock'
 

--- a/sentry-ruby/spec/sentry/breadcrumb/redis_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/redis_logger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe :redis_logger do

--- a/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Sentry::Breadcrumbs::SentryLogger" do

--- a/sentry-ruby/spec/sentry/breadcrumb_buffer_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb_buffer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::BreadcrumbBuffer do

--- a/sentry-ruby/spec/sentry/breadcrumb_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Breadcrumb do

--- a/sentry-ruby/spec/sentry/client/event_sending_spec.rb
+++ b/sentry-ruby/spec/sentry/client/event_sending_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Client do

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 class ExceptionWithContext < StandardError

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -343,7 +343,12 @@ RSpec.describe Sentry::Client do
         event = subject.event_from_exception(NonStringMessageError.new)
         hash = event.to_hash
         expect(event).to be_a(Sentry::ErrorEvent)
-        expect(hash[:exception][:values][0][:value]).to eq("{:foo=>\"bar\"}")
+
+        if RUBY_VERSION >= "3.4"
+          expect(hash[:exception][:values][0][:value]).to eq("{foo: \"bar\"}")
+        else
+          expect(hash[:exception][:values][0][:value]).to eq("{:foo=>\"bar\"}")
+        end
       end
     end
 

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Configuration do

--- a/sentry-ruby/spec/sentry/cron/monitor_check_ins_spec.rb
+++ b/sentry-ruby/spec/sentry/cron/monitor_check_ins_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Cron::MonitorCheckIns do

--- a/sentry-ruby/spec/sentry/cron/monitor_config_spec.rb
+++ b/sentry-ruby/spec/sentry/cron/monitor_config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Cron::MonitorConfig do

--- a/sentry-ruby/spec/sentry/cron/monitor_schedule_spec.rb
+++ b/sentry-ruby/spec/sentry/cron/monitor_schedule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Cron::MonitorSchedule::Crontab do

--- a/sentry-ruby/spec/sentry/dsn_spec.rb
+++ b/sentry-ruby/spec/sentry/dsn_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::DSN do

--- a/sentry-ruby/spec/sentry/envelope/item_spec.rb
+++ b/sentry-ruby/spec/sentry/envelope/item_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Envelope::Item do

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Event do

--- a/sentry-ruby/spec/sentry/faraday_spec.rb
+++ b/sentry-ruby/spec/sentry/faraday_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "faraday"
 require_relative "../spec_helper"
 

--- a/sentry-ruby/spec/sentry/graphql_spec.rb
+++ b/sentry-ruby/spec/sentry/graphql_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 with_graphql = begin

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Hub do

--- a/sentry-ruby/spec/sentry/integrable_spec.rb
+++ b/sentry-ruby/spec/sentry/integrable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "sentry/integrable"
 

--- a/sentry-ruby/spec/sentry/interface_spec.rb
+++ b/sentry-ruby/spec/sentry/interface_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'sentry/interface'
 

--- a/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 return unless defined?(Rack)

--- a/sentry-ruby/spec/sentry/interfaces/stacktrace_builder_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/stacktrace_builder_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Sentry::StacktraceBuilder do
 
   let(:backtrace) do
     [
-      "#{fixture_file}:6:in `bar'",
-      "#{fixture_file}:2:in `foo'"
+      "#{fixture_file}:8:in `bar'",
+      "#{fixture_file}:4:in `foo'"
     ]
   end
 
@@ -38,8 +38,8 @@ RSpec.describe Sentry::StacktraceBuilder do
 
       expect(first_frame.filename).to match(/stacktrace_test_fixture.rb/)
       expect(first_frame.function).to eq("foo")
-      expect(first_frame.lineno).to eq(2)
-      expect(first_frame.pre_context).to eq([nil, nil, "def foo\n"])
+      expect(first_frame.lineno).to eq(4)
+      expect(first_frame.pre_context).to eq(["# frozen_string_literal: true\n", "\n", "def foo\n"])
       expect(first_frame.context_line).to eq("  bar\n")
       expect(first_frame.post_context).to eq(["end\n", "\n", "def bar\n"])
 
@@ -47,7 +47,7 @@ RSpec.describe Sentry::StacktraceBuilder do
 
       expect(second_frame.filename).to match(/stacktrace_test_fixture.rb/)
       expect(second_frame.function).to eq("bar")
-      expect(second_frame.lineno).to eq(6)
+      expect(second_frame.lineno).to eq(8)
       expect(second_frame.pre_context).to eq(["end\n", "\n", "def bar\n"])
       expect(second_frame.context_line).to eq("  baz\n")
       expect(second_frame.post_context).to eq(["end\n", nil, nil])
@@ -94,7 +94,7 @@ RSpec.describe Sentry::StacktraceBuilder do
 
         expect(second_frame.filename).to match(/stacktrace_test_fixture.rb/)
         expect(second_frame.function).to eq("bar")
-        expect(second_frame.lineno).to eq(6)
+        expect(second_frame.lineno).to eq(8)
         expect(second_frame.vars).to eq({ foo: "bar" })
       end
     end
@@ -106,7 +106,7 @@ RSpec.describe Sentry::StacktraceBuilder do
 
       expect(hash[:filename]).to match(/stacktrace_test_fixture.rb/)
       expect(hash[:function]).to eq("bar")
-      expect(hash[:lineno]).to eq(6)
+      expect(hash[:lineno]).to eq(8)
       expect(hash[:pre_context]).to eq(["end\n", "\n", "def bar\n"])
       expect(hash[:context_line]).to eq("  baz\n")
       expect(hash[:post_context]).to eq(["end\n", nil, nil])

--- a/sentry-ruby/spec/sentry/interfaces/stacktrace_builder_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/stacktrace_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::StacktraceBuilder do

--- a/sentry-ruby/spec/sentry/interfaces/stacktrace_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/stacktrace_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::StacktraceInterface::Frame do

--- a/sentry-ruby/spec/sentry/linecache_spec.rb
+++ b/sentry-ruby/spec/sentry/linecache_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 # rubocop:disable Style/WordArray
 RSpec.describe Sentry::LineCache do

--- a/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Metrics::Aggregator do

--- a/sentry-ruby/spec/sentry/metrics/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Metrics::Configuration do

--- a/sentry-ruby/spec/sentry/metrics/counter_metric_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/counter_metric_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Metrics::CounterMetric do

--- a/sentry-ruby/spec/sentry/metrics/distribution_metric_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/distribution_metric_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Metrics::DistributionMetric do

--- a/sentry-ruby/spec/sentry/metrics/gauge_metric_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/gauge_metric_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Metrics::GaugeMetric do

--- a/sentry-ruby/spec/sentry/metrics/local_aggregator_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/local_aggregator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Metrics::LocalAggregator do

--- a/sentry-ruby/spec/sentry/metrics/metric_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/metric_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Metrics::Metric do

--- a/sentry-ruby/spec/sentry/metrics/set_metric_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/set_metric_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Metrics::SetMetric do

--- a/sentry-ruby/spec/sentry/metrics/timing_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/timing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Metrics::Timing do

--- a/sentry-ruby/spec/sentry/metrics_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Metrics do

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require 'contexts/with_request_mock'
 

--- a/sentry-ruby/spec/sentry/profiler_spec.rb
+++ b/sentry-ruby/spec/sentry/profiler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Profiler, when: :stack_prof_installed? do

--- a/sentry-ruby/spec/sentry/propagation_context_spec.rb
+++ b/sentry-ruby/spec/sentry/propagation_context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::PropagationContext do

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'sentry/vernier/profiler'
 

--- a/sentry-ruby/spec/sentry/rake_spec.rb
+++ b/sentry-ruby/spec/sentry/rake_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "rake auto-reporting" do

--- a/sentry-ruby/spec/sentry/redis_spec.rb
+++ b/sentry-ruby/spec/sentry/redis_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Redis do

--- a/sentry-ruby/spec/sentry/scope/setters_spec.rb
+++ b/sentry-ruby/spec/sentry/scope/setters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Scope do

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Scope do

--- a/sentry-ruby/spec/sentry/session_flusher_spec.rb
+++ b/sentry-ruby/spec/sentry/session_flusher_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::SessionFlusher do

--- a/sentry-ruby/spec/sentry/span_spec.rb
+++ b/sentry-ruby/spec/sentry/span_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Span do

--- a/sentry-ruby/spec/sentry/test_helper_spec.rb
+++ b/sentry-ruby/spec/sentry/test_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::TestHelper do

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Transaction do

--- a/sentry-ruby/spec/sentry/transport/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Transport::Configuration do

--- a/sentry-ruby/spec/sentry/transport/http_transport_rate_limiting_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_rate_limiting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'contexts/with_request_mock'
 

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'contexts/with_request_mock'
 

--- a/sentry-ruby/spec/sentry/transport/spotlight_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/spotlight_transport_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::SpotlightTransport do

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Transport do

--- a/sentry-ruby/spec/sentry/utils/real_ip_spec.rb
+++ b/sentry-ruby/spec/sentry/utils/real_ip_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Utils::RealIp do

--- a/sentry-ruby/spec/sentry/utils/request_id_spec.rb
+++ b/sentry-ruby/spec/sentry/utils/request_id_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Utils::RequestId do

--- a/sentry-ruby/spec/sentry/vernier/profiler_spec.rb
+++ b/sentry-ruby/spec/sentry/vernier/profiler_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Sentry::Vernier::Profiler, when: { ruby_version?: [:>=, "3.2.1"] 
           expect(foo_frame[:function]).to eq('Foo.foo')
           expect(foo_frame[:module]).to eq('ProfilerTest::Bar')
           expect(foo_frame[:in_app]).to eq(true)
-          expect(foo_frame[:lineno]).to eq(4)
+          expect(foo_frame[:lineno]).to eq(6)
           expect(foo_frame[:filename]).to eq('spec/support/profiler.rb')
           expect(foo_frame[:abs_path]).to include('sentry-ruby/sentry-ruby/spec/support/profiler.rb')
         end
@@ -261,7 +261,7 @@ RSpec.describe Sentry::Vernier::Profiler, when: { ruby_version?: [:>=, "3.2.1"] 
           expect(foo_frame[:function]).to eq('Foo.foo')
           expect(foo_frame[:module]).to eq('ProfilerTest::Bar')
           expect(foo_frame[:in_app]).to eq(true)
-          expect(foo_frame[:lineno]).to eq(4)
+          expect(foo_frame[:lineno]).to eq(6)
           expect(foo_frame[:filename]).to eq('spec/support/profiler.rb')
           expect(foo_frame[:abs_path]).to include('sentry-ruby/sentry-ruby/spec/support/profiler.rb')
         end

--- a/sentry-ruby/spec/sentry/vernier/profiler_spec.rb
+++ b/sentry-ruby/spec/sentry/vernier/profiler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 require "sentry/vernier/profiler"

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require 'contexts/with_request_mock'
 

--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 begin
   require "debug/prelude"

--- a/sentry-ruby/spec/support/Rakefile.rb
+++ b/sentry-ruby/spec/support/Rakefile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rake"
 require "sentry-ruby"
 

--- a/sentry-ruby/spec/support/profiler.rb
+++ b/sentry-ruby/spec/support/profiler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ProfilerTest
   module Bar
     module Foo

--- a/sentry-ruby/spec/support/stacktrace_test_fixture.rb
+++ b/sentry-ruby/spec/support/stacktrace_test_fixture.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def foo
   bar
 end

--- a/sentry-sidekiq/Gemfile
+++ b/sentry-sidekiq/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 git_source(:github) { |name| "https://github.com/#{name}.git" }
 

--- a/sentry-sidekiq/Rakefile
+++ b/sentry-sidekiq/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 

--- a/sentry-sidekiq/bin/console
+++ b/sentry-sidekiq/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "sentry/ruby"

--- a/sentry-sidekiq/example/Gemfile
+++ b/sentry-sidekiq/example/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "sidekiq"

--- a/sentry-sidekiq/example/error_worker.rb
+++ b/sentry-sidekiq/example/error_worker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "sidekiq"
 require "sentry-sidekiq"
 

--- a/sentry-sidekiq/lib/sentry-sidekiq.rb
+++ b/sentry-sidekiq/lib/sentry-sidekiq.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "sidekiq"
 require "sentry-ruby"
 require "sentry/integrable"

--- a/sentry-sidekiq/lib/sentry/sidekiq/configuration.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   class Configuration
     attr_reader :sidekiq

--- a/sentry-sidekiq/lib/sentry/sidekiq/context_filter.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/context_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Sidekiq
     class ContextFilter

--- a/sentry-sidekiq/lib/sentry/sidekiq/context_filter.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/context_filter.rb
@@ -3,8 +3,8 @@
 module Sentry
   module Sidekiq
     class ContextFilter
-      ACTIVEJOB_RESERVED_PREFIX_REGEX = /^_aj_/.freeze
-      SIDEKIQ_NAME = "Sidekiq".freeze
+      ACTIVEJOB_RESERVED_PREFIX_REGEX = /^_aj_/
+      SIDEKIQ_NAME = "Sidekiq"
 
       attr_reader :context
 

--- a/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "sentry/sidekiq/context_filter"
 
 module Sentry

--- a/sentry-sidekiq/lib/sentry/sidekiq/version.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sentry
   module Sidekiq
     VERSION = "5.20.1"

--- a/sentry-sidekiq/sentry-sidekiq.gemspec
+++ b/sentry-sidekiq/sentry-sidekiq.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/sentry/sidekiq/version"
 
 Gem::Specification.new do |spec|

--- a/sentry-sidekiq/spec/sentry/rails_spec.rb
+++ b/sentry-sidekiq/spec/sentry/rails_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 return unless ENV["WITH_SENTRY_RAILS"]
 
 require "rails"

--- a/sentry-sidekiq/spec/sentry/sidekiq-scheduler/scheduler_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq-scheduler/scheduler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 return unless defined?(SidekiqScheduler::Scheduler)

--- a/sentry-sidekiq/spec/sentry/sidekiq/configuration_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Sidekiq::Configuration do

--- a/sentry-sidekiq/spec/sentry/sidekiq/context_filter_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/context_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Sentry::Sidekiq::ContextFilter do

--- a/sentry-sidekiq/spec/sentry/sidekiq/cron/job_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/cron/job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 return unless defined?(Sidekiq::Cron::Job)

--- a/sentry-sidekiq/spec/sentry/sidekiq/error_handler_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/error_handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Sentry::Sidekiq::ErrorHandler do

--- a/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.shared_context "sidekiq", shared_context: :metadata do

--- a/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require 'sidekiq/manager'
 require 'sidekiq/api'

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 begin
   require "debug/prelude"


### PR DESCRIPTION
Currently, some string literals are frozen with the frozen literal comment, some with `freeze` calls, and some are not frozen at all.

I think we can standardize it with RuboCop so it's easier to maintain.

I recommend reviewing by commits and I added a changelog for this too in case the newly frozen string causes some unexpected issues.