### PR TITLE
feat: Remove usage of user segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Fix latency related nil error for Sidekiq Queues Module span data [#2486](https://github.com/getsentry/sentry-ruby/pull/2486)
   - Fixes [#2485](https://github.com/getsentry/sentry-ruby/issues/2485)
 
+### Internal
+
+- Remove usage of user segment from baggage and dynamic sampling context propagation logic [#2493](https://github.com/getsentry/sentry-ruby/pull/2493) 
+
 ## 5.22.0
 
 ### Features

--- a/sentry-ruby/lib/sentry/propagation_context.rb
+++ b/sentry-ruby/lib/sentry/propagation_context.rb
@@ -125,7 +125,6 @@ module Sentry
         "environment" => configuration.environment,
         "release" => configuration.release,
         "public_key" => configuration.dsn&.public_key,
-        "user_segment" => @scope.user && @scope.user["segment"]
       }
 
       items.compact!

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -337,7 +337,6 @@ module Sentry
       items["transaction"] = name unless source_low_quality?
 
       user = @hub.current_scope&.user
-      items["user_segment"] = user["segment"] if user && user["segment"]
 
       items.compact!
       @baggage = Baggage.new(items, mutable: false)


### PR DESCRIPTION
ref https://github.com/getsentry/team-sdks/issues/44

user segment has been deprecated across all the sdks, and was never used for dynamic sampling logic, so it's safe to remove.