### PR TITLE
Add max_nesting of 10 to breadcrumbs data serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - Add new sidekiq config `report_only_dead_jobs` ([#2581](https://github.com/getsentry/sentry-ruby/pull/2581))
+- Add `max_nesting` of 10 to breadcrumbs data serialization ([#2583](https://github.com/getsentry/sentry-ruby/pull/2583))
 
 ### Bug Fixes
 

--- a/sentry-ruby/lib/sentry/breadcrumb.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb.rb
@@ -2,6 +2,7 @@
 
 module Sentry
   class Breadcrumb
+    MAX_NESTING = 10
     DATA_SERIALIZATION_ERROR_MESSAGE = "[data were removed due to serialization issues]"
 
     # @return [String, nil]
@@ -60,7 +61,7 @@ module Sentry
 
     def serialized_data
       begin
-        ::JSON.parse(::JSON.generate(@data))
+        ::JSON.parse(::JSON.generate(@data, max_nesting: MAX_NESTING))
       rescue Exception => e
         Sentry.logger.debug(LOGGER_PROGNAME) do
           <<~MSG


### PR DESCRIPTION
This is [trimmed in relay](https://github.com/getsentry/relay/blob/bcbfa7e7db6e4a8f3f0383270fbb2b5cfe668770/relay-event-schema/src/protocol/breadcrumb.rs#L111) at a depth of 5.
We allow upto 10 to have some leeway but if we have a really large data object we just drop it to avoid `SystemStackError`.

Closes #2393 and #2397