### PR TITLE
Fix sentry-rails' backtrace cleaner issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - Fix `RescuedExceptionInterceptor` to handle an empty configuration [#2428](https://github.com/getsentry/sentry-ruby/pull/2428)
 - Add mutex sync to `SessionFlusher` aggregates [#2469](https://github.com/getsentry/sentry-ruby/pull/2469)
   - Fixes [#2468](https://github.com/getsentry/sentry-ruby/issues/2468)
+- Fix sentry-rails' backtrace cleaner issues ([#2475](https://github.com/getsentry/sentry-ruby/pull/2475))
+  - Fixes [#2472](https://github.com/getsentry/sentry-ruby/issues/2472)
 
 ## 5.21.0
 

--- a/sentry-rails/lib/sentry/rails/backtrace_cleaner.rb
+++ b/sentry-rails/lib/sentry/rails/backtrace_cleaner.rb
@@ -11,8 +11,10 @@ module Sentry
 
       def initialize
         super
-        # we don't want any default silencers because they're too aggressive
+        # We don't want any default silencers because they're too aggressive
         remove_silencers!
+        # We don't want any default filters because Rails 7.2 starts shortening the paths. See #2472
+        remove_filters!
 
         @root = "#{Sentry.configuration.project_root}/"
         add_filter do |line|

--- a/sentry-rails/lib/sentry/rails/backtrace_cleaner.rb
+++ b/sentry-rails/lib/sentry/rails/backtrace_cleaner.rb
@@ -16,10 +16,6 @@ module Sentry
         # We don't want any default filters because Rails 7.2 starts shortening the paths. See #2472
         remove_filters!
 
-        @root = "#{Sentry.configuration.project_root}/"
-        add_filter do |line|
-          line.start_with?(@root) ? line.from(@root.size) : line
-        end
         add_filter do |line|
           if line =~ RENDER_TEMPLATE_PATTERN
             line.sub(RENDER_TEMPLATE_PATTERN, "")

--- a/sentry-rails/spec/sentry/rails/event_spec.rb
+++ b/sentry-rails/spec/sentry/rails/event_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Sentry::Event do
     it 'marks in_app correctly' do
       frames = hash[:exception][:values][0][:stacktrace][:frames]
       expect(frames[0][:filename]).to eq("test/some/other/path")
+      expect(frames[0][:abs_path]).to eq("test/some/other/path")
       expect(frames[0][:in_app]).to eq(true)
       expect(frames[1][:filename]).to eq("/app/some/other/path")
       expect(frames[1][:in_app]).to eq(false)
@@ -41,7 +42,7 @@ RSpec.describe Sentry::Event do
       expect(frames[3][:in_app]).to eq(true)
       expect(frames[4][:filename]).to eq("vendor/bundle/some_gem.rb")
       expect(frames[4][:in_app]).to eq(false)
-      expect(frames[5][:filename]).to eq("vendor/bundle/cache/other_gem.rb")
+      expect(frames[5][:filename]).to eq("dummy/test_rails_app/vendor/bundle/cache/other_gem.rb")
       expect(frames[5][:in_app]).to eq(false)
     end
 
@@ -50,6 +51,7 @@ RSpec.describe Sentry::Event do
         $LOAD_PATH << "#{Rails.root}/app/models"
         frames = hash[:exception][:values][0][:stacktrace][:frames]
         expect(frames[3][:filename]).to eq("app/models/user.rb")
+        expect(frames[3][:abs_path]).to eq("#{Rails.root}/app/models/user.rb")
         $LOAD_PATH.delete("#{Rails.root}/app/models")
       end
     end
@@ -58,7 +60,8 @@ RSpec.describe Sentry::Event do
       it 'normalizes the filename using the load path' do
         $LOAD_PATH.push "vendor/bundle"
         frames = hash[:exception][:values][0][:stacktrace][:frames]
-        expect(frames[5][:filename]).to eq("cache/other_gem.rb")
+        expect(frames[5][:filename]).to eq("dummy/test_rails_app/vendor/bundle/cache/other_gem.rb")
+        expect(frames[5][:abs_path]).to eq("#{Rails.root}/vendor/bundle/cache/other_gem.rb")
         $LOAD_PATH.pop
       end
     end
@@ -66,7 +69,8 @@ RSpec.describe Sentry::Event do
     context "when a non-in_app path under project_root isn't on the load path" do
       it 'normalizes the filename using project_root' do
         frames = hash[:exception][:values][0][:stacktrace][:frames]
-        expect(frames[5][:filename]).to eq("vendor/bundle/cache/other_gem.rb")
+        expect(frames[5][:filename]).to eq("dummy/test_rails_app/vendor/bundle/cache/other_gem.rb")
+        expect(frames[5][:abs_path]).to eq("#{Rails.root}/vendor/bundle/cache/other_gem.rb")
       end
     end
   end

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -242,6 +242,16 @@ RSpec.describe Sentry::Rails, type: :request do
       expect(traces.dig(-1, "function")).to be_nil
     end
 
+    it "makes sure BacktraceCleaner gem cleanup doesn't affect context lines population" do
+      get "/view_exception"
+
+      traces = event.dig("exception", "values", 0, "stacktrace", "frames")
+      gem_frame = traces.find { |t| t["abs_path"].match(/actionview/) }
+      expect(gem_frame["pre_context"]).not_to be_empty
+      expect(gem_frame["post_context"]).not_to be_empty
+      expect(gem_frame["context_line"]).not_to be_empty
+    end
+
     it "doesn't filters exception backtrace if backtrace_cleanup_callback is overridden" do
       make_basic_app do |config|
         config.backtrace_cleanup_callback = lambda { |backtrace| backtrace }


### PR DESCRIPTION
## Clear Rails' default backtrace filters from Sentry's backtrace cleaner

In Rails 7.2, Rails's backtrace cleaner, which sentry-rails' backtrace cleaner inherits from, starts shortening gem's paths in backtraces. This will prevent sentry-ruby's `Sentry::Backtrace` from handling them correctly, which will result in issues like #2472.

This commit avoids the issue by clearing the default filters that Sentry's backtrace cleaner inherits.

## Remove premature path-removal filter

This filter removes the project root part from the stacktrace, which prevents
sentry-ruby from retaining the correct absolute path of it.

Generally speaking, if stacktrace is messed up between Rails versions, but not Ruby versions, then it's usually caused by `Sentry::Rails::BacktraceCleaner` and/or the `backtrace_cleanup_callback` [`sentry-ruby` registers](https://github.com/getsentry/sentry-ruby/blob/a9b3687d3ce5d00d5586ef3fe76ae8233d8405f1/sentry-rails/lib/sentry/rails/railtie.rb#L114) (less likely). But if the backtrace is messed up between Ruby versions, it'd be on `sentry-ruby`'s backtrace handling instead.

Closes #2472