### PR TITLE
Default to internal_error rather than unknown_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Safe-navigate to session flusher [#2396](https://github.com/getsentry/sentry-ruby/pull/2396)
 - Fix latency related nil error for Sidekiq Queues Module span data [#2486](https://github.com/getsentry/sentry-ruby/pull/2486)
   - Fixes [#2485](https://github.com/getsentry/sentry-ruby/issues/2485)
+- Default to `internal_error` error type for OpenTelemetry spans [#2473](https://github.com/getsentry/sentry-ruby/pull/2473)
 
 ## 5.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug fixes
+
+- Default to `internal_error` error type for OpenTelemetry spans [#2473](https://github.com/getsentry/sentry-ruby/pull/2473)
+
 ## 5.22.1
 
 ### Bug Fixes
@@ -5,7 +11,6 @@
 - Safe-navigate to session flusher [#2396](https://github.com/getsentry/sentry-ruby/pull/2396)
 - Fix latency related nil error for Sidekiq Queues Module span data [#2486](https://github.com/getsentry/sentry-ruby/pull/2486)
   - Fixes [#2485](https://github.com/getsentry/sentry-ruby/issues/2485)
-- Default to `internal_error` error type for OpenTelemetry spans [#2473](https://github.com/getsentry/sentry-ruby/pull/2473)
 
 ## 5.22.0
 

--- a/sentry-opentelemetry/lib/sentry/opentelemetry/span_processor.rb
+++ b/sentry-opentelemetry/lib/sentry/opentelemetry/span_processor.rb
@@ -151,7 +151,7 @@ module Sentry
         if (http_status_code = otel_span.attributes[SEMANTIC_CONVENTIONS::HTTP_STATUS_CODE])
           sentry_span.set_http_status(http_status_code)
         elsif (status_code = otel_span.status.code)
-          status = [0, 1].include?(status_code) ? "ok" : "unknown_error"
+          status = [0, 1].include?(status_code) ? "ok" : "internal_error"
           sentry_span.set_status(status)
         end
       end


### PR DESCRIPTION
When using `sentry-opentelemetry` to trace code that isn't related to an HTTP call, the `SpanProcessor` will set the status of a `Transaction` to be `"unknown_error"`, which is benign, but within Sentry UI this status is not interpreted as an error at all. 

The result is that all the impacted transactions appears to have 0% failure rate, etc. Changing it to `"internal_error"` prevents this, and also is in line with [other sentry SDKs](https://github.com/getsentry/sentry-python/blob/a7c2d704a90b374bc3c6a69365922614710d95f7/sentry_sdk/integrations/opentelemetry/span_processor.py#L304) behaviour.

Sidebar:  The `SpanEvent` metadata around exceptions seems to be dropped in the conversion process to `Transaction` , which is too bad.