### PR TITLE
Multi ruby devcontainer setup

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -1,0 +1,7 @@
+IMAGE=bitnami/ruby
+
+# Adjust as needed
+TAG=3.4
+
+# IMAGE=jruby
+# TAG=latest

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,50 @@
+ARG IMAGE="bitnami/ruby"
+ARG TAG="latest"
+
+FROM ${IMAGE}:${TAG}
+
+USER root
+RUN apt-get update && apt-get install -y \
+  gnupg \
+  git \
+  curl \
+  wget \
+  zsh \
+  vim \
+  build-essential \
+  sudo \
+  libssl-dev \
+  libreadline-dev \
+  zlib1g-dev \
+  autoconf \
+  bison \
+  libyaml-dev \
+  libncurses5-dev \
+  libffi-dev \
+  libgdbm-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 1000 sentry \
+  && useradd --uid 1000 --gid sentry --shell /bin/zsh --create-home sentry
+
+# Add sentry to sudoers with NOPASSWD option
+RUN echo "sentry ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/sentry \
+  && chmod 0440 /etc/sudoers.d/sentry
+
+WORKDIR /workspace/sentry
+
+RUN chown -R sentry:sentry /workspace/sentry
+RUN mkdir /workspace/gems && chown -R sentry:sentry /workspace/gems
+
+ARG TAG=latest
+
+ENV LANG=C.UTF-8 \
+  BUNDLE_JOBS=4 \
+  BUNDLE_RETRY=3 \
+  GEM_HOME=/workspace/gems/${TAG} \
+  REDIS_HOST=redis
+
+USER sentry
+
+CMD ["ruby", "--version"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "sentry-ruby",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace/sentry",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "sleistner.vscode-fileutils",
+        "Shopify.ruby-lsp"
+      ]
+    }
+  },
+  "remoteUser": "sentry",
+  "postCreateCommand": "ruby --version"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        IMAGE: ${IMAGE}
+        TAG: ${TAG}
+    volumes:
+      - ..:/workspace/sentry:cached
+    command: sleep infinity
+    environment:
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:latest
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    ports:
+      - "6379:6379"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,18 @@ And if you have any questions, please feel free to reach out on [Discord].
 If you use editors that support [VS Code-style multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces),
 such as VS Code, Cursor...etc., opening the editor with `sentry-ruby.code-workspace` file will provide a better development experience.
 
+## Working in a devcontainer
+
+If you use [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension, you can open the project with the devcontainer by running `Remote-Containers: Reopen in Container` command.
+
+The devcontainer is configured with `.devcontainer/.env` file, that you need to create:
+
+```bash
+cp .devcontainer/.env.example .devcontainer/.env
+```
+
+This file defines which specific image and Ruby version will be used to run the code. Edit it whenever you need to use a different image or Ruby version.
+
 ## Contribute To Individual Gems
 
 - Install the dependencies of a specific gem by running `bundle` in it's subdirectory. I.e:

--- a/sentry-ruby.code-workspace
+++ b/sentry-ruby.code-workspace
@@ -1,30 +1,40 @@
 {
-    "folders": [
-        {
-            "path": "sentry-ruby"
-        },
-        {
-            "path": "sentry-rails"
-        },
-        {
-            "path": "sentry-sidekiq"
-        },
-        {
-            "path": "sentry-delayed_job"
-        },
-        {
-            "path": "sentry-resque"
-        },
-        {
-            "path": "sentry-opentelemetry"
-        },
-        {
-            "path": ".github"
-        }
-    ],
-    "extensions": {
-        "recommendations": [
-            "Shopify.ruby-lsp"
-        ]
+  "folders": [
+    {
+      "path": ".devcontainer"
+    },
+    {
+      "path": ".github",
+    },
+    {
+      "path": ".",
+      "name": "root"
+    },
+    {
+      "path": "sentry-ruby"
+    },
+    {
+      "path": "sentry-rails"
+    },
+    {
+      "path": "sentry-sidekiq"
+    },
+    {
+      "path": "sentry-delayed_job"
+    },
+    {
+      "path": "sentry-resque"
+    },
+    {
+      "path": "sentry-opentelemetry"
+    },
+    {
+      "path": "sentry-raven"
     }
+  ],
+  "extensions": {
+    "recommendations": [
+      "Shopify.ruby-lsp"
+    ]
+  }
 }

--- a/sentry-ruby/spec/sentry/breadcrumb/redis_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/redis_logger_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 RSpec.describe :redis_logger do
-  let(:redis) { Redis.new(host: "127.0.0.1") }
+  let(:redis) { Redis.new(host: REDIS_HOST) }
 
   before do
     perform_basic_setup do |config|
@@ -20,7 +20,7 @@ RSpec.describe :redis_logger do
       expect(result).to eq("OK")
       expect(Sentry.get_current_scope.breadcrumbs.peek).to have_attributes(
         category: "db.redis",
-        data: { commands: [{ command: "SET", key: "key" }], server: "127.0.0.1:6379/0" }
+        data: { commands: [{ command: "SET", key: "key" }], server: "#{REDIS_HOST}:6379/0" }
       )
     end
   end
@@ -34,7 +34,7 @@ RSpec.describe :redis_logger do
       expect(result).to eq("OK")
       expect(Sentry.get_current_scope.breadcrumbs.peek).to have_attributes(
         category: "db.redis",
-        data: { commands: [{ command: "SET", key: "key", arguments: "value" }], server: "127.0.0.1:6379/0" }
+        data: { commands: [{ command: "SET", key: "key", arguments: "value" }], server: "#{REDIS_HOST}:6379/0" }
       )
     end
 
@@ -62,7 +62,7 @@ RSpec.describe :redis_logger do
       expect(result.key?("uptime_in_days")).to eq(true)
       expect(Sentry.get_current_scope.breadcrumbs.peek).to have_attributes(
         category: "db.redis",
-        data: { commands: [{ command: "INFO", key: nil }], server: "127.0.0.1:6379/0" }
+        data: { commands: [{ command: "INFO", key: nil }], server: "#{REDIS_HOST}:6379/0" }
       )
     end
   end
@@ -88,7 +88,7 @@ RSpec.describe :redis_logger do
             { command: "INCR",  key: "counter" },
             { command: "EXEC",  key: nil }
           ],
-          server: "127.0.0.1:6379/0"
+          server: "#{REDIS_HOST}:6379/0"
         }
       )
     end
@@ -105,7 +105,7 @@ RSpec.describe :redis_logger do
       expect(result).to eq("OK")
       expect(Sentry.get_current_scope.breadcrumbs.peek).to have_attributes(
         category: "db.redis",
-        data: { commands: [{ command: "SET", key: "key" }], server: "127.0.0.1:6379/0" }
+        data: { commands: [{ command: "SET", key: "key" }], server: "#{REDIS_HOST}:6379/0" }
       )
     end
   end

--- a/sentry-ruby/spec/sentry/redis_spec.rb
+++ b/sentry-ruby/spec/sentry/redis_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 RSpec.describe Sentry::Redis do
-  let(:redis) { Redis.new(host: "127.0.0.1") }
+  let(:redis) { Redis.new(host: REDIS_HOST) }
 
   context "with tracing enabled" do
     before do
@@ -33,7 +33,7 @@ RSpec.describe Sentry::Redis do
           expect(request_span.data).to eq({
             "db.name" => 0,
             "db.system" => "redis",
-            "server.address" => "127.0.0.1",
+            "server.address" => REDIS_HOST,
             "server.port" => 6379
           })
         end

--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -18,6 +18,8 @@ SimpleCov.start do
   coverage_dir File.join(__FILE__, "../../coverage")
 end
 
+REDIS_HOST = ENV.fetch("REDIS_HOST", "127.0.0.1")
+
 if ENV["CI"]
   require 'simplecov-cobertura'
   SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter


### PR DESCRIPTION
I struggled a lot when switching between rubies to test things out / fix specs etc. so I ended up with a devcontainer setup that allows me to easily switch to a specific ruby version in VS Code.

I figured I could share this here because it may turn out to be useful for others.

The reason why this is based on devcontainers is simple - we support too many rubies that have conflicting dependencies. I could not use rvm or any other Ruby version manager to easily switch between super old crubies or jruby.

Furthermore, I think we could have a nice setup with relay running as a docker service which can *really help* with figuring things out with envelopes etc.

#skip-changelog