### PR TITLE
Fix bundle cache on CI

### DIFF
--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -25,7 +25,12 @@ jobs:
         working-directory: sentry-delayed_job
     name: Ruby ${{ matrix.ruby_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ubuntu-latest
+    env:
+      RUBYOPT: ${{ matrix.options.rubyopt }}
+      BUNDLE_GEMFILE: ${{ github.workspace }}/sentry-delayed_job/Gemfile
+      BUNDLE_WITHOUT: rubocop
     strategy:
+      fail-fast: false
       matrix:
         ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         include:
@@ -55,13 +60,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
 
       - name: Run specs
-        env:
-          RUBYOPT: ${{ matrix.options.rubyopt }}
-        run: |
-          bundle install --jobs 4 --retry 3
-          bundle exec rake
+        run: bundle exec rake
 
       - name: Upload Coverage
         if: ${{ matrix.options.codecov }}

--- a/.github/workflows/sentry_opentelemetry_test.yml
+++ b/.github/workflows/sentry_opentelemetry_test.yml
@@ -25,7 +25,13 @@ jobs:
         working-directory: sentry-opentelemetry
     name: Ruby ${{ matrix.ruby_version }} & OpenTelemetry ${{ matrix.opentelemetry_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ubuntu-latest
+    env:
+      RUBYOPT: ${{ matrix.options.rubyopt }}
+      BUNDLE_GEMFILE: ${{ github.workspace }}/sentry-opentelemetry/Gemfile
+      BUNDLE_WITHOUT: rubocop
+      OPENTELEMETRY_VERSION: ${{ matrix.opentelemetry_version }}
     strategy:
+      fail-fast: false
       matrix:
         ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         # opentelemetry_version: [1.2.0]
@@ -48,12 +54,7 @@ jobs:
           bundler-cache: true
 
       - name: Run specs
-        env:
-          RUBYOPT: ${{ matrix.options.rubyopt }}
-          OPENTELEMETRY_VERSION: ${{ matrix.opentelemetry_version }}
-        run: |
-          bundle install --jobs 4 --retry 3
-          bundle exec rake
+        run: bundle exec rake
 
       - name: Upload Coverage
         if: ${{ matrix.options.codecov }}

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -19,6 +19,11 @@ jobs:
         working-directory: sentry-rails
     name: Ruby ${{ matrix.ruby_version }} & Rails ${{ matrix.rails_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ubuntu-latest
+    env:
+      RUBYOPT: ${{ matrix.options.rubyopt }}
+      BUNDLE_GEMFILE: ${{ github.workspace }}/sentry-rails/Gemfile
+      BUNDLE_WITHOUT: rubocop
+      RAILS_VERSION: ${{ matrix.rails_version }}
     strategy:
       fail-fast: false
       matrix:
@@ -75,12 +80,7 @@ jobs:
           bundler-cache: true
 
       - name: Build with Rails ${{ matrix.rails_version }}
-        env:
-          RAILS_VERSION: ${{ matrix.rails_version }}
-          RUBYOPT: ${{ matrix.options.rubyopt }}
-        run: |
-          bundle install --jobs 4 --retry 3
-          bundle exec rake
+        run: bundle exec rake
 
       - name: Upload Coverage
         if: ${{ matrix.options.codecov }}

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -25,7 +25,12 @@ jobs:
         working-directory: sentry-resque
     name: Ruby ${{ matrix.ruby_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ubuntu-latest
+    env:
+      RUBYOPT: ${{ matrix.options.rubyopt }}
+      BUNDLE_GEMFILE: ${{ github.workspace }}/sentry-resque/Gemfile_with_rails.rb
+      BUNDLE_WITHOUT: rubocop
     strategy:
+      fail-fast: false
       matrix:
         ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         include:
@@ -53,17 +58,10 @@ jobs:
       - name: Run specs
         env:
           RUBYOPT: ${{ matrix.options.rubyopt }}
-        run: |
-          bundle install --jobs 4 --retry 3
-          bundle exec rake
+        run: bundle exec rake
 
       - name: Run specs with Rails
-        env:
-          BUNDLE_GEMFILE: Gemfile_with_rails.rb
-          RUBYOPT: ${{ matrix.options.rubyopt }}
-        run: |
-          bundle install --jobs 4 --retry 3
-          bundle exec rake
+        run: bundle exec rake
 
       - name: Upload Coverage
         if: ${{ matrix.options.codecov }}

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUBYOPT: ${{ matrix.options.rubyopt }}
-      BUNDLE_GEMFILE: ${{ github.workspace }}/sentry-resque/Gemfile_with_rails.rb
+      BUNDLE_GEMFILE: ${{ github.workspace }}/sentry-resque/Gemfile
       BUNDLE_WITHOUT: rubocop
     strategy:
       fail-fast: false
@@ -55,12 +55,14 @@ jobs:
         with:
           redis-version: 5
 
-      - name: Run specs
+      - name: Run specs without Rails
         env:
           RUBYOPT: ${{ matrix.options.rubyopt }}
-        run: bundle exec rake
+        run: BUNDLE_WITHOUT="rubocop rails" bundle exec rake
 
       - name: Run specs with Rails
+        env:
+          RUBYOPT: ${{ matrix.options.rubyopt }}
         run: bundle exec rake
 
       - name: Upload Coverage

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -26,6 +26,12 @@ jobs:
     name: Ruby ${{ matrix.ruby_version }} & Rack ${{ matrix.rack_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      RUBYOPT: ${{ matrix.options.rubyopt }}
+      BUNDLE_GEMFILE: ${{ github.workspace }}/sentry-ruby/Gemfile
+      BUNDLE_WITHOUT: rubocop
+      RACK_VERSION: ${{ matrix.rack_version }}
+      REDIS_RB_VERSION: ${{ matrix.redis_rb_version }}
     strategy:
       fail-fast: false
       matrix:
@@ -69,14 +75,7 @@ jobs:
           redis-version: 6
 
       - name: Run specs with Rack ${{ matrix.rack_version }} and redis-rb ${{ matrix.redis_rb_version }}
-        env:
-          RUBYOPT: ${{ matrix.options.rubyopt }}
-          RACK_VERSION: ${{ matrix.rack_version }}
-          REDIS_RB_VERSION: ${{ matrix.redis_rb_version }}
-        run: |
-          bundle config set without 'rubocop'
-          bundle install --jobs 4 --retry 3
-          bundle exec rake
+        run: bundle exec rake
 
       - name: Upload Coverage
         if: ${{ matrix.options.codecov }}

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -66,7 +66,9 @@ jobs:
           redis-version: ${{ matrix.sidekiq_version == '7.0' && 6 || 5 }}
 
       - name: Run specs with Sidekiq ${{ matrix.sidekiq_version }}
-        run: make test
+        env:
+          WITH_SENTRY_RAILS: 1
+        run: bundle exec rake
 
       - name: Upload Coverage
         if: ${{ matrix.options.codecov }}

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -19,7 +19,13 @@ jobs:
         working-directory: sentry-sidekiq
     name: Ruby ${{ matrix.ruby_version }} & Sidekiq ${{ matrix.sidekiq_version }}, options - ${{ toJson(matrix.options) }}
     runs-on: ubuntu-latest
+    env:
+      RUBYOPT: ${{ matrix.options.rubyopt }}
+      BUNDLE_GEMFILE: ${{ github.workspace }}/sentry-sidekiq/Gemfile
+      BUNDLE_WITHOUT: rubocop
+      SIDEKIQ_VERSION: ${{ matrix.sidekiq_version }}
     strategy:
+      fail-fast: false
       matrix:
         sidekiq_version: ["5.0", "6.5", "7.0"]
         ruby_version: ["2.7", "3.0", "3.1", "3.2", "3.3", jruby]
@@ -60,12 +66,7 @@ jobs:
           redis-version: ${{ matrix.sidekiq_version == '7.0' && 6 || 5 }}
 
       - name: Run specs with Sidekiq ${{ matrix.sidekiq_version }}
-        env:
-          SIDEKIQ_VERSION: ${{ matrix.sidekiq_version }}
-          RUBYOPT: ${{ matrix.options.rubyopt }}
-        run: |
-          bundle install --jobs 4 --retry 3
-          make test
+        run: make test
 
       - name: Upload Coverage
         if: ${{ matrix.options.codecov }}

--- a/sentry-resque/Gemfile
+++ b/sentry-resque/Gemfile
@@ -10,3 +10,8 @@ gem "sentry-ruby", path: "../sentry-ruby"
 gem "resque-retry", "~> 1.8"
 
 eval_gemfile File.expand_path("../Gemfile", __dir__)
+
+group :rails do
+  gem "sentry-rails", path: "../sentry-rails"
+  gem "rails"
+end

--- a/sentry-resque/Gemfile_with_rails.rb
+++ b/sentry-resque/Gemfile_with_rails.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-eval_gemfile File.expand_path("Gemfile", __dir__)
-
-gem "sentry-rails", path: "../sentry-rails"
-gem "rails"

--- a/sentry-sidekiq/Makefile
+++ b/sentry-sidekiq/Makefile
@@ -1,5 +1,4 @@
 build:
-	bundle install
 	gem build sentry-sidekiq.gemspec
 
 test:

--- a/sentry-sidekiq/Makefile
+++ b/sentry-sidekiq/Makefile
@@ -1,6 +1,3 @@
 build:
+	bundle install
 	gem build sentry-sidekiq.gemspec
-
-test:
-	WITH_SENTRY_RAILS=1 bundle exec rspec spec/sentry/rails_spec.rb
-	bundle exec rspec


### PR DESCRIPTION
We didn't set BUNDLE_GEMFILE correctly so caching bundles didn't work. This PR fixes it which should give us a significant speed bump when running this massive test suite.

#skip-changelog