### PR TITLE
Use attempt_threshold to skip reporting on first N attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - Improve the accuracy of duration calculations in cron jobs monitoring ([#2471](https://github.com/getsentry/sentry-ruby/pull/2471))
+- Use attempt_threshold to skip reporting on first N attempts ([#2503](https://github.com/getsentry/sentry-ruby/pull/2503))
 
 ### Bug fixes
 

--- a/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
@@ -109,16 +109,43 @@ RSpec.describe Sentry::Sidekiq do
     expect(retry_set.count).to eq(1)
   end
 
+  def retry_last_failed_job
+    retry_set.first.add_to_queue
+    job = queue.first
+    work = Sidekiq::BasicFetch::UnitOfWork.new('queue:default', job.value)
+    process_work(processor, work)
+  end
+
+  context "with attempt_threshold" do
+    it "doesn't report the error until attempts equal the threshold" do
+      worker = Class.new(SadWorker)
+      worker.sidekiq_options attempt_threshold: 3
+
+      execute_worker(processor, worker)
+      expect(transport.events.count).to eq(0)
+
+      retry_last_failed_job
+      expect(transport.events.count).to eq(0)
+
+      retry_last_failed_job
+      expect(transport.events.count).to eq(1)
+    end
+
+    it "doesn't report the error when threshold is not reached" do
+      worker = Class.new(SadWorker)
+      worker.sidekiq_options attempt_threshold: 3
+
+      execute_worker(processor, worker)
+      expect(transport.events.count).to eq(0)
+
+      retry_last_failed_job
+      expect(transport.events.count).to eq(0)
+    end
+  end
+
   context "with config.report_after_job_retries = true" do
     before do
       Sentry.configuration.sidekiq.report_after_job_retries = true
-    end
-
-    def retry_last_failed_job
-      retry_set.first.add_to_queue
-      job = queue.first
-      work = Sidekiq::BasicFetch::UnitOfWork.new('queue:default', job.value)
-      process_work(processor, work)
     end
 
     context "when retry: is specified" do


### PR DESCRIPTION
This is an implementation for #1632.

I am bringing over the concept of `attempt_threshold` from [Honeybadger](https://github.com/honeybadger-io/honeybadger-ruby/blob/master/lib/honeybadger/plugins/sidekiq.rb#L103).

Retry counting is a bit tricky, and so I included a comment [based on a GH comment from Honeybadger](https://github.com/honeybadger-io/honeybadger-ruby/pull/347/files#r390555981).

There are two relatively arbitrary decisions I made here that you should validate:
1. I am 1-indexing attempts, not 0-indexing
2. I am skipping until the number of attempts _equals_ the `attempt_threshold`. Alternatively, we could skip until number of attempts is _greater than_ `attempt_threshold`.

Thanks for your consideration!