### PR TITLE
Add multi-root workspace configuration file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,11 @@ You can contribute to this project in the following ways:
 
 And if you have any questions, please feel free to reach out on [Discord].
 
+## Develop This Project With Multi-root Workspaces
+
+If you use editors that support [VS Code-style multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces),
+such as VS Code, Cursor...etc., opening the editor with `sentry-ruby.code-workspace` file will provide a better development experience.
+
 ## Contribute To Individual Gems
 
 - Install the dependencies of a specific gem by running `bundle` in it's subdirectory. I.e:

--- a/sentry-ruby.code-workspace
+++ b/sentry-ruby.code-workspace
@@ -1,0 +1,30 @@
+{
+    "folders": [
+        {
+            "path": "sentry-ruby"
+        },
+        {
+            "path": "sentry-rails"
+        },
+        {
+            "path": "sentry-sidekiq"
+        },
+        {
+            "path": "sentry-delayed_job"
+        },
+        {
+            "path": "sentry-resque"
+        },
+        {
+            "path": "sentry-opentelemetry"
+        },
+        {
+            "path": ".github"
+        }
+    ],
+    "extensions": {
+        "recommendations": [
+            "Shopify.ruby-lsp"
+        ]
+    }
+}


### PR DESCRIPTION
Currently, to make LSP servers like Ruby LSP properly work for gem, like `sentry-ruby`, we need to open `/sentry-ruby` separately. When working on tasks across multiple gems, like `sentry-ruby` and `sentry-rails`, it requires 2 separate VS Code windows while each can not interact with each other.

For example, when using `Debug` code lens provided by Ruby LSP in `sentry-rails`'s tests, we can put breakpoints inside `sentry-rails`'s codebase, but not in `sentry-ruby`.

But if we open the project through this new workspace configuration file, the multi-root workspace feature in VS Code will allow us to

- Access code across multiple gems
- Debug code with VS Code across multiple gems
- Run language servers independently for each gem

## Limitations

- `CHANGELOG.md` can't be included under this setting because VS Code decided to only support folders (https://github.com/microsoft/vscode/issues/45177)

## Potential Improvements

- We can add workspace-level copilot prompt to make Copilot smarter about the SDK ([example](https://github.com/Shopify/ruby-lsp/blob/da2fbec53682a31a74ab88241242131889b10827/lsp.code-workspace#L27-L31))
- We can add some launch configurations to make debugging with our example apps easier
- If you are used to [VS Code tasks](https://code.visualstudio.com/docs/editor/tasks), we can add some project-wide tasks (linting, testing...etc.) that may be handy



#skip-changelog
