### PR TITLE
Revert "Enforce latest rubygems on CI (#2439)"

### DIFF
--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -60,7 +60,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          rubygems: latest
           bundler-cache: true
 
       - name: Run specs

--- a/.github/workflows/sentry_opentelemetry_test.yml
+++ b/.github/workflows/sentry_opentelemetry_test.yml
@@ -50,7 +50,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          rubygems: latest
           bundler-cache: true
 
       - name: Run specs

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -76,7 +76,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          rubygems: latest
           bundler-cache: true
 
       - name: Build with Rails ${{ matrix.rails_version }}

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -47,7 +47,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          rubygems: latest
           bundler-cache: true
 
       - name: Start Redis

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -66,7 +66,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          rubygems: latest
           bundler-cache: true
 
       - name: Start Redis

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -36,7 +36,7 @@ jobs:
           - { ruby_version: 2.6, sidekiq_version: 5.0 }
           - { ruby_version: 2.6, sidekiq_version: 6.0 }
           - { ruby_version: jruby, sidekiq_version: 5.0 }
-          - { ruby_version: jruby, sidekiq_version: 6.5 }
+          - { ruby_version: jruby, sidekiq_version: 6.0 }
           - { ruby_version: jruby, sidekiq_version: 7.0 }
           - {
               ruby_version: "3.2",
@@ -57,7 +57,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          rubygems: latest
           bundler-cache: true
 
       - name: Start Redis

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -6,8 +6,6 @@ begin
 rescue LoadError
 end
 
-require "sidekiq"
-
 # this enables sidekiq's server mode
 require "sidekiq/cli"
 


### PR DESCRIPTION
No idea what's going on but after merging in CI started failing. I cleared the bundle cache but it didn't help :( Reverting for now.

#skip-changelog