### PR TITLE
Add Sidekiq 8.0 beta to CI metrix

### DIFF
--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -45,11 +45,11 @@ jobs:
             options:
               rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal"
           - ruby_version: "3.2"
-            sidekiq_version: 7.0
+            sidekiq_version: 8.0.0.beta1
           - ruby_version: "3.3"
-            sidekiq_version: 7.0
+            sidekiq_version: 8.0.0.beta1
           - ruby_version: "3.4"
-            sidekiq_version: 7.0
+            sidekiq_version: 8.0.0.beta1
     steps:
       - uses: actions/checkout@v4
 
@@ -62,7 +62,7 @@ jobs:
       - name: Start Redis
         uses: supercharge/redis-github-action@1.1.0
         with:
-          redis-version: ${{ matrix.sidekiq_version == '7.0' && 6 || 5 }}
+          redis-version: ${{ (contains(matrix.sidekiq_version, '7.0') || contains(matrix.sidekiq_version, '8.0')) && 6 || 5 }}
 
       - name: Run specs with Sidekiq ${{ matrix.sidekiq_version }}
         env:


### PR DESCRIPTION
I was expecting to see some broken tests and fix them in this PR. But it's great to see our SDK may be 100% compatible with the next major Sidekiq version too :-)

#skip-changelog