### PR TITLE
Accept Hash in `before_send*` callbacks again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Bug Fixes
+
+- Accept Hash in `before_send*` callbacks again ([#2529](https://github.com/getsentry/sentry-ruby/pull/2529))
+  - Fixes [#2526](https://github.com/getsentry/sentry-ruby/issues/2526)
+
 ## 5.22.2
 
 ### Features
@@ -6,7 +13,7 @@
 - Use attempt_threshold to skip reporting on first N attempts ([#2503](https://github.com/getsentry/sentry-ruby/pull/2503))
 - Support `code.namespace` for Ruby 3.4+ stacktraces ([#2506](https://github.com/getsentry/sentry-ruby/pull/2506))
 
-### Bug fixes
+### Bug Fixes
 
 - Default to `internal_error` error type for OpenTelemetry spans [#2473](https://github.com/getsentry/sentry-ruby/pull/2473)
 - Improve `before_send` and `before_send_transaction`'s return value handling ([#2504](https://github.com/getsentry/sentry-ruby/pull/2504))

--- a/sentry-ruby/spec/sentry/client/event_sending_spec.rb
+++ b/sentry-ruby/spec/sentry/client/event_sending_spec.rb
@@ -269,20 +269,22 @@ RSpec.describe Sentry::Client do
           123
         end
 
-        client.send_event(event)
+        return_value = client.send_event(event)
         expect(string_io.string).to include("Discarded event because before_send didn't return a Sentry::ErrorEvent object but an instance of Integer")
+        expect(return_value).to eq(nil)
       end
 
-      it "doesn't warn if before_send returns a Hash" do
+      it "warns about Hash value's deprecation" do
         string_io = StringIO.new
         logger = Logger.new(string_io, level: :debug)
         configuration.logger = logger
         configuration.before_send = lambda do |_event, _hint|
-          {}
+          { foo: "bar" }
         end
 
-        client.send_event(event)
-        expect(string_io.string).not_to include("Discarded event because before_send didn't return a Sentry::ErrorEvent object")
+        return_value = client.send_event(event)
+        expect(string_io.string).to include("Returning a Hash from before_send is deprecated and will be removed in the next major version.")
+        expect(return_value).to eq({ foo: "bar" })
       end
     end
 
@@ -335,20 +337,22 @@ RSpec.describe Sentry::Client do
           nil
         end
 
-        client.send_event(event)
+        return_value = client.send_event(event)
         expect(string_io.string).to include("Discarded event because before_send_transaction didn't return a Sentry::TransactionEvent object but an instance of NilClass")
+        expect(return_value).to be_nil
       end
 
-      it "doesn't warn if before_send returns a Hash" do
+      it "warns about Hash value's deprecation" do
         string_io = StringIO.new
         logger = Logger.new(string_io, level: :debug)
         configuration.logger = logger
         configuration.before_send_transaction = lambda do |_event, _hint|
-          {}
+          { foo: "bar" }
         end
 
-        client.send_event(event)
-        expect(string_io.string).not_to include("Discarded event because before_send_transaction didn't return a Sentry::TransactionEvent object")
+        return_value = client.send_event(event)
+        expect(string_io.string).to include("Returning a Hash from before_send_transaction is deprecated and will be removed in the next major version.")
+        expect(return_value).to eq({ foo: "bar" })
       end
     end
 

--- a/sentry-ruby/spec/sentry/client/event_sending_spec.rb
+++ b/sentry-ruby/spec/sentry/client/event_sending_spec.rb
@@ -272,6 +272,18 @@ RSpec.describe Sentry::Client do
         client.send_event(event)
         expect(string_io.string).to include("Discarded event because before_send didn't return a Sentry::ErrorEvent object but an instance of Integer")
       end
+
+      it "doesn't warn if before_send returns a Hash" do
+        string_io = StringIO.new
+        logger = Logger.new(string_io, level: :debug)
+        configuration.logger = logger
+        configuration.before_send = lambda do |_event, _hint|
+          {}
+        end
+
+        client.send_event(event)
+        expect(string_io.string).not_to include("Discarded event because before_send didn't return a Sentry::ErrorEvent object")
+      end
     end
 
     it_behaves_like "Event in send_event" do
@@ -325,6 +337,18 @@ RSpec.describe Sentry::Client do
 
         client.send_event(event)
         expect(string_io.string).to include("Discarded event because before_send_transaction didn't return a Sentry::TransactionEvent object but an instance of NilClass")
+      end
+
+      it "doesn't warn if before_send returns a Hash" do
+        string_io = StringIO.new
+        logger = Logger.new(string_io, level: :debug)
+        configuration.logger = logger
+        configuration.before_send_transaction = lambda do |_event, _hint|
+          {}
+        end
+
+        client.send_event(event)
+        expect(string_io.string).not_to include("Discarded event because before_send_transaction didn't return a Sentry::TransactionEvent object")
       end
     end
 


### PR DESCRIPTION
It was unintentionally dropped in #2504. But because we do want to stop accepting Hash value in the future, I made it print deprecation messages when a Hash is passed as well.

Closes #2526 