### PR TITLE
Only expose `ActiveStorage` keys on span data if `send_default_pii` is on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   ```ruby
   config.sidekiq.propagate_traces = false unless Rails.const_defined?('Server')
   ```
+- Only expose `active_storage` keys on span data if `send_default_pii` is on ([#2589](https://github.com/getsentry/sentry-ruby/pull/2589))
 
 ### Bug Fixes
 

--- a/sentry-rails/lib/sentry/rails/tracing/active_storage_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/active_storage_subscriber.rb
@@ -33,7 +33,10 @@ module Sentry
               duration: duration
             ) do |span|
               payload.each do |key, value|
-                span.set_data(key, value) unless key == START_TIMESTAMP_NAME
+                next if key == START_TIMESTAMP_NAME
+                next if key == :key && !Sentry.configuration.send_default_pii
+
+                span.set_data(key, value)
               end
             end
           end


### PR DESCRIPTION
closes #2497 