### PR TITLE
Improve `before_send` and `before_send_transaction`'s return value handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Default to `internal_error` error type for OpenTelemetry spans [#2473](https://github.com/getsentry/sentry-ruby/pull/2473)
+- Improve `before_send` and `before_send_transaction`'s return value handling ([#2504](https://github.com/getsentry/sentry-ruby/pull/2504))
 
 ## 5.22.1
 

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -201,7 +201,7 @@ module Sentry
           spans_delta = spans_before - spans_after
           transport.record_lost_event(:before_send, "span", num: spans_delta) if spans_delta > 0
         else
-          # Avoid seraliazing the event object in this case because we aren't sure what it is and what it contains
+          # Avoid serializing the event object in this case because we aren't sure what it is and what it contains
           log_debug(<<~MSG)
             Discarded event because before_send_transaction didn't return a Sentry::TransactionEvent object but an instance of #{event.class}
           MSG

--- a/sentry-ruby/spec/sentry/client/event_sending_spec.rb
+++ b/sentry-ruby/spec/sentry/client/event_sending_spec.rb
@@ -248,6 +248,30 @@ RSpec.describe Sentry::Client do
         expect(dbl).not_to receive(:call)
         client.send_event(event)
       end
+
+      it "warns if before_send returns nil" do
+        string_io = StringIO.new
+        logger = Logger.new(string_io, level: :debug)
+        configuration.logger = logger
+        configuration.before_send = lambda do |_event, _hint|
+          nil
+        end
+
+        client.send_event(event)
+        expect(string_io.string).to include("Discarded event because before_send didn't return a Sentry::ErrorEvent object but an instance of NilClass")
+      end
+
+      it "warns if before_send returns non-Event objects" do
+        string_io = StringIO.new
+        logger = Logger.new(string_io, level: :debug)
+        configuration.logger = logger
+        configuration.before_send = lambda do |_event, _hint|
+          123
+        end
+
+        client.send_event(event)
+        expect(string_io.string).to include("Discarded event because before_send didn't return a Sentry::ErrorEvent object but an instance of Integer")
+      end
     end
 
     it_behaves_like "Event in send_event" do
@@ -289,6 +313,18 @@ RSpec.describe Sentry::Client do
         else
           expect(event["tags"]["called"]).to eq(true)
         end
+      end
+
+      it "warns if before_send_transaction returns nil" do
+        string_io = StringIO.new
+        logger = Logger.new(string_io, level: :debug)
+        configuration.logger = logger
+        configuration.before_send_transaction = lambda do |_event, _hint|
+          nil
+        end
+
+        client.send_event(event)
+        expect(string_io.string).to include("Discarded event because before_send_transaction didn't return a Sentry::TransactionEvent object but an instance of NilClass")
       end
     end
 

--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -26,7 +26,8 @@ end
 require "sentry-ruby"
 require "sentry/test_helper"
 
-Dir[Pathname(__dir__).join("support/**/*.rb")].sort.each { |f| require f }
+require "support/profiler"
+require "support/stacktrace_test_fixture"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
The 1st commit fixes a testing setup issue and the 2nd commit adds additional checks to the `before_send` and `before_send_transaction`'s callback values. I explained the changes with more details in the commit messages.