### PR TITLE
Stop relying on fugit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Test Ruby 3.4 in CI ([#2506](https://github.com/getsentry/sentry-ruby/pull/2506))
 - Upgrade actions workflows versions ([#2506](https://github.com/getsentry/sentry-ruby/pull/2506))
+- Stop relying on fugit ([#2519](https://github.com/getsentry/sentry-ruby/pull/2519))
 
 ## 5.22.1
 


### PR DESCRIPTION
It is an overkill to have a (implicit) dependency
on fugit, especially that it doesn't even offer
a public interface to do what we need.

It's older version don't support timezones in cron which I believe is the culprit in #2513.

Even if it's not, I still think it's a good change.