### PR TITLE
Make Sentry.{close,get_main_hub} thread-safe

### DIFF
--- a/sentry-sidekiq/Gemfile
+++ b/sentry-sidekiq/Gemfile
@@ -12,9 +12,6 @@ gem "sentry-rails", path: "../sentry-rails"
 # loofah changed the required ruby version in a patch so we need to explicitly pin it
 gem "loofah", "2.20.0" if RUBY_VERSION.to_f < 2.5
 
-# For https://github.com/ruby/psych/issues/655
-gem "psych", "5.1.0"
-
 sidekiq_version = ENV["SIDEKIQ_VERSION"]
 sidekiq_version = "7.0" if sidekiq_version.nil?
 sidekiq_version = Gem::Version.new(sidekiq_version)


### PR DESCRIPTION
Since we're dealing with a bunch of global vars in `Sentry.close`, it should be wrapped in a mutex sync because threads may be accessing these vars while Sentry is closing, and THAT *probably* causes #2386 and #2396.

#skip-changelog