### PR TITLE
RescuedExceptionInterceptor: Handle empty configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix Vernier profiler not stopping when already stopped [#2429](https://github.com/getsentry/sentry-ruby/pull/2429)
 - Fix `send_default_pii` handling in rails controller spans [#2443](https://github.com/getsentry/sentry-ruby/pull/2443)
   - Fixes [#2438](https://github.com/getsentry/sentry-ruby/issues/2438)
+- Fix `RescuedExceptionInterceptor` to handle an empty configuration [#2428](https://github.com/getsentry/sentry-ruby/pull/2428)
 
 ## 5.21.0
 

--- a/sentry-rails/lib/sentry/rails/rescued_exception_interceptor.rb
+++ b/sentry-rails/lib/sentry/rails/rescued_exception_interceptor.rb
@@ -19,7 +19,16 @@ module Sentry
       end
 
       def report_rescued_exceptions?
-        Sentry.configuration.rails.report_rescued_exceptions
+        # In rare edge cases, `Sentry.configuration` might be `nil` here.
+        # Hence, we use a safe navigation and fallback to a reasonable default
+        # of `true` in case the configuration couldn't be loaded.
+        # See https://github.com/getsentry/sentry-ruby/issues/2386
+        report_rescued_exceptions = Sentry.configuration&.rails&.report_rescued_exceptions
+        return report_rescued_exceptions unless report_rescued_exceptions.nil?
+
+        # `true` is the default for `report_rescued_exceptions`, as specified in
+        # `sentry-rails/lib/sentry/rails/configuration.rb`.
+        true
       end
     end
   end


### PR DESCRIPTION
<!--
Thanks for your Pull Request 🎉 

**Please keep these instructions in mind so we can review it more efficiently:**

- Add the references of all the related issues/PRs in the description
- Whether it's a new feature or a bug fix, make sure they're covered by new test cases
- If this PR contains any refactoring work, please give it its own commit(s)
- Finally, please add an entry to the corresponding changelog


**Other Notes**
- We squash all commits before merging
- We generally review new PRs within a week
- If you have any question, you can ask for feedback in our [discord community](https://discord.gg/Ww9hbqr) first

## Description
Describe your changes:
-->

Previously, it could happen that `Sentry.configuration` was `nil`. In this case, calling `rails` would produce a `NoMethodError`. We fix this issue by using safe navigation.

Furthermore, this commit ensures we use a reasonable default in case the configuration couldn't be loaded. Since the config `report_rescued_exceptions` defaults to `true`, we assume this value here, too.
 
Fixes #2386