### PR TITLE
TypeError when payload class is already a constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fix argument serialization for ranges that consist of ActiveSupport::TimeWithZone ([#2548](https://github.com/getsentry/sentry-ruby/pull/2548))
 - Prevent starting Vernier in nested transactions ([#2528](https://github.com/getsentry/sentry-ruby/pull/2528))
+- Fix TypeError when Resque.inline == true ([#2564] https://github.com/getsentry/sentry-ruby/pull/2564)
 
 ### Miscellaneous
 

--- a/sentry-resque/lib/sentry/resque.rb
+++ b/sentry-resque/lib/sentry/resque.rb
@@ -40,8 +40,11 @@ module Sentry
 
               finish_transaction(transaction, 200)
             rescue Exception => exception
-              klass = payload["class"]
-              klass = Object.const_get(klass) unless klass.is_a?(Class)
+              klass = if payload["class"].respond_to?(:constantize)
+                payload["class"].constantize
+              else
+                Object.const_get(payload["class"].to_s)
+              end
 
               raise if Sentry.configuration.resque.report_after_job_retries &&
                        defined?(::Resque::Plugins::Retry) == "constant" &&

--- a/sentry-resque/lib/sentry/resque.rb
+++ b/sentry-resque/lib/sentry/resque.rb
@@ -40,11 +40,8 @@ module Sentry
 
               finish_transaction(transaction, 200)
             rescue Exception => exception
-              klass = if payload["class"].respond_to?(:constantize)
-                payload["class"].constantize
-              else
-                Object.const_get(payload["class"].to_s)
-              end
+              klass = payload["class"]
+              klass = Object.const_get(klass) unless klass.is_a?(Class)
 
               raise if Sentry.configuration.resque.report_after_job_retries &&
                        defined?(::Resque::Plugins::Retry) == "constant" &&

--- a/sentry-resque/lib/sentry/resque.rb
+++ b/sentry-resque/lib/sentry/resque.rb
@@ -43,7 +43,7 @@ module Sentry
               klass = if payload["class"].respond_to?(:constantize)
                 payload["class"].constantize
               else
-                Object.const_get(payload["class"])
+                Object.const_get(payload["class"].to_s)
               end
 
               raise if Sentry.configuration.resque.report_after_job_retries &&

--- a/sentry-resque/spec/sentry/resque_spec.rb
+++ b/sentry-resque/spec/sentry/resque_spec.rb
@@ -208,6 +208,22 @@ RSpec.describe Sentry::Resque do
         expect(event[:tags]).to eq({ "resque.queue" => "default" })
       end
     end
+
+    context "with Resque.inline = true" do
+      around do |example|
+        Resque.inline = true
+        example.run
+        Resque.inline = false
+      end
+
+      it 'reports the class properly' do
+        expect do
+          Resque::Job.create(:default, FailedRetriableJob)
+          process_job(worker)
+        end.not_to raise_error
+      end
+    end
+
   end
 
   rails_gems = begin

--- a/sentry-resque/spec/sentry/resque_spec.rb
+++ b/sentry-resque/spec/sentry/resque_spec.rb
@@ -226,7 +226,6 @@ RSpec.describe Sentry::Resque do
         expect(event.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
       end
     end
-
   end
 
   rails_gems = begin

--- a/sentry-resque/spec/sentry/resque_spec.rb
+++ b/sentry-resque/spec/sentry/resque_spec.rb
@@ -220,7 +220,10 @@ RSpec.describe Sentry::Resque do
         expect do
           Resque::Job.create(:default, FailedRetriableJob)
           process_job(worker)
-        end.not_to raise_error
+        end.not_to raise_error(TypeError)
+
+        event = transport.events.last.to_hash
+        expect(event.dig(:exception, :values, 0, :type)).to eq("ZeroDivisionError")
       end
     end
 


### PR DESCRIPTION
## Description
When `Resque.inline = true`, which is often used in an application's specs when testing a Resque job's business logic, the `payload["class"]` that the Sentry hook gets is an actual class, not a string! I've added a spec for this case and fixed it by avoiding constantization if it's already a class.

Note: Reliance on [ActiveSupport::Inflector#constantize](https://github.com/rails/rails/blob/cf6ff17e9a3c6c1139040b519a341f55f0be16cf/activesupport/lib/active_support/inflector/methods.rb#L289) can be removed if/when `sentry-ruby` no longer supports Ruby 2.4-2.6. According to [this Rails commit](https://github.com/rails/rails/commit/7057ccf6565c1cb5354c1906880119276a9d15c0), `Object.const_get` works properly from Rails 2.7 on.