### PR TITLE
Test sentry-rails against Rails 8.0.0

### DIFF
--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -51,6 +51,8 @@ jobs:
           - { ruby_version: "3.1", rails_version: 7.2.0 }
           - { ruby_version: "3.2", rails_version: 7.2.0 }
           - { ruby_version: "3.3", rails_version: 7.2.0 }
+          - { ruby_version: "3.2", rails_version: "8.0.0.rc1" }
+          - { ruby_version: "3.3", rails_version: "8.0.0.rc1" }
           - { ruby_version: "jruby", rails_version: 6.1.0 }
           - {
               ruby_version: "3.2",

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -42,9 +42,6 @@ gem "mini_magick"
 
 gem "sprockets-rails"
 
-gem "sidekiq"
-
-
 ruby_version = Gem::Version.new(RUBY_VERSION)
 
 if ruby_version < Gem::Version.new("2.5.0")

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -18,33 +18,31 @@ rails_version = ENV["RAILS_VERSION"]
 rails_version = "7.2.0" if rails_version.nil?
 rails_version = Gem::Version.new(rails_version)
 
-if rails_version >= Gem::Version.new("8.1.0.alpha")
-  gem "rails", github: "rails/rails"
+gem "rails", "~> #{rails_version}"
+
+if rails_version >= Gem::Version.new("8.0.0.alpha")
   gem "rspec-rails"
   gem "sqlite3", platform: :ruby
 elsif rails_version >= Gem::Version.new("7.1.0")
-  gem "rails", "~> #{rails_version}"
   gem "rspec-rails"
   gem "sqlite3", "~> 1.7.3", platform: :ruby
 elsif rails_version >= Gem::Version.new("6.1.0")
   gem "rspec-rails", "~> 4.0"
-  gem "rails", "~> #{rails_version}"
 
   if ruby_version >= Gem::Version.new("2.7.0")
     gem "sqlite3", "~> 1.7.3", platform: :ruby
   else
     gem "sqlite3", "~> 1.6.9", platform: :ruby
   end
-elsif rails_version >= Gem::Version.new("6.0.0")
-  gem "sqlite3", "~> 1.4.0", platform: :ruby
-  gem "rspec-rails", "~> 4.0"
-  gem "rails", "~> #{rails_version}"
-  gem "psych", "~> 3.0.0"
 else
-  gem "sqlite3", "~> 1.3.0", platform: :ruby
   gem "rspec-rails", "~> 4.0"
-  gem "rails", "~> #{rails_version}"
   gem "psych", "~> 3.0.0"
+
+  if rails_version >= Gem::Version.new("6.0.0")
+    gem "sqlite3", "~> 1.4.0", platform: :ruby
+  else
+    gem "sqlite3", "~> 1.3.0", platform: :ruby
+  end
 end
 
 if ruby_version < Gem::Version.new("2.5.0")

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -12,43 +12,50 @@ platform :jruby do
   gem "jdbc-sqlite3"
 end
 
+ruby_version = Gem::Version.new(RUBY_VERSION)
+
 rails_version = ENV["RAILS_VERSION"]
-rails_version = "7.1.0" if rails_version.nil?
+rails_version = "7.2.0" if rails_version.nil?
 rails_version = Gem::Version.new(rails_version)
 
-if rails_version < Gem::Version.new("6.0.0")
-  gem "sqlite3", "~> 1.3.0", platform: :ruby
-else
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0")
+if rails_version >= Gem::Version.new("8.1.0.alpha")
+  gem "rails", github: "rails/rails"
+  gem "rspec-rails"
+  gem "sqlite3", platform: :ruby
+elsif rails_version >= Gem::Version.new("7.1.0")
+  gem "rails", "~> #{rails_version}"
+  gem "rspec-rails"
+  gem "sqlite3", "~> 1.7.3", platform: :ruby
+elsif rails_version >= Gem::Version.new("6.1.0")
+  gem "rspec-rails", "~> 4.0"
+  gem "rails", "~> #{rails_version}"
+
+  if ruby_version >= Gem::Version.new("2.7.0")
     gem "sqlite3", "~> 1.7.3", platform: :ruby
   else
     gem "sqlite3", "~> 1.6.9", platform: :ruby
   end
-end
-
-if rails_version >= Gem::Version.new("8.0.0.alpha")
-  gem "rails", github: "rails/rails"
-  gem "rspec-rails"
-elsif rails_version >= Gem::Version.new("7.1.0")
+elsif rails_version >= Gem::Version.new("6.0.0")
+  gem "sqlite3", "~> 1.4.0", platform: :ruby
+  gem "rspec-rails", "~> 4.0"
   gem "rails", "~> #{rails_version}"
-  gem "rspec-rails"
+  gem "psych", "~> 3.0.0"
 else
+  gem "sqlite3", "~> 1.3.0", platform: :ruby
   gem "rspec-rails", "~> 4.0"
   gem "rails", "~> #{rails_version}"
   gem "psych", "~> 3.0.0"
 end
-
-gem "mini_magick"
-
-gem "sprockets-rails"
-
-ruby_version = Gem::Version.new(RUBY_VERSION)
 
 if ruby_version < Gem::Version.new("2.5.0")
   # https://github.com/flavorjones/loofah/pull/267
   # loofah changed the required ruby version in a patch so we need to explicitly pin it
   gem "loofah", "2.20.0"
 end
+
+gem "mini_magick"
+
+gem "sprockets-rails"
 
 gem "benchmark-ips"
 gem "benchmark_driver"

--- a/sentry-rails/spec/sentry/rails/activejob_spec.rb
+++ b/sentry-rails/spec/sentry/rails/activejob_spec.rb
@@ -309,21 +309,17 @@ RSpec.describe "ActiveJob integration" do
 
   context "when we are using an adapter which has a specific integration" do
     before do
-      Sentry.configuration.rails.skippable_job_adapters = ["ActiveJob::QueueAdapters::SidekiqAdapter"]
+      Sentry.configuration.rails.skippable_job_adapters = ["ActiveJob::QueueAdapters::TestAdapter"]
+    end
+
+    after do
+      Sentry.configuration.rails.skippable_job_adapters = []
     end
 
     it "does not trigger sentry and re-raises" do
-      begin
-        original_queue_adapter = FailedJob.queue_adapter
-        FailedJob.queue_adapter = :sidekiq
+      expect { FailedJob.perform_now }.to raise_error(FailedJob::TestError)
 
-        expect { FailedJob.perform_now }.to raise_error(FailedJob::TestError)
-
-        expect(transport.events.size).to eq(0)
-      ensure
-        # this doesn't affect test result, but we shouldn't change it anyway
-        FailedJob.queue_adapter = original_queue_adapter
-      end
+      expect(transport.events.size).to eq(0)
     end
   end
 

--- a/sentry-rails/spec/sentry/rails/tracing/active_support_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_support_subscriber_spec.rb
@@ -47,12 +47,11 @@ RSpec.describe Sentry::Rails::Tracing::ActiveSupportSubscriber, :subscriber, typ
       expect(transport.events.count).to eq(1)
       cache_transaction = transport.events.first.to_hash
       expect(cache_transaction[:type]).to eq("transaction")
-      expect(cache_transaction[:spans].count).to eq(2)
-      expect(cache_transaction[:spans][1][:op]).to eq("cache.put")
-      expect(cache_transaction[:spans][1][:origin]).to eq("auto.cache.rails")
+      expect(cache_transaction[:spans].count).to eq(1)
+      expect(cache_transaction[:spans][0][:op]).to eq("cache.put")
+      expect(cache_transaction[:spans][0][:origin]).to eq("auto.cache.rails")
     end
 
-    #
     it "tracks cache decrement" do
       skip("Tracks on Rails 8.0 for all Cache Stores; Until then only MemCached and Redis Stores.") if Rails.version.to_f < 8.0
 
@@ -67,9 +66,9 @@ RSpec.describe Sentry::Rails::Tracing::ActiveSupportSubscriber, :subscriber, typ
       expect(transport.events.count).to eq(1)
       cache_transaction = transport.events.first.to_hash
       expect(cache_transaction[:type]).to eq("transaction")
-      expect(cache_transaction[:spans].count).to eq(2)
-      expect(cache_transaction[:spans][1][:op]).to eq("cache.put")
-      expect(cache_transaction[:spans][1][:origin]).to eq("auto.cache.rails")
+      expect(cache_transaction[:spans].count).to eq(1)
+      expect(cache_transaction[:spans][0][:op]).to eq("cache.put")
+      expect(cache_transaction[:spans][0][:origin]).to eq("auto.cache.rails")
     end
 
     it "tracks cache read" do


### PR DESCRIPTION
This PR:
- Includes a commit from #2445, which can be merged separately or together
- Re-organizes Gemfile's Ruby/Rails conditions
- Updates Rails 8 specific tests
- Adds Rails 8.0.0.rc1 as test target (which can easily be updated to 8.0)

#skip-changelog
