### PR TITLE
Better CI setup

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -21,10 +21,8 @@ on:
 jobs:
   codecov:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Codecov
-        uses: codecov/codecov-action@v5.3.1
-
-      - name: Trigger Codecov
-        run: codecovcli send-notifications
+        uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3
+        run_command: send-notifications

--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -2,24 +2,22 @@ name: sentry-delayed_job Test
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
-      - \d+-\d+
-  pull_request:
+  workflow_call:
+    outputs:
+      matrix-result:
+        description: "Matrix job result"
+        value: ${{ jobs.test.outputs.matrix-result }}
+    inputs:
+      versions:
+        required: true
+        type: string
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: sentry-delayed-job-test-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
-  ruby-versions:
-    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
-    with:
-      engine: cruby-jruby
-      min_version: 2.4
   test:
-    needs: ruby-versions
     defaults:
       run:
         working-directory: sentry-delayed_job
@@ -32,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
+        ruby_version: ${{ fromJson(inputs.versions) }}
         include:
           - ruby_version: "3.2"
             options:

--- a/.github/workflows/sentry_opentelemetry_test.yml
+++ b/.github/workflows/sentry_opentelemetry_test.yml
@@ -2,24 +2,22 @@ name: sentry-opentelemetry Test
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
-      - \d+-\d+
-  pull_request:
+  workflow_call:
+    outputs:
+      matrix-result:
+        description: "Matrix job result"
+        value: ${{ jobs.test.outputs.matrix-result }}
+    inputs:
+      versions:
+        required: true
+        type: string
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: sentry-opentelemetry-test-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
-  ruby-versions:
-    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
-    with:
-      engine: cruby-jruby
-      min_version: 2.6
   test:
-    needs: ruby-versions
     defaults:
       run:
         working-directory: sentry-opentelemetry
@@ -33,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
+        ruby_version: ${{ fromJson(inputs.versions) }}
         # opentelemetry_version: [1.2.0]
         include:
           - ruby_version: 3.2

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -2,15 +2,15 @@ name: sentry-rails Test
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
-      - \d+-\d+
-  pull_request:
+  workflow_call:
+    inputs:
+      versions:
+        required: true
+        type: string
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: sentry-rails-test-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   test:
@@ -27,8 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        ruby_version: ${{ fromJson(inputs.versions) }}
         rails_version: [6.1.0, 7.0.0, 7.1.0]
-        ruby_version: [2.7, "3.0", "3.1", "3.2", "3.3"]
         include:
           - ruby_version: "2.4"
             rails_version: 5.0.0
@@ -88,6 +88,14 @@ jobs:
               rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal"
           - ruby_version: "3.2"
             rails_version: 7.1.0
+        exclude:
+          - ruby_version: head
+          - ruby_version: jruby-head
+          - ruby_version: "3.4"
+            rails_version: "6.1.0"
+          - ruby_version: "3.4"
+            rails_version: "7.0.0"
+
     steps:
       - uses: actions/checkout@v4
       - name: Install sqlite and ImageMagick

--- a/.github/workflows/sentry_raven_test.yml
+++ b/.github/workflows/sentry_raven_test.yml
@@ -12,7 +12,7 @@ on:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: sentry-raven-test-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   test:

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -2,24 +2,22 @@ name: sentry-resque Test
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
-      - \d+-\d+
-  pull_request:
+  workflow_call:
+    outputs:
+      matrix-result:
+        description: "Matrix job result"
+        value: ${{ jobs.test.outputs.matrix-result }}
+    inputs:
+      versions:
+        required: true
+        type: string
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: sentry-resque-test-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
-  ruby-versions:
-    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
-    with:
-      engine: cruby-jruby
-      min_version: 2.4
   test:
-    needs: ruby-versions
     defaults:
       run:
         working-directory: sentry-resque
@@ -32,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
+        ruby_version: ${{ fromJson(inputs.versions) }}
         include:
           - ruby_version: "3.2"
             options:

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -2,24 +2,18 @@ name: sentry-ruby Test
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
-      - \d+-\d+
-  pull_request:
+  workflow_call:
+    inputs:
+      versions:
+        required: true
+        type: string
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: sentry-ruby-test-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
-  ruby-versions:
-    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
-    with:
-      engine: cruby-jruby
-      min_version: 2.4
   test:
-    needs: ruby-versions
     defaults:
       run:
         working-directory: sentry-ruby
@@ -35,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
+        ruby_version: ${{ fromJson(inputs.versions) }}
         rack_version: [2.0, 3.0, 3.1]
         redis_rb_version: [4.0]
         include:

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -2,11 +2,15 @@ name: sentry-sidekiq Test
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
-      - \d+-\d+
-  pull_request:
+  workflow_call:
+    outputs:
+      matrix-result:
+        description: "Matrix job result"
+        value: ${{ jobs.test.outputs.matrix-result }}
+    inputs:
+      versions:
+        required: true
+        type: string
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
@@ -27,8 +31,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        ruby_version: ${{ fromJson(inputs.versions) }}
         sidekiq_version: ["5.0", "6.5", "7.0"]
-        ruby_version: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", jruby]
         include:
           - ruby_version: 2.4
             sidekiq_version: 5.0
@@ -56,6 +60,9 @@ jobs:
             sidekiq_version: 8.0.0.beta1
           - ruby_version: "3.4"
             sidekiq_version: 8.0.0.beta1
+        exclude:
+          - ruby_version: head
+          - ruby_version: jruby-head
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,74 @@
+name: Tests & CodeCov
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - \d+-\d+
+  pull_request:
+
+concurrency:
+  group: tests-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      engine: cruby-jruby
+      min_version: 2.7
+
+  delayed_job-tests:
+    needs: ruby-versions
+    uses: ./.github/workflows/sentry_delayed_job_test.yml
+    with:
+      versions: ${{ needs.ruby-versions.outputs.versions }}
+
+  opentelemetry-tests:
+    needs: ruby-versions
+    uses: ./.github/workflows/sentry_opentelemetry_test.yml
+    with:
+      versions: ${{ needs.ruby-versions.outputs.versions }}
+
+  rails-tests:
+    needs: ruby-versions
+    uses: ./.github/workflows/sentry_rails_test.yml
+    with:
+      versions: ${{ needs.ruby-versions.outputs.versions }}
+
+  resque-tests:
+    needs: ruby-versions
+    uses: ./.github/workflows/sentry_resque_test.yml
+    with:
+      versions: ${{ needs.ruby-versions.outputs.versions }}
+
+  ruby-tests:
+    needs: ruby-versions
+    uses: ./.github/workflows/sentry_ruby_test.yml
+    with:
+      versions: ${{ needs.ruby-versions.outputs.versions }}
+
+  sidekiq-tests:
+    needs: ruby-versions
+    uses: ./.github/workflows/sentry_sidekiq_test.yml
+    with:
+      versions: ${{ needs.ruby-versions.outputs.versions }}
+
+  codecov:
+    name: CodeCov
+    runs-on: ubuntu-latest
+    needs:
+      - ruby-tests
+      - rails-tests
+      - sidekiq-tests
+      - delayed_job-tests
+      - resque-tests
+      - opentelemetry-tests
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Codecov
+        uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3
+        with:
+          run_command: send-notifications

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   ruby-versions:
-    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@6d15c16f6259d657961bcdccf2598d3d53e90635
     with:
       engine: cruby-jruby
       min_version: 2.7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,3 +72,4 @@ jobs:
         uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3
         with:
           run_command: send-notifications
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This adds a new top-level workflow called "Tests & CodeCov" that orchestrates running tests for all 6 gems and once they are done, it runs CodeCov.

This has multiple advantages:

- We run ruby-versions workflow just once and pass it to the test workflows
- We can observe all tests running from a single workflow UI
- We run codecov after all coverage reports were submitted
- It looks cool 👇🏻

<img width="1546" alt="Screenshot 2025-02-19 at 14 28 32" src="https://github.com/user-attachments/assets/e042c02f-28c9-479a-8283-ead22778869a" />


#skip-changelog