### PR TITLE
Improve the accuracy of duration calculations in cron jobs monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add support for string errors in error reporter ([#2464](https://github.com/getsentry/sentry-ruby/pull/2464))
 - Reset trace_id and add root transaction for sidekiq-cron [#2446](https://github.com/getsentry/sentry-ruby/pull/2446)
 - Add support for Excon HTTP client instrumentation ([#2383](https://github.com/getsentry/sentry-ruby/pull/2383))
+- Improve the accuracy of duration calculations in cron jobs monitoring ([#2471](https://github.com/getsentry/sentry-ruby/pull/2471))
 
     Note: MemoryStore and FileStore require Rails 8.0+
 

--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 Individual gem's changelog has been deprecated. Please check the [project changelog](https://github.com/getsentry/sentry-ruby/blob/master/CHANGELOG.md).
 
-## Unreleased
-
-- Improve the accuracy of duration calculations in cron jobs monitoring ([#2471](https://github.com/getsentry/sentry-ruby/pull/2471))
-
 ## 4.4.2
 
 - Fix NoMethodError when SDK's dsn is nil [#1433](https://github.com/getsentry/sentry-ruby/pull/1433)

--- a/sentry-ruby/CHANGELOG.md
+++ b/sentry-ruby/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Individual gem's changelog has been deprecated. Please check the [project changelog](https://github.com/getsentry/sentry-ruby/blob/master/CHANGELOG.md).
 
+## Unreleased
+
+- Improve the accuracy of duration calculations in cron jobs monitoring ([#2471](https://github.com/getsentry/sentry-ruby/pull/2471))
+
 ## 4.4.2
 
 - Fix NoMethodError when SDK's dsn is nil [#1433](https://github.com/getsentry/sentry-ruby/pull/1433)

--- a/sentry-ruby/lib/sentry/cron/monitor_check_ins.rb
+++ b/sentry-ruby/lib/sentry/cron/monitor_check_ins.rb
@@ -14,12 +14,12 @@ module Sentry
                                                 :in_progress,
                                                 monitor_config: monitor_config)
 
-          start = Sentry.utc_now.to_i
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
           begin
             # need to do this on ruby <= 2.6 sadly
             ret = method(:perform).super_method.arity == 0 ? super() : super
-            duration = Sentry.utc_now.to_f - start
+            duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
 
             Sentry.capture_check_in(slug,
                                     :ok,
@@ -29,7 +29,7 @@ module Sentry
 
             ret
           rescue Exception
-            duration = Sentry.utc_now.to_f - start
+            duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
 
             Sentry.capture_check_in(slug,
                                     :error,

--- a/sentry-ruby/lib/sentry/cron/monitor_check_ins.rb
+++ b/sentry-ruby/lib/sentry/cron/monitor_check_ins.rb
@@ -19,7 +19,7 @@ module Sentry
           begin
             # need to do this on ruby <= 2.6 sadly
             ret = method(:perform).super_method.arity == 0 ? super() : super
-            duration = Sentry.utc_now.to_i - start
+            duration = Sentry.utc_now.to_f - start
 
             Sentry.capture_check_in(slug,
                                     :ok,
@@ -29,7 +29,7 @@ module Sentry
 
             ret
           rescue Exception
-            duration = Sentry.utc_now.to_i - start
+            duration = Sentry.utc_now.to_f - start
 
             Sentry.capture_check_in(slug,
                                     :error,


### PR DESCRIPTION
This pull request includes changes to the `perform` method in the `sentry-ruby/lib/sentry/cron/monitor_check_ins.rb` file to improve the accuracy of duration calculations.

* Changed the duration calculation to use floating-point precision instead of integer precision to improve accuracy. [[1]](diffhunk://#diff-b5003612709a99eda69c66d664ad3dfed9ba11297720f5e94a231b19f5f084d0L22-R22) [[2]](diffhunk://#diff-b5003612709a99eda69c66d664ad3dfed9ba11297720f5e94a231b19f5f084d0L32-R32)

Before:

![image](https://github.com/user-attachments/assets/55f0b351-9da5-4340-8407-48c8548795c5)

After:

![image](https://github.com/user-attachments/assets/2f8c298a-7122-4e2e-895b-585d53b7b2e0)

