### PR TITLE
Don't log warnings about missing deps when profiling is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Revert "[rails] support string errors in error reporter (#2464)" ([#2533](https://github.com/getsentry/sentry-ruby/pull/2533))
 - Removed unnecessary warning about missing `stackprof` when Vernier is configured as the profiler ([#2537](https://github.com/getsentry/sentry-ruby/pull/2537))
 
+### Internal
+
+- Introduced `Configuration#validate` to validate configuration in `Sentry.init` block ([#2538](https://github.com/getsentry/sentry-ruby/pull/2538))
+- Introduced `Sentry.dependency_installed?` to check if a 3rd party dependency is available ie `Sentry.dependency_installed?(:Vernier)` ([#2542](https://github.com/getsentry/sentry-ruby/pull/2542))
+
 ## 5.22.3
 
 ### Bug Fixes

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -609,6 +609,11 @@ module Sentry
     def utc_now
       Time.now.utc
     end
+
+    # @!visibility private
+    def dependency_installed?(name)
+      Object.const_defined?(name)
+    end
   end
 end
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -457,11 +457,11 @@ module Sentry
     end
 
     def validate
-      if profiler_class == Sentry::Profiler && !defined?(StackProf)
+      if profiler_class == Sentry::Profiler && profiles_sample_rate && !Sentry.dependency_installed?(:StackProf)
         log_warn("Please add the 'stackprof' gem to your Gemfile to use the StackProf profiler with Sentry.")
       end
 
-      if profiler_class == Sentry::Vernier::Profiler && !defined?(Vernier)
+      if profiler_class == Sentry::Vernier::Profiler && profiles_sample_rate && !Sentry.dependency_installed?(:Vernier)
         log_warn("Please add the 'vernier' gem to your Gemfile to use the Vernier profiler with Sentry.")
       end
 

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -708,4 +708,51 @@ RSpec.describe Sentry::Configuration do
       expect(subject.profiler_class).to eq(Sentry::Profiler)
     end
   end
+
+  describe "#validate" do
+    it "logs a warning if StackProf is not installed" do
+      allow(Sentry).to receive(:dependency_installed?).with(:StackProf).and_return(false)
+
+      expect {
+        Sentry.init do |config|
+          config.logger = Logger.new($stdout)
+          config.profiles_sample_rate = 1.0
+        end
+      }.to output(/Please add the 'stackprof' gem to your Gemfile/).to_stdout
+    end
+
+    it "doesn't log a warning when StackProf is not installed and profiles_sample_rate is not set" do
+      allow(Sentry).to receive(:dependency_installed?).with(:StackProf).and_return(false)
+
+      expect {
+        Sentry.init do |config|
+          config.logger = Logger.new($stdout)
+          config.profiles_sample_rate = nil
+        end
+      }.to_not output(/Please add the 'stackprof' gem to your Gemfile/).to_stdout
+    end
+
+    it "logs a warning if Vernier is not installed" do
+      allow(Sentry).to receive(:dependency_installed?).with(:Vernier).and_return(false)
+
+      expect {
+        Sentry.init do |config|
+          config.logger = Logger.new($stdout)
+          config.profiler_class = Sentry::Vernier::Profiler
+          config.profiles_sample_rate = 1.0
+        end
+      }.to output(/Please add the 'vernier' gem to your Gemfile/).to_stdout
+    end
+
+    it "doesn't log a warning when Vernier is not installed and profiles_sample_rate is not set" do
+      allow(Sentry).to receive(:dependency_installed?).with(:Vernier).and_return(false)
+
+      expect {
+        Sentry.init do |config|
+          config.logger = Logger.new($stdout)
+          config.profiles_sample_rate = nil
+        end
+      }.to_not output(/Please add the 'vernier' gem to your Gemfile/).to_stdout
+    end
+  end
 end


### PR DESCRIPTION
Quick follow-up after #2537 

I *really tried* to do it without introducing a new method but it was hopeless. I also think we need a robust mechanism for checking if a 3rd party dep is present and this is the first step in that direction.

Refs #2534
 