### PR TITLE
Revert "Add date range to licence"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020-2025 Sentry
+Copyright (c) 2020 Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Reverts getsentry/sentry-ruby#2516

#skip-changelog

I'm sorry about the fuzz. We decided some time ago that we don't add date ranges to licenses in our internal [Open Source Legal Policy](https://www.notion.so/sentry/Open-Source-Legal-Policy-ac4885d265cb4d7898a01c060b061e42). 

cc @gavin-zee 