### PR TITLE
Fix issues with specs again

### DIFF
--- a/sentry-ruby/spec/isolated/init.rb
+++ b/sentry-ruby/spec/isolated/init.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+Sentry.init do |config|
+  config.dsn = Sentry::TestHelper::DUMMY_DSN
+end
+
+trap('HUP') do
+  hub = Sentry.get_main_hub
+  puts hub.class
+end
+
+Process.kill('HUP', Process.pid)

--- a/sentry-ruby/spec/isolated/init_spec.rb
+++ b/sentry-ruby/spec/isolated/init_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+SimpleCov.command_name "RSpecIsolated"
+
+RSpec.describe Sentry do
+  context "works within a trap context", when: { ruby_engine?: "ruby" } do
+    it "doesn't raise error when accessing main hub in trap context" do
+      out = `ruby spec/isolated/init.rb`
+
+      expect(out).to include("Sentry::Hub")
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -70,45 +70,6 @@ RSpec.describe Sentry do
         end
       end
     end
-
-    context "works within a trap context", when: { ruby_engine?: "ruby", ruby_version?: [:>=, "3.4"] } do
-      it "doesn't raise error when accessing main hub in trap context" do
-        read_pipe, write_pipe = IO.pipe
-
-        pid = fork do
-          described_class.init do |config|
-            config.dsn = Sentry::TestHelper::DUMMY_DSN
-          end
-
-          trap('HUP') do
-            hub = described_class.get_main_hub
-
-            write_pipe.write(hub.class.to_s)
-            write_pipe.close
-          end
-
-          Process.kill('HUP', Process.pid)
-        end
-
-        write_pipe.close
-
-        result = nil
-        retries = 0
-
-        while retries < 10
-          break if Process.wait(pid)
-
-          sleep 0.01
-
-          retries += 1
-        end
-
-        result = read_pipe.read
-        read_pipe.close
-
-        expect(result).to eq("Sentry::Hub")
-      end
-    end
   end
 
   describe "#clone_hub_to_current_thread" do

--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -26,8 +26,8 @@ end
 require "sentry-ruby"
 require "sentry/test_helper"
 
-require "support/profiler"
-require "support/stacktrace_test_fixture"
+require_relative "support/profiler"
+require_relative "support/stacktrace_test_fixture"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/sentry-sidekiq/spec/sentry/rails_spec.rb
+++ b/sentry-sidekiq/spec/sentry/rails_spec.rb
@@ -22,7 +22,7 @@ def make_basic_app
 
   app.config.hosts = nil
   app.config.secret_key_base = "test"
-  app.config.eager_load = true
+  app.config.eager_load = false
   app.initializer :configure_sentry do
     Sentry.init do |config|
       config.release = 'beta'


### PR DESCRIPTION
This spec couldn't run reliably on multiple older rubies, couldn't run at all on jruby, and it would hang forever every now and then. So I fixed it here.

This also disables eager_load in sidekiq tests (we did the same thing in rails spec suite last year) as it causes VERY strange errors, this time it was send_event_job.rb causing all sorts of weird crashes with modules or methods being undefined, like this one:

```
NoMethodError:
       undefined method `lookup' for ActiveJob::QueueAdapters:Module
```

#skip-changelog