### PR TITLE
Enforce latest rubygems on CI

### DIFF
--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -60,6 +60,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
+          rubygems: latest
           bundler-cache: true
 
       - name: Run specs

--- a/.github/workflows/sentry_opentelemetry_test.yml
+++ b/.github/workflows/sentry_opentelemetry_test.yml
@@ -50,6 +50,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
+          rubygems: latest
           bundler-cache: true
 
       - name: Run specs

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -76,6 +76,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
+          rubygems: latest
           bundler-cache: true
 
       - name: Build with Rails ${{ matrix.rails_version }}

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -47,6 +47,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
+          rubygems: latest
           bundler-cache: true
 
       - name: Start Redis

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -66,6 +66,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
+          rubygems: latest
           bundler-cache: true
 
       - name: Start Redis

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -36,7 +36,7 @@ jobs:
           - { ruby_version: 2.6, sidekiq_version: 5.0 }
           - { ruby_version: 2.6, sidekiq_version: 6.0 }
           - { ruby_version: jruby, sidekiq_version: 5.0 }
-          - { ruby_version: jruby, sidekiq_version: 6.0 }
+          - { ruby_version: jruby, sidekiq_version: 6.5 }
           - { ruby_version: jruby, sidekiq_version: 7.0 }
           - {
               ruby_version: "3.2",
@@ -57,6 +57,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
+          rubygems: latest
           bundler-cache: true
 
       - name: Start Redis

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -6,6 +6,8 @@ begin
 rescue LoadError
 end
 
+require "sidekiq"
+
 # this enables sidekiq's server mode
 require "sidekiq/cli"
 


### PR DESCRIPTION
This makes sure that we use latest rubygems on CI. Without this we're seeing random failures caused by bugs in old Rubygems when bundling may crash with ArgumentError.

I discovered this through #2436 failing like that: https://github.com/getsentry/sentry-ruby/actions/runs/11411361838/job/31767045829?pr=2436#step:4:123

#skip-changelog