### PR TITLE
Upload coverage from all test runs

### DIFF
--- a/.github/workflows/sentry_opentelemetry_test.yml
+++ b/.github/workflows/sentry_opentelemetry_test.yml
@@ -43,7 +43,6 @@ jobs:
                   rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal",
                 },
             }
-          - { ruby_version: 3.2, options: { codecov: 1 } }
     steps:
       - uses: actions/checkout@v1
 
@@ -57,7 +56,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        if: ${{ matrix.options.codecov }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -62,8 +62,7 @@ jobs:
             }
           - {
               ruby_version: "3.2",
-              rails_version: 7.1.0,
-              options: { codecov: 1 },
+              rails_version: 7.1.0
             }
     steps:
       - uses: actions/checkout@v1
@@ -83,7 +82,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        if: ${{ matrix.options.codecov }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -41,7 +41,6 @@ jobs:
                   rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal",
                 },
             }
-          - { ruby_version: "3.2", options: { codecov: 1 } }
     steps:
       - uses: actions/checkout@v1
       - name: Set up Ruby ${{ matrix.ruby_version }}
@@ -66,7 +65,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        if: ${{ matrix.options.codecov }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -57,8 +57,7 @@ jobs:
           - {
               ruby_version: 3.3,
               rack_version: 3.1,
-              redis_rb_version: 5.3,
-              options: { codecov: 1 },
+              redis_rb_version: 5.3
             }
     steps:
       - uses: actions/checkout@v1
@@ -78,7 +77,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        if: ${{ matrix.options.codecov }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -48,8 +48,7 @@ jobs:
             }
           - {
               ruby_version: "3.2",
-              sidekiq_version: 7.0,
-              options: { codecov: 1 },
+              sidekiq_version: 7.0
             }
     steps:
       - uses: actions/checkout@v1
@@ -71,7 +70,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        if: ${{ matrix.options.codecov }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
According to Codecov docs, merging reports works automatically (https://docs.codecov.com/docs/merging-reports) which means that if we just send multiple reports from all test runs, it'll merge them all. This PR shows that the coverage increased, so I guess it works?

#skip-changelog