### PR TITLE
Reset trace and transaction for sidekiq-cron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `include_sentry_event` matcher for RSpec [#2424](https://github.com/getsentry/sentry-ruby/pull/2424)
 - Add support for Sentry Cache instrumentation, when using Rails.cache ([#2380](https://github.com/getsentry/sentry-ruby/pull/2380))
 - Add support for Queue Instrumentation for Sidekiq. [#2403](https://github.com/getsentry/sentry-ruby/pull/2403)
+- Reset trace_id and add root transaction for sidekiq-cron [#2446](https://github.com/getsentry/sentry-ruby/pull/2446)
 
     Note: MemoryStore and FileStore require Rails 8.0+
 

--- a/sentry-sidekiq/lib/sentry/sidekiq/cron/job.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/cron/job.rb
@@ -12,6 +12,32 @@ module Sentry
   module Sidekiq
     module Cron
       module Job
+        def self.enqueueing_method
+          ::Sidekiq::Cron::Job.instance_methods.include?(:enque!) ? :enque! : :enqueue!
+        end
+
+        define_method(enqueueing_method) do |*args|
+          # make sure the current thread has a clean hub
+          Sentry.clone_hub_to_current_thread
+
+          Sentry.with_scope do |scope|
+            Sentry.with_session_tracking do
+              begin
+                scope.set_transaction_name("#{name} (#{klass})")
+
+                transaction = start_transaction(scope)
+                scope.set_span(transaction) if transaction
+                super(*args)
+
+                finish_transaction(transaction, 200)
+              rescue
+                finish_transaction(transaction, 500)
+                raise
+              end
+            end
+          end
+        end
+
         def save
           # validation failed, do nothing
           return false unless super
@@ -33,6 +59,22 @@ module Sentry
           end
 
           true
+        end
+
+        def start_transaction(scope)
+          Sentry.start_transaction(
+            name: scope.transaction_name,
+            source: scope.transaction_source,
+            op: "queue.sidekiq-cron",
+            origin: "auto.queue.sidekiq.cron"
+          )
+        end
+
+        def finish_transaction(transaction, status_code)
+          return unless transaction
+
+          transaction.set_http_status(status_code)
+          transaction.finish
         end
       end
     end


### PR DESCRIPTION
## Description
Adds a new transaciton and reset for Sidekiq cron #enque!, so that they are not forever-running traces in the web view.

~~Depends on #2403.~~

Fixes #2391 