### PR TITLE
Fix compatibility issues with `sidekiq-cron` `2.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Fixes [#2376](https://github.com/getsentry/sentry-ruby/issues/2376)
 - Fix breadcrumb serialization error message to be an object ([#2584](https://github.com/getsentry/sentry-ruby/pull/2584))
   - Fixes [#2478](https://github.com/getsentry/sentry-ruby/issues/2478)
+- Fix compatibility issues with sidekiq-cron 2.2.0 ([#2591](https://github.com/getsentry/sentry-ruby/pull/2591))
 
 ### Internal
 


### PR DESCRIPTION
Since Sidekiq::Cron 2.2.0, `Sidekiq::Cron::Support.constantize` is removed and `Sidekiq::Cron::Support.safe_constantize` is added.

We need to check the method is available before calling it.

Related PR: https://github.com/sidekiq-cron/sidekiq-cron/pull/541