### PR TITLE
Fix ActiveJob tests for Rails 7.2 and 8.0

### DIFF
--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -22,7 +22,7 @@ gem "rails", "~> #{rails_version}"
 
 if rails_version >= Gem::Version.new("8.0.0")
   gem "rspec-rails"
-  gem "sqlite3", platform: :ruby
+  gem "sqlite3", "~> 2.1.1", platform: :ruby
 elsif rails_version >= Gem::Version.new("7.1.0")
   gem "rspec-rails"
   gem "sqlite3", "~> 1.7.3", platform: :ruby

--- a/sentry-rails/spec/sentry/rails/activejob_spec.rb
+++ b/sentry-rails/spec/sentry/rails/activejob_spec.rb
@@ -68,7 +68,7 @@ class FailedJobWithCron < FailedJob
 end
 
 
-RSpec.describe "without Sentry initialized" do
+RSpec.describe "without Sentry initialized", type: :job do
   it "runs job" do
     expect { FailedJob.perform_now }.to raise_error(FailedJob::TestError)
   end
@@ -78,7 +78,7 @@ RSpec.describe "without Sentry initialized" do
   end
 end
 
-RSpec.describe "ActiveJob integration" do
+RSpec.describe "ActiveJob integration", type: :job do
   before do
     make_basic_app
   end

--- a/sentry-rails/spec/spec_helper.rb
+++ b/sentry-rails/spec/spec_helper.rb
@@ -56,6 +56,8 @@ RSpec.configure do |config|
     ENV.delete('RAILS_ENV')
     ENV.delete('RACK_ENV')
   end
+
+  config.include ActiveJob::TestHelper, type: :job
 end
 
 def reload_send_event_job


### PR DESCRIPTION
## Description

This PR fixes the test suite so that the ActiveJob related tests pass with Rails 7.2 and 8.0.

While working on the ActiveJob integration, I noticed that one of the tests was failing with Rails 7.2 and 8.0, specifically this one: https://github.com/getsentry/sentry-ruby/blob/1eb011b2ae31459bd3e2060dae7925e3b2629572/sentry-rails/spec/sentry/rails/activejob_spec.rb#L310-L324

After investigating, I realized that with Rails >= 7.2, all the test jobs were using `ActiveJob::QueueAdapters::AsyncAdapter` as their queue adapter instead of `ActiveJob::QueueAdapters::TestAdapter`. This is likely because of [this change](https://github.com/rails/rails/pull/48585) that was introduced in Rails 7.2.

The fix is easy enough: we simply need to make sure `ActiveJob::TestHelper` is included before the test suite runs. After including the helper module, all test jobs correctly use `ActiveJob::QueueAdapters::TestAdapter` as their queue adapter.

What I don't understand is why this happens locally but not in CI 🤔

#skip-changelog