### PR TITLE
Fix jruby on CI

### DIFF
--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -57,12 +57,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          bundler-cache: ${{ ! contains(matrix.ruby_version, 'jruby') }}
-
-      # https://github.com/jruby/jruby/issues/8606#issuecomment-2641501008
-      - name: Bundle Jruby
-        if: ${{ contains(matrix.ruby_version, 'jruby') }}
-        run: gem install jar-dependencies && bundle
+          bundler-cache: true
 
       - name: Run specs
         run: bundle exec rake

--- a/.github/workflows/sentry_opentelemetry_test.yml
+++ b/.github/workflows/sentry_opentelemetry_test.yml
@@ -46,12 +46,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          bundler-cache: ${{ ! contains(matrix.ruby_version, 'jruby') }}
-
-      # https://github.com/jruby/jruby/issues/8606#issuecomment-2641501008
-      - name: Bundle Jruby
-        if: ${{ contains(matrix.ruby_version, 'jruby') }}
-        run: gem install jar-dependencies && bundle
+          bundler-cache: true
 
       - name: Run specs
         run: bundle exec rake

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -90,6 +90,7 @@ jobs:
             rails_version: 7.1.0
         exclude:
           - ruby_version: head
+          - ruby_version: 'jruby'
           - ruby_version: jruby-head
           - ruby_version: "3.4"
             rails_version: "6.1.0"
@@ -108,12 +109,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          bundler-cache: ${{ ! contains(matrix.ruby_version, 'jruby') }}
-
-      # https://github.com/jruby/jruby/issues/8606#issuecomment-2641501008
-      - name: Bundle Jruby
-        if: ${{ contains(matrix.ruby_version, 'jruby') }}
-        run: gem install jar-dependencies && bundle
+          bundler-cache: true
 
       - name: Build with Rails ${{ matrix.rails_version }}
         run: bundle exec rake

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -36,19 +36,15 @@ jobs:
             options:
               rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal"
         exclude:
-          - { ruby_version: 'jruby-head' }
+          - ruby_version: 'jruby'
+          - ruby_version: 'jruby-head'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby_version }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          bundler-cache: ${{ ! contains(matrix.ruby_version, 'jruby') }}
-
-      # https://github.com/jruby/jruby/issues/8606#issuecomment-2641501008
-      - name: Bundle Jruby
-        if: ${{ contains(matrix.ruby_version, 'jruby') }}
-        run: gem install jar-dependencies && bundle
+          bundler-cache: true
 
       - name: Start Redis
         uses: supercharge/redis-github-action@1.1.0

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -53,7 +53,8 @@ jobs:
             rack_version: 3.1
             redis_rb_version: 5.3
         exclude:
-          - { ruby_version: 'jruby-head' }
+          - ruby_version: 'jruby'
+          - ruby_version: 'jruby-head'
     steps:
       - uses: actions/checkout@v4
 
@@ -61,12 +62,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          bundler-cache: ${{ ! contains(matrix.ruby_version, 'jruby') }}
-
-      # https://github.com/jruby/jruby/issues/8606#issuecomment-2641501008
-      - name: Bundle Jruby
-        if: ${{ contains(matrix.ruby_version, 'jruby') }}
-        run: gem install jar-dependencies && bundle
+          bundler-cache: true
 
       - name: Start Redis
         uses: supercharge/redis-github-action@c169aa53af4cd5d9321e9114669dbd11be08d307

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -62,6 +62,7 @@ jobs:
             sidekiq_version: 8.0.0.beta1
         exclude:
           - ruby_version: head
+          - ruby_version: jruby
           - ruby_version: jruby-head
     steps:
       - uses: actions/checkout@v4
@@ -70,12 +71,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          bundler-cache: ${{ ! contains(matrix.ruby_version, 'jruby') }}
-
-      # https://github.com/jruby/jruby/issues/8606#issuecomment-2641501008
-      - name: Bundle Jruby
-        if: ${{ contains(matrix.ruby_version, 'jruby') }}
-        run: gem install jar-dependencies && bundle
+          bundler-cache: true
 
       - name: Start Redis
         uses: supercharge/redis-github-action@1.1.0

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -44,11 +44,11 @@ jobs:
             sidekiq_version: 5.0
           - ruby_version: 2.6
             sidekiq_version: 6.0
-          - ruby_version: jruby
+          - ruby_version: jruby-9.4.12.0
             sidekiq_version: 5.0
-          - ruby_version: jruby
+          - ruby_version: jruby-9.4.12.0
             sidekiq_version: 6.0
-          - ruby_version: jruby
+          - ruby_version: jruby-9.4.12.0
             sidekiq_version: 7.0
           - ruby_version: "3.2"
             sidekiq_version: 7.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
     with:
       engine: cruby-jruby
       min_version: 2.7
+      versions: '["jruby-9.4.12.0"]'
 
   delayed_job-tests:
     needs: ruby-versions

--- a/sentry-rails/spec/sentry/rails/activejob_spec.rb
+++ b/sentry-rails/spec/sentry/rails/activejob_spec.rb
@@ -435,6 +435,12 @@ RSpec.describe "ActiveJob integration", type: :job do
   end
 
   describe "active_job_report_after_job_retries", skip: RAILS_VERSION < 7.0 do
+    before do
+      if defined?(JRUBY_VERSION) && JRUBY_VERSION == "9.4.12.0" && RAILS_VERSION <= 7.1
+        skip "This crashes on jruby + rails 7.0.0.x. See https://github.com/getsentry/sentry-ruby/issues/2612"
+      end
+    end
+
     context "when active_job_report_after_job_retries is false" do
       it "reports 3 exceptions" do
         allow(Sentry::Rails::ActiveJobExtensions::SentryReporter)

--- a/sentry-sidekiq/Gemfile
+++ b/sentry-sidekiq/Gemfile
@@ -35,6 +35,4 @@ gem "rails", "> 5.0.0"
 
 gem "timecop"
 
-if RUBY_VERSION >= "3.2.1"
-  gem "vernier"
-end
+gem "vernier", platforms: :ruby if RUBY_VERSION >= "3.2.1"

--- a/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
@@ -363,7 +363,7 @@ RSpec.describe Sentry::Sidekiq do
     end
   end
 
-  context "when profiling is enabled with Vernier", skip: RUBY_VERSION < "3.2.1" do
+  context "when profiling is enabled with Vernier", skip: !defined?(Vernier) do
     before do
       perform_basic_setup do |config|
         config.traces_sample_rate = 1.0


### PR DESCRIPTION
- `jruby` in CI now means `10.0.x.x`
- There's new `jruby-9.12.4.0`
- Some test suites were failing on `jruby` so I excluded it for now
- Two specs from AJ suite cause random SOE in java, so I made them skipped for now and reported #2612 


#skip-changelog