### PR TITLE
Fix flaky spec

### DIFF
--- a/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq/sentry_context_middleware_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Sentry::Sidekiq::SentryContextServerMiddleware do
         expect(trace[:data]['messaging.message.id']).to eq('123456')
         expect(trace[:data]['messaging.destination.name']).to eq('default')
         expect(trace[:data]['messaging.message.retry.count']).to eq(0)
-        expect(trace[:data]['messaging.message.receive.latency']).to eq(expected_latency)
+        expect(trace[:data]['messaging.message.receive.latency']).to be_within(1).of(expected_latency)
       end
 
       if MIN_SIDEKIQ_6


### PR DESCRIPTION
Addresses this failure from jruby:

```
Failures:

  1) Sentry::Sidekiq::SentryContextServerMiddleware with tracing enabled span data for Queues module adds a queue.process transaction with correct data
     Failure/Error: expect(trace[:data]['messaging.message.receive.latency']).to eq(expected_latency)

       expected: 86400000
            got: 86399999

       (compared using ==)
     # ./spec/sentry/sidekiq/sentry_context_middleware_spec.rb:93:in 'block (4 levels) in <top (required)>'
```

#skip-changelog