### PR TITLE
Stop byteslicing empty strings in breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Use `File.open` in `LineCache` ([#2566](https://github.com/getsentry/sentry-ruby/pull/2566))
 - Update java backtrace regexp ([#2567](https://github.com/getsentry/sentry-ruby/pull/2567))
+- Stop byteslicing empty strings in breadcrumbs ([#2574](https://github.com/getsentry/sentry-ruby/pull/2574))
 
 ### Miscellaneous
 

--- a/sentry-ruby/lib/sentry/breadcrumb.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb.rb
@@ -47,7 +47,7 @@ module Sentry
     # @param message [String]
     # @return [void]
     def message=(message)
-      @message = (message || "").byteslice(0..Event::MAX_MESSAGE_SIZE_IN_BYTES)
+      @message = message ? message.byteslice(0..Event::MAX_MESSAGE_SIZE_IN_BYTES) : ""
     end
 
     # @param level [String]


### PR DESCRIPTION
**Please keep these instructions in mind so we can review it more efficiently:**

- Add the references of all the related issues/PRs in the description
- Whether it's a new feature or a bug fix, make sure they're covered by new test cases
- If this PR contains any refactoring work, please give it its own commit(s)
- Finally, please add an entry to the corresponding changelog


**Other Notes**
- We squash all commits before merging
- We generally review new PRs within a week
- If you have any question, you can ask for feedback in our [discord community](https://discord.gg/Ww9hbqr) first

## Description
Describe your changes:

If we don't pass a message to the breadcrumb message, we default to an empty string. However we can avoid byteslicing it, which allocates a new empty string every time regardless.

This is a pretty hot path, and the tests pass. Only difference I can think of is returning a frozen empty string, which could cause issues downstream. Let me know if it should be dup-ed!

```rb

require 'benchmark-memory'

MAX_MESSAGE_SIZE_IN_BYTES = 1024 * 8

def current(message)
  (message || "").byteslice(0..MAX_MESSAGE_SIZE_IN_BYTES)
end

def updated(message)
  message ? message.byteslice(0..MAX_MESSAGE_SIZE_IN_BYTES) : ""
end

Benchmark.memory do |x|
  x.report("current") do
    current(nil)
  end

  x.report("updated") do
    updated(nil)
  end

  x.compare!
end
```

Calculating -------------------------------------
             current    80.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)
             updated     0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
             updated:          0 allocated
             current:         80 allocated - Infx more
