### PR TITLE
Update dev container setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,13 +2,17 @@
   "name": "sentry-ruby",
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
-  "workspaceFolder": "/workspace/sentry",
+  "workspaceFolder": "/workspace/sentry-ruby",
   "customizations": {
     "vscode": {
       "extensions": [
         "sleistner.vscode-fileutils",
         "Shopify.ruby-lsp"
-      ]
+      ],
+      "settings": {}
+    },
+    "rubyLsp.rubyVersionManager": {
+      "identifier": "none"
     }
   },
   "remoteUser": "sentry",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         IMAGE: ${IMAGE}
         TAG: ${TAG}
     volumes:
-      - ..:/workspace/sentry:cached
+      - ..:/workspace/sentry-ruby:cached
     command: sleep infinity
     environment:
       - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}


### PR DESCRIPTION
Addressing feedback from @st0012 with this PR:

> You mentioned that the VS Code command is called Remote-Containers: Reopen in Container, but I did find it and ended up using this instead. I wonder what's causing the difference 🤔

If you didn't have the project opened as a workspace, then it probably caused it?

> Screenshot 2025-03-08 at 22 55 35
> How did you pull your local shell configs...etc. into the container? I currently don't see a way to do it and it makes the terminal in the container hard to use 😢

VS Code has built-in support for dotfiles stored on github, so I just use that, it's been a game changer for me :)

See here https://code.visualstudio.com/docs/devcontainers/containers#_personalizing-with-dotfile-repositories

> I noticed that the top-level folder is sentry instead of sentry-ruby, which fails some tests (see below). Do you want to update the config to use sentry-ruby as the root instead?

This PR changes the dir, specs are passing now, thanks for spotting this 🙇🏻

> Ruby LSP doesn't run with the current setting as the container doesn't use any Ruby version manager and the devcontainer setting doesn't specify sufficient settings as an alternative. How do you make it work?

This PR sets version manager to `none` and it seems to be working.

#skip-changelog