### PR TITLE
Test Ruby 3.4; Upgrade actions workflows versions

### DIFF
--- a/.github/workflows/build_batch_release.yml
+++ b/.github/workflows/build_batch_release.yml
@@ -9,11 +9,11 @@ jobs:
     name: Build gems
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.3
+        ruby-version: 3.4
     - name: Build gem source
       run:  ruby .scripts/batch_build.rb
     - name: Archive Artifacts

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -9,12 +9,12 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.4
     - name: Capture sdk name
       uses: actions-ecosystem/action-regex-match@v2
       id: regex-match

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,11 +6,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: true
       - name: Run rubocop
         run: bundle exec rubocop

--- a/.github/workflows/prepare_batch_release.yml
+++ b/.github/workflows/prepare_batch_release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/prepare_raven_release.yml
+++ b/.github/workflows/prepare_raven_release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -49,7 +49,7 @@ jobs:
           - { ruby_version: "head" }
           - { ruby_version: 'jruby-head' }
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Install sqlite
         run: |
           # See https://github.community/t5/GitHub-Actions/ubuntu-latest-Apt-repository-list-issues/td-p/41122/page/2
@@ -68,6 +68,6 @@ jobs:
 
       - name: Upload Coverage
         if: ${{ matrix.options.codecov }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sentry_opentelemetry_test.yml
+++ b/.github/workflows/sentry_opentelemetry_test.yml
@@ -46,7 +46,7 @@ jobs:
         exclude:
           - { ruby_version: 'jruby-head' }
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby ${{ matrix.ruby_version }}
         uses: ruby/setup-ruby@v1
@@ -58,6 +58,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -51,8 +51,10 @@ jobs:
           - { ruby_version: "3.1", rails_version: 7.2.0 }
           - { ruby_version: "3.2", rails_version: 7.2.0 }
           - { ruby_version: "3.3", rails_version: 7.2.0 }
+          - { ruby_version: "3.4", rails_version: 7.2.0 }
           - { ruby_version: "3.2", rails_version: "8.0.0" }
           - { ruby_version: "3.3", rails_version: "8.0.0" }
+          - { ruby_version: "3.4", rails_version: "8.0.0" }
           - { ruby_version: "jruby", rails_version: 6.1.0 }
           - {
               ruby_version: "3.2",
@@ -67,7 +69,7 @@ jobs:
               rails_version: 7.1.0
             }
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Install sqlite and ImageMagick
         run: |
           # See https://github.community/t5/GitHub-Actions/ubuntu-latest-Apt-repository-list-issues/td-p/41122/page/2
@@ -84,6 +86,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sentry_raven_test.yml
+++ b/.github/workflows/sentry_raven_test.yml
@@ -48,7 +48,7 @@ jobs:
             rails_version: 6.0.0
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby ${{ matrix.ruby_version }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -44,7 +44,7 @@ jobs:
         exclude:
           - { ruby_version: 'jruby-head' }
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby_version }}
         uses: ruby/setup-ruby@v1
         with:
@@ -67,6 +67,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -59,10 +59,15 @@ jobs:
               rack_version: 3.1,
               redis_rb_version: 5.3
             }
+          - {
+              ruby_version: 3.4,
+              rack_version: 3.1,
+              redis_rb_version: 5.3
+            }
         exclude:
           - { ruby_version: 'jruby-head' }
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby ${{ matrix.ruby_version }}
         uses: ruby/setup-ruby@v1
@@ -79,6 +84,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         sidekiq_version: ["5.0", "6.5", "7.0"]
-        ruby_version: ["2.7", "3.0", "3.1", "3.2", "3.3", jruby]
+        ruby_version: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", jruby]
         include:
           - { ruby_version: 2.4, sidekiq_version: 5.0 }
           - { ruby_version: 2.5, sidekiq_version: 5.0 }
@@ -46,12 +46,11 @@ jobs:
                   rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal",
                 },
             }
-          - {
-              ruby_version: "3.2",
-              sidekiq_version: 7.0
-            }
+          - { ruby_version: "3.2", sidekiq_version: 7.0 }
+          - { ruby_version: "3.3", sidekiq_version: 7.0 }
+          - { ruby_version: "3.4", sidekiq_version: 7.0 }
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby ${{ matrix.ruby_version }}
         uses: ruby/setup-ruby@v1
@@ -70,6 +69,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,17 @@
 ### Features
 
 - Improve the accuracy of duration calculations in cron jobs monitoring ([#2471](https://github.com/getsentry/sentry-ruby/pull/2471))
+- Support `code.namespace` for Ruby 3.4+ stacktraces ([#2506](https://github.com/getsentry/sentry-ruby/pull/2506))
+
 
 ### Bug fixes
 
 - Default to `internal_error` error type for OpenTelemetry spans [#2473](https://github.com/getsentry/sentry-ruby/pull/2473)
+
+### Internal
+
+- Test Ruby 3.4 in CI ([#2506](https://github.com/getsentry/sentry-ruby/pull/2506))
+- Upgrade actions workflows versions ([#2506](https://github.com/getsentry/sentry-ruby/pull/2506))
 
 ## 5.22.1
 

--- a/sentry-rails/lib/sentry/rails/backtrace_cleaner.rb
+++ b/sentry-rails/lib/sentry/rails/backtrace_cleaner.rb
@@ -7,7 +7,7 @@ module Sentry
   module Rails
     class BacktraceCleaner < ActiveSupport::BacktraceCleaner
       APP_DIRS_PATTERN = /\A(?:\.\/)?(?:app|config|lib|test|\(\w*\))/
-      RENDER_TEMPLATE_PATTERN = /:in `.*_\w+_{2,3}\d+_\d+'/
+      RENDER_TEMPLATE_PATTERN = /:in (?:`|').*_\w+_{2,3}\d+_\d+'/
 
       def initialize
         super

--- a/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
@@ -71,6 +71,7 @@ module Sentry
 
                 if source_location
                   backtrace_line = Sentry::Backtrace::Line.parse(source_location)
+
                   span.set_data(Span::DataConventions::FILEPATH, backtrace_line.file) if backtrace_line.file
                   span.set_data(Span::DataConventions::LINENO, backtrace_line.number) if backtrace_line.number
                   span.set_data(Span::DataConventions::FUNCTION, backtrace_line.method) if backtrace_line.method

--- a/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/active_record_subscriber_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
         Post.all.to_a
       end
       query_line = __LINE__ - 2
+      rspec_class = self.name # RSpec::ExampleGroups::[....]
 
       before do
         transaction = Sentry::Transaction.new(sampled: true, hub: Sentry.get_current_hub)
@@ -94,6 +95,7 @@ RSpec.describe Sentry::Rails::Tracing::ActiveRecordSubscriber, :subscriber do
           data = span[:data]
           expect(data["code.filepath"]).to eq(__FILE__)
           expect(data["code.lineno"]).to eq(query_line)
+          expect(data["code.namespace"]).to eq(rspec_class) if RUBY_VERSION.to_f >= 3.4
           expect(data["code.function"]).to eq("foo")
         end
       end

--- a/sentry-ruby/lib/sentry/backtrace.rb
+++ b/sentry-ruby/lib/sentry/backtrace.rb
@@ -12,7 +12,7 @@ module Sentry
       RUBY_INPUT_FORMAT = /
         ^ \s* (?: [a-zA-Z]: | uri:classloader: )? ([^:]+ | <.*>):
         (\d+)
-        (?: :in\s('|`)([^']+)')?$
+        (?: :in\s('|`)(?:([\w:]+)\#)?([^']+)')?$
       /x
 
       # org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
@@ -37,10 +37,11 @@ module Sentry
       # @return [Line] The parsed backtrace line
       def self.parse(unparsed_line, in_app_pattern = nil)
         ruby_match = unparsed_line.match(RUBY_INPUT_FORMAT)
+
         if ruby_match
-          _, file, number, _, method = ruby_match.to_a
+          _, file, number, _, module_name, method = ruby_match.to_a
           file.sub!(/\.class$/, RB_EXTENSION)
-          module_name = nil
+          module_name = module_name
         else
           java_match = unparsed_line.match(JAVA_INPUT_FORMAT)
           _, module_name, method, file, number = java_match.to_a


### PR DESCRIPTION
## Description
Describe your changes:

Upgrades tons of actions/checkout@v1 to v4, add 3.4 to build matrix.

Other questions: Ruby 2.4 is supported and tested, although it's EOL since 2020. Same goes for all versions through 3.0 actually, in yearly increments.

I'm all for keeping the test suite including some EOL versions, but 2.4 seems excessive. 
