### PR TITLE
Use RFC2396_PARSER explicitly to avoid the warning.

### DIFF
--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -66,7 +66,7 @@ module Sentry
         # IPv6 url could look like '::1/path', and that won't parse without
         # wrapping it in square brackets.
         hostname = address =~ Resolv::IPv6::Regex ? "[#{address}]" : address
-        uri = req.uri || URI.parse(URI::DEFAULT_PARSER.escape("#{use_ssl? ? 'https' : 'http'}://#{hostname}#{req.path}"))
+        uri = req.uri || URI.parse(URI::RFC2396_PARSER.escape("#{use_ssl? ? 'https' : 'http'}://#{hostname}#{req.path}"))
         url = "#{uri.scheme}://#{uri.host}#{uri.path}" rescue uri.to_s
 
         result = { method: req.method, url: url }


### PR DESCRIPTION
Thanks for your Pull Request 🎉 

**Please keep these instructions in mind so we can review it more efficiently:**

- Add the references of all the related issues/PRs in the description
- Whether it's a new feature or a bug fix, make sure they're covered by new test cases
- If this PR contains any refactoring work, please give it its own commit(s)
- Finally, please add an entry to the corresponding changelog


**Other Notes**
- We squash all commits before merging
- We generally review new PRs within a week
- If you have any question, you can ask for feedback in our [discord community](https://discord.gg/Ww9hbqr) first

## Description
Describe your changes:

The URI library recently changed the `URI::DEFAULT_PARSER` to `URI::RFC3986_PARSER`.
https://github.com/ruby/uri/blob/master/lib/uri/common.rb#L22

Additionally, when using the `URI::RFC3986_PARSER.escape` method a warning is logged, telling that the method is obsolete and that `URI::RFC2396_PARSER.escape` should be used explicitly instead.
https://github.com/ruby/uri/blob/master/lib/uri/rfc3986_parser.rb#L155-L159

This results in a lot of warnings logged stderr. This simple fix should do the trick :)
