### PR TITLE
Introduce Sentry.capture_log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   config.sidekiq.propagate_traces = false unless Rails.const_defined?('Server')
   ```
 - Only expose `active_storage` keys on span data if `send_default_pii` is on ([#2589](https://github.com/getsentry/sentry-ruby/pull/2589))
+- Add `Sentry.capture_log` ([#2606](https://github.com/getsentry/sentry-ruby/pull/2606))
 
 ### Bug Fixes
 

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -489,6 +489,18 @@ module Sentry
       get_current_hub.capture_check_in(slug, status, **options)
     end
 
+    # Captures a log event and sends it to Sentry via the currently active hub.
+    #
+    # @param message [String] the log message
+    # @param [Hash] options Extra log event options
+    # @option options [Symbol] level The log level
+    #
+    # @return [LogEvent, nil]
+    def capture_log(message, **options)
+      return unless initialized?
+      get_current_hub.capture_log_event(message, **options)
+    end
+
     # Takes or initializes a new Sentry::Transaction and makes a sampling decision for it.
     #
     # @return [Transaction, nil]

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "sentry/transport"
+require "sentry/log_event"
 
 module Sentry
   class Client
@@ -164,6 +165,20 @@ module Sentry
         duration: duration,
         monitor_config: monitor_config,
         check_in_id: check_in_id
+      )
+    end
+
+    # Initializes a LogEvent object with the given message and options
+    def event_from_log(message, level:, **options)
+      return unless configuration.sending_allowed?
+
+      attributes = options.reject { |k, _| k == :level }
+
+      LogEvent.new(
+        level: level,
+        body: message,
+        timestamp: Time.now.to_f,
+        attributes: attributes
       )
     end
 

--- a/sentry-ruby/lib/sentry/envelope/item.rb
+++ b/sentry-ruby/lib/sentry/envelope/item.rb
@@ -15,7 +15,7 @@ module Sentry
     # rate limits and client reports use the data_category rather than envelope item type
     def self.data_category(type)
       case type
-      when "session", "attachment", "transaction", "profile", "span" then type
+      when "session", "attachment", "transaction", "profile", "span", "log" then type
       when "sessions" then "session"
       when "check_in" then "monitor"
       when "statsd", "metric_meta" then "metric_bucket"

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -216,6 +216,16 @@ module Sentry
       event.check_in_id
     end
 
+    def capture_log_event(message, **options)
+      return unless current_client
+
+      event = current_client.event_from_log(message, **options)
+
+      return unless event
+
+      capture_event(event, **options)
+    end
+
     def capture_event(event, **options, &block)
       check_argument_type!(event, Sentry::Event)
 

--- a/sentry-ruby/lib/sentry/log_event.rb
+++ b/sentry-ruby/lib/sentry/log_event.rb
@@ -8,7 +8,16 @@ module Sentry
     TYPE = "log"
 
     SERIALIZEABLE_ATTRIBUTES = %i[
-      level body timestamp trace_id attributes
+      level
+      body
+      timestamp
+      trace_id
+      attributes
+      release
+      sdk
+      platform
+      environment
+      server_name
     ]
 
     LEVELS = %i[trace debug info warn error fatal].freeze

--- a/sentry-ruby/lib/sentry/log_event.rb
+++ b/sentry-ruby/lib/sentry/log_event.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Sentry
+  class LogEvent < Event
+    TYPE = "log"
+
+    LEVELS = %i[trace debug info warn error fatal].freeze
+
+    attr_accessor :level, :body, :attributes, :trace_id
+
+    def initialize(configuration: Sentry.configuration, **options)
+      super(configuration: configuration)
+      @type = TYPE
+      @level = options.fetch(:level)
+      @body = options[:body]
+      @trace_id = options[:trace_id] || SecureRandom.hex(16)
+      @attributes = options[:attributes] || {}
+    end
+
+    # https://develop.sentry.dev/sdk/telemetry/logs/#log-envelope-item-payload
+    def to_hash
+      data = {}
+      data[:level] = @level.to_s
+      data[:body] = @body
+      data[:timestamp] = Time.parse(@timestamp).to_f
+      data[:trace_id] = @trace_id
+      data[:attributes] = serialize_attributes
+      data
+    end
+
+    private
+
+    def serialize_attributes
+      result = {}
+
+      @attributes.each do |key, value|
+        result[key] = {
+          value: value,
+          type: value_type(value)
+        }
+      end
+
+      result
+    end
+
+    def value_type(value)
+      case value
+      when Integer
+        "integer"
+      when TrueClass, FalseClass
+        "boolean"
+      when Float
+        "double"
+      else
+        "string"
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/log_event.rb
+++ b/sentry-ruby/lib/sentry/log_event.rb
@@ -18,6 +18,7 @@ module Sentry
       platform
       environment
       server_name
+      trace_id
     ]
 
     LEVELS = %i[trace debug info warn error fatal].freeze
@@ -29,8 +30,8 @@ module Sentry
       @type = TYPE
       @level = options.fetch(:level)
       @body = options[:body]
-      @trace_id = options[:trace_id] || SecureRandom.hex(16)
       @attributes = options[:attributes] || {}
+      @contexts = {}
     end
 
     def to_hash
@@ -57,6 +58,10 @@ module Sentry
 
     def serialize_timestamp
       Time.parse(timestamp).to_f
+    end
+
+    def serialize_trace_id
+      @contexts.dig(:trace, :trace_id)
     end
 
     def serialize_attributes

--- a/sentry-ruby/lib/sentry/log_event.rb
+++ b/sentry-ruby/lib/sentry/log_event.rb
@@ -60,16 +60,12 @@ module Sentry
     end
 
     def serialize_attributes
-      result = {}
-
-      @attributes.each do |key, value|
-        result[key] = {
+      @attributes.each_with_object({}) do |(key, value), memo|
+        memo[key] = {
           value: value,
           type: value_type(value)
         }
       end
-
-      result
     end
 
     def value_type(value)

--- a/sentry-ruby/lib/sentry/log_event.rb
+++ b/sentry-ruby/lib/sentry/log_event.rb
@@ -19,7 +19,7 @@ module Sentry
       "sentry.trace.parent_span_id" => :parent_span_id,
       "sentry.environment" => :environment,
       "sentry.release" => :release,
-      "sentry.server_name" => :server_name,
+      "sentry.address" => :server_name,
       "sentry.sdk.name" => :sdk_name,
       "sentry.sdk.version" => :sdk_version
     }

--- a/sentry-ruby/lib/sentry/log_event.rb
+++ b/sentry-ruby/lib/sentry/log_event.rb
@@ -60,11 +60,11 @@ module Sentry
     end
 
     def serialize_sdk_name
-      Sentry.sdk_meta[:name]
+      Sentry.sdk_meta["name"]
     end
 
     def serialize_sdk_version
-      Sentry.sdk_meta[:version]
+      Sentry.sdk_meta["version"]
     end
 
     def serialize_timestamp

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -54,7 +54,7 @@ module Sentry
         event.transaction = transaction_name if transaction_name
         event.transaction_info = { source: transaction_source } if transaction_source
         event.fingerprint = fingerprint
-        event.level = level
+        event.level = level unless event.is_a?(LogEvent)
         event.breadcrumbs = breadcrumbs
         event.rack_env = rack_env if rack_env
         event.attachments = attachments

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -133,10 +133,21 @@ module Sentry
 
       envelope = Envelope.new(envelope_headers)
 
-      envelope.add_item(
-        { type: item_type, content_type: "application/json" },
-        event_payload
-      )
+      if event.is_a?(LogEvent)
+        envelope.add_item(
+          {
+            type: "log",
+            item_count: 1,
+            content_type: "application/vnd.sentry.items.log+json"
+          },
+          { items: [event_payload] }
+        )
+      else
+        envelope.add_item(
+          { type: item_type, content_type: "application/json" },
+          event_payload
+        )
+      end
 
       if event.is_a?(TransactionEvent) && event.profile
         envelope.add_item(

--- a/sentry-ruby/spec/sentry/envelope/item_spec.rb
+++ b/sentry-ruby/spec/sentry/envelope/item_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Sentry::Envelope::Item do
       ['transaction', 'transaction'],
       ['span', 'span'],
       ['profile', 'profile'],
+      ['log', 'log'],
       ['check_in', 'monitor'],
       ['statsd', 'metric_bucket'],
       ['metric_meta', 'metric_bucket'],

--- a/sentry-ruby/spec/sentry/log_event_spec.rb
+++ b/sentry-ruby/spec/sentry/log_event_spec.rb
@@ -70,9 +70,9 @@ RSpec.describe Sentry::LogEvent do
       expect(attributes).to be_a(Hash)
       expect(attributes["sentry.message.template"]).to eq({ value: "User %s has logged in!", type: "string" })
       expect(attributes["sentry.message.parameters.0"]).to eq({ value: "John", type: "string" })
-      expect(attributes["sentry.environment"]).to eq({value: "test", type: "string"})
-      expect(attributes["sentry.release"]).to eq({value: "1.2.3", type: "string"})
-      expect(attributes["sentry.server_name"]).to eq({value: "server-123", type: "string"})
+      expect(attributes["sentry.environment"]).to eq({ value: "test", type: "string" })
+      expect(attributes["sentry.release"]).to eq({ value: "1.2.3", type: "string" })
+      expect(attributes["sentry.server_name"]).to eq({ value: "server-123", type: "string" })
       expect(attributes["sentry.sdk.name"]).to eq({ value: "sentry.ruby", type: "string" })
       expect(attributes["sentry.sdk.version"]).to eq({ value: Sentry::VERSION, type: "string" })
     end

--- a/sentry-ruby/spec/sentry/log_event_spec.rb
+++ b/sentry-ruby/spec/sentry/log_event_spec.rb
@@ -77,6 +77,12 @@ RSpec.describe Sentry::LogEvent do
       expect(hash[:attributes]).to be_a(Hash)
       expect(hash[:attributes]["sentry.message.template"]).to eq({ value: "User %s has logged in!", type: "string" })
       expect(hash[:attributes]["sentry.message.parameters.0"]).to eq({ value: "John", type: "string" })
+
+      expect(hash[:sdk]).to eq(Sentry.sdk_meta)
+      expect(hash[:platform]).to eq(:ruby)
+      expect(hash[:environment]).to eq("development")
+      expect(hash).to have_key(:release)
+      expect(hash).to have_key(:server_name)
     end
 
     it "serializes different attribute types correctly" do

--- a/sentry-ruby/spec/sentry/log_event_spec.rb
+++ b/sentry-ruby/spec/sentry/log_event_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe Sentry::LogEvent do
   end
 
   describe "#to_hash" do
+    before do
+      configuration.release = "1.2.3"
+      configuration.environment = "test"
+      configuration.server_name = "server-123"
+    end
+
     it "includes all required fields" do
       attributes = {
         "sentry.message.template" => "User %s has logged in!",
@@ -58,15 +64,15 @@ RSpec.describe Sentry::LogEvent do
       expect(hash[:level]).to eq("info")
       expect(hash[:body]).to eq("User John has logged in!")
       expect(hash[:timestamp]).to be_a(Float)
-      expect(hash[:attributes]).to be_a(Hash)
-      expect(hash[:attributes]["sentry.message.template"]).to eq({ value: "User %s has logged in!", type: "string" })
-      expect(hash[:attributes]["sentry.message.parameters.0"]).to eq({ value: "John", type: "string" })
 
-      expect(hash[:sdk]).to eq(Sentry.sdk_meta)
-      expect(hash[:platform]).to eq(:ruby)
-      expect(hash[:environment]).to eq("development")
-      expect(hash).to have_key(:release)
-      expect(hash).to have_key(:server_name)
+      attributes = hash[:attributes]
+
+      expect(attributes).to be_a(Hash)
+      expect(attributes["sentry.message.template"]).to eq({ value: "User %s has logged in!", type: "string" })
+      expect(attributes["sentry.message.parameters.0"]).to eq({ value: "John", type: "string" })
+      expect(attributes["sentry.environment"]).to eq({value: "test", type: "string"})
+      expect(attributes["sentry.release"]).to eq({value: "1.2.3", type: "string"})
+      expect(attributes["sentry.server_name"]).to eq({value: "server-123", type: "string"})
     end
 
     it "serializes different attribute types correctly" do

--- a/sentry-ruby/spec/sentry/log_event_spec.rb
+++ b/sentry-ruby/spec/sentry/log_event_spec.rb
@@ -20,19 +20,6 @@ RSpec.describe Sentry::LogEvent do
       expect(event).to be_a(described_class)
       expect(event.level).to eq(:info)
       expect(event.body).to eq("User John has logged in!")
-      expect(event.trace_id).to_not be(nil)
-    end
-
-    it "accepts trace_id" do
-      trace_id = "5b8efff798038103d269b633813fc60c"
-      event = described_class.new(
-        configuration: configuration,
-        level: :info,
-        body: "User John has logged in!",
-        trace_id: trace_id
-      )
-
-      expect(event.trace_id).to eq(trace_id)
     end
 
     it "accepts attributes" do
@@ -54,7 +41,6 @@ RSpec.describe Sentry::LogEvent do
 
   describe "#to_hash" do
     it "includes all required fields" do
-      trace_id = "5b8efff798038103d269b633813fc60c"
       attributes = {
         "sentry.message.template" => "User %s has logged in!",
         "sentry.message.parameters.0" => "John"
@@ -64,7 +50,6 @@ RSpec.describe Sentry::LogEvent do
         configuration: configuration,
         level: :info,
         body: "User John has logged in!",
-        trace_id: trace_id,
         attributes: attributes
       )
 
@@ -72,7 +57,6 @@ RSpec.describe Sentry::LogEvent do
 
       expect(hash[:level]).to eq("info")
       expect(hash[:body]).to eq("User John has logged in!")
-      expect(hash[:trace_id]).to eq(trace_id)
       expect(hash[:timestamp]).to be_a(Float)
       expect(hash[:attributes]).to be_a(Hash)
       expect(hash[:attributes]["sentry.message.template"]).to eq({ value: "User %s has logged in!", type: "string" })

--- a/sentry-ruby/spec/sentry/log_event_spec.rb
+++ b/sentry-ruby/spec/sentry/log_event_spec.rb
@@ -73,6 +73,8 @@ RSpec.describe Sentry::LogEvent do
       expect(attributes["sentry.environment"]).to eq({value: "test", type: "string"})
       expect(attributes["sentry.release"]).to eq({value: "1.2.3", type: "string"})
       expect(attributes["sentry.server_name"]).to eq({value: "server-123", type: "string"})
+      expect(attributes["sentry.sdk.name"]).to eq({ value: "sentry.ruby", type: "string" })
+      expect(attributes["sentry.sdk.version"]).to eq({ value: Sentry::VERSION, type: "string" })
     end
 
     it "serializes different attribute types correctly" do

--- a/sentry-ruby/spec/sentry/log_event_spec.rb
+++ b/sentry-ruby/spec/sentry/log_event_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Sentry::LogEvent do
+  let(:configuration) do
+    Sentry::Configuration.new.tap do |config|
+      config.dsn = Sentry::TestHelper::DUMMY_DSN
+    end
+  end
+
+  describe "#initialize" do
+    it "initializes with required attributes" do
+      event = described_class.new(
+        configuration: configuration,
+        level: :info,
+        body: "User John has logged in!"
+      )
+
+      expect(event).to be_a(described_class)
+      expect(event.level).to eq(:info)
+      expect(event.body).to eq("User John has logged in!")
+      expect(event.trace_id).to_not be(nil)
+    end
+
+    it "accepts trace_id" do
+      trace_id = "5b8efff798038103d269b633813fc60c"
+      event = described_class.new(
+        configuration: configuration,
+        level: :info,
+        body: "User John has logged in!",
+        trace_id: trace_id
+      )
+
+      expect(event.trace_id).to eq(trace_id)
+    end
+
+    it "accepts attributes" do
+      attributes = {
+        "sentry.message.template" => "User %s has logged in!",
+        "sentry.message.parameters.0" => "John"
+      }
+
+      event = described_class.new(
+        configuration: configuration,
+        level: :info,
+        body: "User John has logged in!",
+        attributes: attributes
+      )
+
+      expect(event.attributes).to eq(attributes)
+    end
+  end
+
+  describe "#to_hash" do
+    it "includes all required fields" do
+      trace_id = "5b8efff798038103d269b633813fc60c"
+      attributes = {
+        "sentry.message.template" => "User %s has logged in!",
+        "sentry.message.parameters.0" => "John"
+      }
+
+      event = described_class.new(
+        configuration: configuration,
+        level: :info,
+        body: "User John has logged in!",
+        trace_id: trace_id,
+        attributes: attributes
+      )
+
+      hash = event.to_hash
+
+      expect(hash[:level]).to eq("info")
+      expect(hash[:body]).to eq("User John has logged in!")
+      expect(hash[:trace_id]).to eq(trace_id)
+      expect(hash[:timestamp]).to be_a(Float)
+      expect(hash[:attributes]).to be_a(Hash)
+      expect(hash[:attributes]["sentry.message.template"]).to eq({ value: "User %s has logged in!", type: "string" })
+      expect(hash[:attributes]["sentry.message.parameters.0"]).to eq({ value: "John", type: "string" })
+    end
+
+    it "serializes different attribute types correctly" do
+      attributes = {
+        "string_attr" => "string value",
+        "integer_attr" => 42,
+        "boolean_attr" => true,
+        "float_attr" => 3.14
+      }
+
+      event = described_class.new(
+        configuration: configuration,
+        level: :info,
+        body: "Test message",
+        attributes: attributes
+      )
+
+      hash = event.to_hash
+
+      expect(hash[:attributes]["string_attr"]).to eq({ value: "string value", type: "string" })
+      expect(hash[:attributes]["integer_attr"]).to eq({ value: 42, type: "integer" })
+      expect(hash[:attributes]["boolean_attr"]).to eq({ value: true, type: "boolean" })
+      expect(hash[:attributes]["float_attr"]).to eq({ value: 3.14, type: "double" })
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/log_event_spec.rb
+++ b/sentry-ruby/spec/sentry/log_event_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Sentry::LogEvent do
       expect(attributes["sentry.message.parameters.0"]).to eq({ value: "John", type: "string" })
       expect(attributes["sentry.environment"]).to eq({ value: "test", type: "string" })
       expect(attributes["sentry.release"]).to eq({ value: "1.2.3", type: "string" })
-      expect(attributes["sentry.server_name"]).to eq({ value: "server-123", type: "string" })
+      expect(attributes["sentry.address"]).to eq({ value: "server-123", type: "string" })
       expect(attributes["sentry.sdk.name"]).to eq({ value: "sentry.ruby", type: "string" })
       expect(attributes["sentry.sdk.version"]).to eq({ value: Sentry::VERSION, type: "string" })
     end

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe Sentry::Transport do
           "sentry.environment" => { "value" => "development", "type" => "string" },
           "sentry.release" => { "value" => "1.0.0", "type" => "string" },
           "sentry.trace.parent_span_id" => { "value" => "b0e6f15b45c36b12", "type" => "string" },
-          "sentry.server_name" => { "value" => matching(/\w+/), "type" => "string" }
+          "sentry.address" => { "value" => matching(/\w+/), "type" => "string" }
         )
       end
     end

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -299,9 +299,10 @@ RSpec.describe Sentry::Transport do
         expect(log_event["attributes"]).to include(
           "sentry.message.template" => { "value" => "User %s has logged in!", "type" => "string" },
           "sentry.message.parameters.0" => { "value" => "John", "type" => "string" },
-          "sentry.environment" => { "value" => "production", "type" => "string" },
+          "sentry.environment" => { "value" => "development", "type" => "string" },
           "sentry.release" => { "value" => "1.0.0", "type" => "string" },
-          "sentry.trace.parent_span_id" => { "value" => "b0e6f15b45c36b12", "type" => "string" }
+          "sentry.trace.parent_span_id" => { "value" => "b0e6f15b45c36b12", "type" => "string" },
+          "sentry.server_name" => { "value" => matching(/\w+/), "type" => "string" }
         )
       end
     end

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -294,7 +294,6 @@ RSpec.describe Sentry::Transport do
         log_event = item_payload_parsed["items"].first
         expect(log_event["level"]).to eq("info")
         expect(log_event["body"]).to eq("User John has logged in!")
-        expect(log_event["trace_id"]).to eq("5b8efff798038103d269b633813fc60c")
         expect(log_event["timestamp"]).to be_a(Float)
 
         expect(log_event["attributes"]).to include(

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -237,6 +237,76 @@ RSpec.describe Sentry::Transport do
       end
     end
 
+    context "log events" do
+      let(:log_events) do
+        5.times.map do |i|
+          Sentry::LogEvent.new(
+            configuration: configuration,
+            level: :info,
+            body: "User John has logged in!",
+            trace_id: "5b8efff798038103d269b633813fc60c",
+            timestamp: 1544719860.0,
+            attributes: {
+              "sentry.message.template" => "User %s has logged in!",
+              "sentry.message.parameters.0" => "John",
+              "sentry.environment" => "production",
+              "sentry.release" => "1.0.0",
+              "sentry.trace.parent_span_id" => "b0e6f15b45c36b12"
+            }
+          )
+        end
+      end
+
+      let(:envelope) do
+        envelope = Sentry::Envelope.new
+
+        envelope.add_item(
+          {
+            type: "log",
+            item_count: log_events.size,
+            content_type: "application/vnd.sentry.items.log+json"
+          },
+          { items: log_events.map(&:to_hash) }
+        )
+
+        envelope
+      end
+
+      it "generates correct envelope content for log events" do
+        result, _ = subject.serialize_envelope(envelope)
+
+        envelope_header, item_header, item_payload = result.split("\n")
+
+        envelope_header_parsed = JSON.parse(envelope_header)
+        expect(envelope_header_parsed).to be_a(Hash)
+
+        item_header_parsed = JSON.parse(item_header)
+        expect(item_header_parsed).to eq({
+          "type" => "log",
+          "item_count" => 5,
+          "content_type" => "application/vnd.sentry.items.log+json"
+        })
+
+        item_payload_parsed = JSON.parse(item_payload)
+        expect(item_payload_parsed).to have_key("items")
+        expect(item_payload_parsed["items"].size).to eq(5)
+
+        log_event = item_payload_parsed["items"].first
+        expect(log_event["level"]).to eq("info")
+        expect(log_event["body"]).to eq("User John has logged in!")
+        expect(log_event["trace_id"]).to eq("5b8efff798038103d269b633813fc60c")
+        expect(log_event["timestamp"]).to be_a(Float)
+
+        expect(log_event["attributes"]).to include(
+          "sentry.message.template" => { "value" => "User %s has logged in!", "type" => "string" },
+          "sentry.message.parameters.0" => { "value" => "John", "type" => "string" },
+          "sentry.environment" => { "value" => "production", "type" => "string" },
+          "sentry.release" => { "value" => "1.0.0", "type" => "string" },
+          "sentry.trace.parent_span_id" => { "value" => "b0e6f15b45c36b12", "type" => "string" }
+        )
+      end
+    end
+
     context "malformed breadcrumb" do
       let(:event) { client.event_from_message("foo") }
 
@@ -500,6 +570,51 @@ RSpec.describe Sentry::Transport do
         subject.send_envelope(envelope)
 
         expect(io.string).to match(/Sending envelope with items \[event, attachment, attachment\]/)
+      end
+    end
+
+    context "log events" do
+      let(:log_events) do
+        5.times.map do |i|
+          Sentry::LogEvent.new(
+            configuration: configuration,
+            level: :info,
+            body: "User John has logged in!",
+            trace_id: "5b8efff798038103d269b633813fc60c",
+            timestamp: 1544719860.0,
+            attributes: {
+              "sentry.message.template" => "User %s has logged in!",
+              "sentry.message.parameters.0" => "John",
+              "sentry.environment" => "production",
+              "sentry.release" => "1.0.0",
+              "sentry.trace.parent_span_id" => "b0e6f15b45c36b12"
+            }
+          )
+        end
+      end
+
+      let(:envelope) do
+        envelope = Sentry::Envelope.new
+
+        # Add log item header
+        envelope.add_item(
+          {
+            type: "log",
+            item_count: log_events.size,
+            content_type: "application/vnd.sentry.items.log+json"
+          },
+          { items: log_events.map(&:to_hash) }
+        )
+
+        envelope
+      end
+
+      it "sends the log events and logs the action" do
+        expect(subject).to receive(:send_data)
+
+        subject.send_envelope(envelope)
+
+        expect(io.string).to match(/Sending envelope with items \[log\]/)
       end
     end
   end

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -394,8 +394,8 @@ RSpec.describe Sentry do
       expect(log_event.attributes).to eql({ tags: { foo: "baz" } })
 
       hash = log_event.to_hash
-      expect(hash[:trace_id]).to_not be(nil)
-      expect(hash[:attributes]["sentry.trace.parent_span_id"]).to eql(transaction.span_id)
+      expect(hash[:trace_id]).to eq(transaction.trace_id)
+      expect(hash[:attributes]["sentry.trace.parent_span_id"]).to eql({ value: transaction.span_id, type: "string" })
     end
   end
 

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -352,6 +352,19 @@ RSpec.describe Sentry do
     end
   end
 
+  describe ".capture_log" do
+    it "sends a log event via current hub" do
+      expect do
+        described_class.capture_log("Test", level: :info, tags: { foo: "baz" })
+      end.to change { sentry_events.count }.by(1)
+
+      log_event = sentry_events.first
+
+      expect(log_event.type).to eql("log")
+      expect(log_event.level).to eq(:info)
+      expect(log_event.attributes).to eql({ tags: { foo: "baz" } })
+    end
+  end
 
   describe ".start_transaction" do
     describe "sampler example" do


### PR DESCRIPTION
First step towards Structured Logging #2600 

This adds `Sentry.capture_log` interface with a new underlying `LogEvent` event type.

Closes #2603 