### PR TITLE
Use relative path for common Gemfile

### DIFF
--- a/sentry-delayed_job/Gemfile
+++ b/sentry-delayed_job/Gemfile
@@ -31,4 +31,4 @@ elsif ruby_version >= Gem::Version.new("3.1.0")
   gem "sqlite3", "~> 2.2", platform: :ruby
 end
 
-eval_gemfile File.expand_path("../Gemfile", __dir__)
+eval_gemfile "../Gemfile"

--- a/sentry-opentelemetry/Gemfile
+++ b/sentry-opentelemetry/Gemfile
@@ -13,4 +13,4 @@ gem "opentelemetry-instrumentation-rails"
 
 gem "sentry-ruby", path: "../sentry-ruby"
 
-eval_gemfile File.expand_path("../Gemfile", __dir__)
+eval_gemfile "../Gemfile"

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -60,4 +60,4 @@ gem "benchmark_driver"
 gem "benchmark-ipsa"
 gem "benchmark-memory"
 
-eval_gemfile File.expand_path("../Gemfile", __dir__)
+eval_gemfile "../Gemfile"

--- a/sentry-resque/Gemfile
+++ b/sentry-resque/Gemfile
@@ -12,7 +12,7 @@ gem "sentry-ruby", path: "../sentry-ruby"
 
 gem "resque-retry", "~> 1.8"
 
-eval_gemfile File.expand_path("../Gemfile", __dir__)
+eval_gemfile "../Gemfile"
 
 group :rails do
   gem "sentry-rails", path: "../sentry-rails"

--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -32,4 +32,4 @@ gem "webrick"
 gem "faraday"
 gem "excon"
 
-eval_gemfile File.expand_path("../Gemfile", __dir__)
+eval_gemfile "../Gemfile"

--- a/sentry-sidekiq/Gemfile
+++ b/sentry-sidekiq/Gemfile
@@ -27,4 +27,4 @@ gem "rails", "> 5.0.0"
 
 gem "timecop"
 
-eval_gemfile File.expand_path("../Gemfile", __dir__)
+eval_gemfile "../Gemfile"


### PR DESCRIPTION
Dependabot does not allow paths to custom gemfiles constructed dynamically, and since it's not really needed, this PR uses relative path to our common Gemfile for all the projects.

#skip-changelog