### PR TITLE
Changelog for 5.22.3

### DIFF
--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -16,7 +16,7 @@ jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
-      engine: cruby-jruby
+      engine: cruby
       min_version: 2.4
   test:
     needs: ruby-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 5.22.3
 
 ### Bug Fixes
 

--- a/sentry-delayed_job/Gemfile
+++ b/sentry-delayed_job/Gemfile
@@ -15,7 +15,7 @@ gem "rails", "> 5.0.0"
 
 platform :jruby do
   # See https://github.com/jruby/activerecord-jdbc-adapter/issues/1139
-  gem "activerecord-jdbcmysql-adapter", github: "jruby/activerecord-jdbc-adapter", ref: "6b3983bbbfda75ee2a1f5bc4c8d35efd7b71d84b"
+  gem "activerecord-jdbcmysql-adapter", "<71.0", github: "jruby/activerecord-jdbc-adapter", ref: "6b3983bbbfda75ee2a1f5bc4c8d35efd7b71d84b"
   gem "jdbc-sqlite3"
 end
 


### PR DESCRIPTION
#skip-changelog

temporarily removing jruby from delayed job matrix for release since CI's broken due to unrelated jdbc new release stuff