### PR TITLE
Revert "[rails] support string errors in error reporter (#2464)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - Fix handling of cron with tz in Cron::Job ([#2530](https://github.com/getsentry/sentry-ruby/pull/2530))
+- Revert "[rails] support string errors in error reporter (#2464)" ([#2533](https://github.com/getsentry/sentry-ruby/pull/2533))
 
 ## 5.22.3
 

--- a/sentry-rails/lib/sentry/rails/error_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/error_subscriber.rb
@@ -27,20 +27,7 @@ module Sentry
           hint.merge!(context.delete(:hint))
         end
 
-        options = { level: severity, contexts: { "rails.error" => context }, tags: tags, hint: hint }
-
-        case error
-        when String
-          Sentry::Rails.capture_message(error, **options)
-        when Exception
-          Sentry::Rails.capture_exception(error, **options)
-        else
-          log_debug("Expected an Exception or a String, got: #{error.inspect}")
-        end
-      end
-
-      def log_debug(message)
-        Sentry.configuration.logger.debug(message)
+        Sentry::Rails.capture_exception(error, level: severity, contexts: { "rails.error" => context }, tags: tags, hint: hint)
       end
     end
   end

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -366,32 +366,6 @@ RSpec.describe Sentry::Rails, type: :request do
 
         expect(transport.events.count).to eq(0)
       end
-
-      it "captures string messages through error reporter" do
-        Rails.error.report("Test message", severity: :info, handled: true, context: { foo: "bar" })
-
-        expect(transport.events.count).to eq(1)
-        event = transport.events.first
-
-        expect(event.message).to eq("Test message")
-        expect(event.level).to eq(:info)
-        expect(event.contexts).to include({ "rails.error" => { foo: "bar" } })
-        expect(event.tags).to include({ handled: true })
-      end
-
-      it "skips non-string and non-exception errors" do
-        expect {
-          Sentry.init do |config|
-            config.logger = Logger.new($stdout)
-          end
-
-          Sentry.logger.debug("Expected an Exception or a String, got: #{312.inspect}")
-
-          Rails.error.report(312, severity: :info, handled: true, context: { foo: "bar" })
-        }.to output(/Expected an Exception or a String, got: 312/).to_stdout
-
-        expect(transport.events.count).to eq(0)
-      end
     end
   end
 end


### PR DESCRIPTION
This reverts commit b31f0f395af16953287e7154b383919c55d7a927.

Closes #2523 