### PR TITLE
Add Metrics::Timing.duration_(start,end)

### DIFF
--- a/sentry-ruby/lib/sentry/cron/monitor_check_ins.rb
+++ b/sentry-ruby/lib/sentry/cron/monitor_check_ins.rb
@@ -14,12 +14,12 @@ module Sentry
                                                 :in_progress,
                                                 monitor_config: monitor_config)
 
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          start = Metrics::Timing.duration_start
 
           begin
             # need to do this on ruby <= 2.6 sadly
             ret = method(:perform).super_method.arity == 0 ? super() : super
-            duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+            duration = Metrics::Timing.duration_end(start)
 
             Sentry.capture_check_in(slug,
                                     :ok,
@@ -29,7 +29,7 @@ module Sentry
 
             ret
           rescue Exception
-            duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+            duration = Metrics::Timing.duration_end(start)
 
             Sentry.capture_check_in(slug,
                                     :error,

--- a/sentry-ruby/lib/sentry/metrics/timing.rb
+++ b/sentry-ruby/lib/sentry/metrics/timing.rb
@@ -37,6 +37,14 @@ module Sentry
         def week
           Sentry.utc_now.to_i / (3600.0 * 24.0 * 7.0)
         end
+
+        def duration_start
+          Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        end
+
+        def duration_end(start)
+          Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+        end
       end
     end
   end

--- a/sentry-ruby/spec/sentry/cron/monitor_check_ins_spec.rb
+++ b/sentry-ruby/spec/sentry/cron/monitor_check_ins_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe Sentry::Cron::MonitorCheckIns do
         expect(ok_event.monitor_slug).to eq('job')
         expect(ok_event.status).to eq(:ok)
         expect(ok_event.monitor_config).to be_nil
+        expect(ok_event.duration).to be > 0
       end
     end
 
@@ -162,6 +163,7 @@ RSpec.describe Sentry::Cron::MonitorCheckIns do
         expect(ok_event.monitor_slug).to eq('job')
         expect(ok_event.status).to eq(:ok)
         expect(ok_event.monitor_config).to be_nil
+        expect(ok_event.duration).to be > 0
       end
     end
 


### PR DESCRIPTION
This is just a quick follow-up after merging #2471

- Adds a helper for measuring duration
- Adds expectations for duration to check ins spec (this wouldn't pass before #2471)

#skip-changelog