### PR TITLE
Fix issues with stopping Vernier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add `include_sentry_event` matcher for RSpec [#2424](https://github.com/getsentry/sentry-ruby/pull/2424)
 
+### Bug Fixes
+
+- Fix Vernier profiler not stopping when already stopped [#2429](https://github.com/getsentry/sentry-ruby/pull/2429)
+
 ## 5.21.0
 
 ### Features

--- a/sentry-ruby/lib/sentry/vernier/profiler.rb
+++ b/sentry-ruby/lib/sentry/vernier/profiler.rb
@@ -55,8 +55,7 @@ module Sentry
         return unless @sampled
         return if @started
 
-        ::Vernier.start_profile
-        @started = true
+        @started = ::Vernier.start_profile
 
         log("Started")
 
@@ -77,6 +76,12 @@ module Sentry
         @result = ::Vernier.stop_profile
 
         log("Stopped")
+      rescue RuntimeError => e
+        if e.message.include?("Profile not started")
+          log("Not stopped since not started")
+        else
+          log("Failed to stop Vernier: #{e.message}")
+        end
       end
 
       def active_thread_id

--- a/sentry-ruby/spec/sentry/vernier/profiler_spec.rb
+++ b/sentry-ruby/spec/sentry/vernier/profiler_spec.rb
@@ -133,6 +133,20 @@ RSpec.describe Sentry::Vernier::Profiler, when: { ruby_version?: [:>=, "3.2.1"] 
       expect(Vernier).to receive(:stop_profile)
       profiler.stop
     end
+
+    it 'does not crash when Vernier was already stopped' do
+      profiler.set_initial_sample_decision(true)
+      profiler.start
+      Vernier.stop_profile
+      profiler.stop
+    end
+
+    it 'does not crash when stopping Vernier crashed' do
+      profiler.set_initial_sample_decision(true)
+      profiler.start
+      expect(Vernier).to receive(:stop_profile).and_raise(RuntimeError.new("Profile not started"))
+      profiler.stop
+    end
   end
 
   describe "#to_hash" do


### PR DESCRIPTION
This ensures that we rely on status returned from `Vernier.start_profile` when setting profiler's `@started` value and also now `Sentry::Vernier::Profiler#stop` will fail gracefully when for whatever reason stopping crashed.

Fixes #2425 