### PR TITLE
Pin jar-dependencies for jruby CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem "rake", "~> 12.0"
 
 ruby_version = Gem::Version.new(RUBY_VERSION)
 
+gem "jar-dependencies", "0.4.1" if RUBY_PLATFORM == "java"
+
 # Development tools
 if ruby_version >= Gem::Version.new("2.7.0")
   gem "debug", github: "ruby/debug", platform: :ruby

--- a/sentry-delayed_job/Gemfile
+++ b/sentry-delayed_job/Gemfile
@@ -8,9 +8,6 @@ gemspec
 gem "sentry-ruby", path: "../sentry-ruby"
 gem "sentry-rails", path: "../sentry-rails"
 
-# For https://github.com/ruby/psych/issues/655
-gem "psych", "5.1.0"
-
 gem "delayed_job"
 gem "delayed_job_active_record"
 


### PR DESCRIPTION
new release broke via `psych`, see https://github.com/jruby/jruby/issues/7262#issuecomment-1206667383
#skip-changelog

