### PR TITLE
[active_job] report on each retry failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   - Fixes [#2478](https://github.com/getsentry/sentry-ruby/issues/2478)
 - Fix compatibility issues with sidekiq-cron 2.2.0 ([#2591](https://github.com/getsentry/sentry-ruby/pull/2591))
 - Update sentry-sidekiq to work correctly with Sidekiq 8.0 and its new timestamp format ([#2570](https://github.com/getsentry/sentry-ruby/pull/2570))
+- Ensure we capture exceptions after each job retry ([#2597](https://github.com/getsentry/sentry-ruby/pull/2597))
 
 ### Internal
 

--- a/sentry-rails/lib/sentry/rails/active_job.rb
+++ b/sentry-rails/lib/sentry/rails/active_job.rb
@@ -17,6 +17,13 @@ module Sentry
         Sentry.configuration.rails.skippable_job_adapters.include?(self.class.queue_adapter.class.to_s)
       end
 
+      def retry_job(error:, **opts)
+        unless Sentry.configuration.rails.active_job_report_after_job_retries
+          SentryReporter.capture_exception(self, error)
+        end
+        super
+      end
+
       class SentryReporter
         OP_NAME = "queue.active_job"
         SPAN_ORIGIN = "auto.queue.active_job"

--- a/sentry-rails/lib/sentry/rails/active_job.rb
+++ b/sentry-rails/lib/sentry/rails/active_job.rb
@@ -92,6 +92,8 @@ module Sentry
             subscribers.clear
           end
 
+          # This handler does not capture error when `active_job_report_after_job_retries` is true
+          # because in such case only the last retry that failed will capture exception
           def retry_handler(*args)
             handle_error_event(*args) do |job, error|
               return if !Sentry.initialized? || job.already_supported_by_sentry_integration?
@@ -101,6 +103,9 @@ module Sentry
             end
           end
 
+          # This handler does not capture error when `active_job_report_after_job_retries` is false
+          # because in such cases regular execution flow that failed will capture it in `record`
+          # method
           def retry_stopped_handler(*args)
             handle_error_event(*args) do |job, error|
               return if !Sentry.initialized? || job.already_supported_by_sentry_integration?

--- a/sentry-rails/lib/sentry/rails/active_job.rb
+++ b/sentry-rails/lib/sentry/rails/active_job.rb
@@ -87,10 +87,15 @@ module Sentry
             end
           end
 
-          def detach_retry_stopped_subscriber
+          def detach_handlers
             if @retry_stopped_subscriber
               ActiveSupport::Notifications.unsubscribe(@retry_stopped_subscriber)
               @retry_stopped_subscriber = nil
+            end
+
+            if @retry_handler
+              ActiveSupport::Notifications.unsubscribe(@retry_handler)
+              @retry_handler = nil
             end
           end
 

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -54,7 +54,7 @@ module Sentry
 
       # Presence of ActiveJob is no longer a reliable cue
       if defined?(Sentry::Rails::ActiveJobExtensions)
-        register_active_job_subscribers
+        Sentry::Rails::ActiveJobExtensions::SentryReporter.register_event_handlers
       end
     end
 
@@ -141,11 +141,6 @@ module Sentry
     def register_error_subscriber(app)
       require "sentry/rails/error_subscriber"
       app.executor.error_reporter.subscribe(Sentry::Rails::ErrorSubscriber.new)
-    end
-
-    def register_active_job_subscribers
-      Sentry::Rails::ActiveJobExtensions::SentryReporter.register_retry_subscriber
-      Sentry::Rails::ActiveJobExtensions::SentryReporter.register_retry_stopped_subscriber
     end
   end
 end

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -53,7 +53,9 @@ module Sentry
       register_error_subscriber(app) if ::Rails.version.to_f >= 7.0 && Sentry.configuration.rails.register_error_subscriber
 
       # Presence of ActiveJob is no longer a reliable cue
-      register_retry_stopped_subscriber if defined?(Sentry::Rails::ActiveJobExtensions)
+      if defined?(Sentry::Rails::ActiveJobExtensions)
+        register_active_job_subscribers
+      end
     end
 
     runner do
@@ -141,7 +143,8 @@ module Sentry
       app.executor.error_reporter.subscribe(Sentry::Rails::ErrorSubscriber.new)
     end
 
-    def register_retry_stopped_subscriber
+    def register_active_job_subscribers
+      Sentry::Rails::ActiveJobExtensions::SentryReporter.register_retry_subscriber
       Sentry::Rails::ActiveJobExtensions::SentryReporter.register_retry_stopped_subscriber
     end
   end

--- a/sentry-rails/spec/sentry/rails/activejob_spec.rb
+++ b/sentry-rails/spec/sentry/rails/activejob_spec.rb
@@ -446,9 +446,11 @@ RSpec.describe "ActiveJob integration", type: :job do
         allow(Sentry::Rails::ActiveJobExtensions::SentryReporter)
           .to receive(:capture_exception).and_call_original
 
-        assert_performed_jobs 3 do
-          FailedJobWithRetryOn.perform_later rescue nil
-        end
+        FailedJobWithRetryOn.perform_later rescue nil
+
+        perform_enqueued_jobs
+        perform_enqueued_jobs
+        perform_enqueued_jobs rescue nil
 
         expect(Sentry::Rails::ActiveJobExtensions::SentryReporter)
           .to have_received(:capture_exception)
@@ -469,9 +471,11 @@ RSpec.describe "ActiveJob integration", type: :job do
         allow(Sentry::Rails::ActiveJobExtensions::SentryReporter)
           .to receive(:capture_exception).and_call_original
 
-        assert_performed_jobs 3 do
-          FailedJobWithRetryOn.perform_later rescue nil
-        end
+        FailedJobWithRetryOn.perform_later rescue nil
+
+        perform_enqueued_jobs
+        perform_enqueued_jobs
+        perform_enqueued_jobs rescue nil
 
         expect(Sentry::Rails::ActiveJobExtensions::SentryReporter)
           .to have_received(:capture_exception)

--- a/sentry-rails/spec/spec_helper.rb
+++ b/sentry-rails/spec/spec_helper.rb
@@ -55,7 +55,7 @@ RSpec.configure do |config|
     Sentry::Rails::Tracing.remove_active_support_notifications_patch
 
     if defined?(Sentry::Rails::ActiveJobExtensions)
-      Sentry::Rails::ActiveJobExtensions::SentryReporter.detach_retry_stopped_subscriber
+      Sentry::Rails::ActiveJobExtensions::SentryReporter.detach_handlers
     end
 
     reset_sentry_globals!

--- a/sentry-rails/spec/spec_helper.rb
+++ b/sentry-rails/spec/spec_helper.rb
@@ -55,7 +55,7 @@ RSpec.configure do |config|
     Sentry::Rails::Tracing.remove_active_support_notifications_patch
 
     if defined?(Sentry::Rails::ActiveJobExtensions)
-      Sentry::Rails::ActiveJobExtensions::SentryReporter.detach_handlers
+      Sentry::Rails::ActiveJobExtensions::SentryReporter.detach_event_handlers
     end
 
     reset_sentry_globals!


### PR DESCRIPTION
### ⚠️ this will increase error reporting rates - we may consider setting `active_job_report_after_job_retries` to `true` by default

Closes #2597 

#skip-changelog