### PR TITLE
Replace logger with sdk_logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Remove `user_segment` from DSC ([#2586](https://github.com/getsentry/sentry-ruby/pull/2586))
 - New configuration option called `report_after_job_retries` for ActiveJob which makes reporting exceptions only happen when the last retry attempt failed ([#2500](https://github.com/getsentry/sentry-ruby/pull/2500))
 - Replace `logger` with `sdk_logger` ([#2621](https://github.com/getsentry/sentry-ruby/pull/2621))
+- `Sentry.logger` is now deprecated when `enable_logs` is turned off. It's original behavior was ported to `Sentry.configuration.sdk_logger`. Please notice that this logger *is internal* and should only be used for SDK-specific logging needs. ([#2621](https://github.com/getsentry/sentry-ruby/pull/2621))
 
 ## 5.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 ### Internal
 
 - Remove `user_segment` from DSC ([#2586](https://github.com/getsentry/sentry-ruby/pull/2586))
+- New configuration option called `report_after_job_retries` for ActiveJob which makes reporting exceptions only happen when the last retry attempt failed ([#2500](https://github.com/getsentry/sentry-ruby/pull/2500))
+- Replace `logger` with `sdk_logger` ([#2621](https://github.com/getsentry/sentry-ruby/pull/2621))
 
 ## 5.23.0
 

--- a/sentry-delayed_job/spec/spec_helper.rb
+++ b/sentry-delayed_job/spec/spec_helper.rb
@@ -87,7 +87,7 @@ end
 def perform_basic_setup
   Sentry.init do |config|
     config.dsn = DUMMY_DSN
-    config.logger = ::Logger.new(nil)
+    config.sdk_logger = ::Logger.new(nil)
     config.background_worker_threads = 0
     config.transport.transport_class = Sentry::DummyTransport
     yield(config) if block_given?

--- a/sentry-opentelemetry/spec/spec_helper.rb
+++ b/sentry-opentelemetry/spec/spec_helper.rb
@@ -44,7 +44,7 @@ end
 
 def perform_basic_setup
   Sentry.init do |config|
-    config.logger = Logger.new(nil)
+    config.sdk_logger = Logger.new(nil)
     config.dsn = Sentry::TestHelper::DUMMY_DSN
     config.transport.transport_class = Sentry::DummyTransport
     # so the events will be sent synchronously for testing

--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -17,12 +17,12 @@ module Sentry
       if ::Rails.logger
         if defined?(::ActiveSupport::BroadcastLogger) && ::Rails.logger.is_a?(::ActiveSupport::BroadcastLogger)
           dupped_broadcasts = ::Rails.logger.broadcasts.map(&:dup)
-          @logger = ::ActiveSupport::BroadcastLogger.new(*dupped_broadcasts)
+          self.sdk_logger = ::ActiveSupport::BroadcastLogger.new(*dupped_broadcasts)
         else
-          @logger = ::Rails.logger.dup
+          self.sdk_logger = ::Rails.logger.dup
         end
       else
-        @logger.warn(Sentry::LOGGER_PROGNAME) do
+        sdk_logger.warn(Sentry::LOGGER_PROGNAME) do
           <<~MSG
           sentry-rails can't detect Rails.logger. it may be caused by misplacement of the SDK initialization code
           please make sure you place the Sentry.init block under the `config/initializers` folder, e.g. `config/initializers/sentry.rb`

--- a/sentry-rails/lib/sentry/rails/tracing/action_controller_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/action_controller_subscriber.rb
@@ -14,7 +14,7 @@ module Sentry
         SPAN_ORIGIN = "auto.view.rails"
 
         def self.subscribe!
-          Sentry.logger.warn <<~MSG
+          Sentry.sdk_logger.warn <<~MSG
             DEPRECATION WARNING: sentry-rails has changed its approach on controller span recording and #{self.name} is now depreacted.
             Please stop using or referencing #{self.name} as it will be removed in the next major release.
           MSG

--- a/sentry-rails/spec/dummy/test_rails_app/app.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/app.rb
@@ -55,7 +55,7 @@ def make_basic_app(&block)
   app.config.action_controller.view_paths = "spec/dummy/test_rails_app"
   app.config.hosts = nil
   app.config.secret_key_base = "test"
-  app.config.logger = ActiveSupport::Logger.new(nil)
+  app.config.sdk_logger = ActiveSupport::Logger.new(nil)
   app.config.eager_load = false
   app.config.active_job.queue_adapter = :test
   app.config.cache_store = :memory_store

--- a/sentry-rails/spec/isolated/active_job_activation.rb
+++ b/sentry-rails/spec/isolated/active_job_activation.rb
@@ -53,7 +53,7 @@ end
 app.config.eager_load = true
 app.initializer :sentry do
   Sentry.init do |config|
-    config.logger = Logger.new(nil)
+    config.sdk_logger = Logger.new(nil)
     config.dsn = 'https://2fb45f003d054a7ea47feb45898f7649@o447951.ingest.sentry.io/5434472'
     config.background_worker_threads = 0
   end

--- a/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing/action_controller_subscriber_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Sentry::Rails::Tracing::ActionControllerSubscriber, :subscriber, 
       make_basic_app do |config|
         config.traces_sample_rate = 1.0
         config.rails.tracing_subscribers = [described_class]
-        config.logger = logger
+        config.sdk_logger = logger
       end
     end
 

--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
         make_basic_app do |config, app|
           app.config.public_file_server.enabled = true
           config.traces_sample_rate = 1.0
-          config.logger = logger
+          config.sdk_logger = logger
         end
       end
 
@@ -202,7 +202,7 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
         make_basic_app do |config, app|
           app.config.public_file_server.enabled = true
           config.traces_sample_rate = 1.0
-          config.logger = logger
+          config.sdk_logger = logger
           config.rails.assets_regexp = %r{/foo/}
         end
       end
@@ -232,7 +232,7 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
       make_basic_app do |config, app|
         app.config.public_file_server.enabled = true
         config.traces_sample_rate = 1.0
-        config.logger = logger
+        config.sdk_logger = logger
       end
     end
 

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Sentry::Rails, type: :request do
         logger = ::Logger.new(nil)
 
         make_basic_app do |config|
-          config.logger = logger
+          config.sdk_logger = logger
         end
 
         expect(Sentry.configuration.sdk_logger).to eq(logger)

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -44,22 +44,22 @@ RSpec.describe Sentry::Rails, type: :request do
     describe "logger detection" do
       it "sets a duplicated Rails logger as the SDK's logger" do
         if Gem::Version.new(Rails.version) > Gem::Version.new("7.1.0.beta")
-          expect(Sentry.configuration.logger).to be_a(ActiveSupport::BroadcastLogger)
+          expect(Sentry.configuration.sdk_logger).to be_a(ActiveSupport::BroadcastLogger)
 
-          Sentry.configuration.logger.level = ::Logger::WARN
+          Sentry.configuration.sdk_logger.level = ::Logger::WARN
 
           # Configuring the SDK's logger should not affect the Rails logger
           expect(Rails.logger.broadcasts.first).to be_a(ActiveSupport::Logger)
           expect(Rails.logger.broadcasts.first.level).to eq(::Logger::DEBUG)
-          expect(Sentry.configuration.logger.level).to eq(::Logger::WARN)
+          expect(Sentry.configuration.sdk_logger.level).to eq(::Logger::WARN)
         else
-          expect(Sentry.configuration.logger).to be_a(ActiveSupport::Logger)
+          expect(Sentry.configuration.sdk_logger).to be_a(ActiveSupport::Logger)
 
-          Sentry.configuration.logger.level = ::Logger::WARN
+          Sentry.configuration.sdk_logger.level = ::Logger::WARN
 
           # Configuring the SDK's logger should not affect the Rails logger
           expect(Rails.logger.level).to eq(::Logger::DEBUG)
-          expect(Sentry.configuration.logger.level).to eq(::Logger::WARN)
+          expect(Sentry.configuration.sdk_logger.level).to eq(::Logger::WARN)
         end
       end
 
@@ -70,7 +70,7 @@ RSpec.describe Sentry::Rails, type: :request do
           config.logger = logger
         end
 
-        expect(Sentry.configuration.logger).to eq(logger)
+        expect(Sentry.configuration.sdk_logger).to eq(logger)
       end
 
       it "doesn't cause error if Rails::Logger is not present during SDK initialization" do
@@ -78,7 +78,7 @@ RSpec.describe Sentry::Rails, type: :request do
 
         Sentry.init
 
-        expect(Sentry.configuration.logger).to be_a(Sentry::Logger)
+        expect(Sentry.configuration.sdk_logger).to be_a(Sentry::Logger)
       end
     end
 

--- a/sentry-resque/spec/spec_helper.rb
+++ b/sentry-resque/spec/spec_helper.rb
@@ -73,7 +73,7 @@ end
 def perform_basic_setup
   Sentry.init do |config|
     config.dsn = DUMMY_DSN
-    config.logger = ::Logger.new(nil)
+    config.sdk_logger = ::Logger.new(nil)
     config.background_worker_threads = 0
     config.transport.transport_class = Sentry::DummyTransport
     yield(config) if block_given?

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -617,6 +617,16 @@ module Sentry
     ##### Helpers #####
 
     # @!visibility private
+    def logger
+      warn <<~STR
+        [sentry] `Sentry.logger` will no longer be used as internal SDK logger when `enable_logs` feature is turned on.
+                 Use Sentry.configuration.sdk_logger for SDK-specific logging needs."
+      STR
+
+      configuration.sdk_logger
+    end
+
+    # @!visibility private
     def sys_command(command)
       result = `#{command} 2>&1` rescue nil
       return if result.nil? || result.empty? || ($CHILD_STATUS && $CHILD_STATUS.exitstatus != 0)

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -94,6 +94,11 @@ module Sentry
     #   @return [Metrics::Aggregator, nil]
     attr_reader :metrics_aggregator
 
+    # @!attribute [r] logger
+    #   @return [Logger]
+    # @!visibility private
+    attr_reader :sdk_logger
+
     ##### Patch Registration #####
 
     # @!visibility private
@@ -138,7 +143,7 @@ module Sentry
     # @param version [String] version of the integration
     def register_integration(name, version)
       if initialized?
-        logger.warn(LOGGER_PROGNAME) do
+        sdk_logger.warn(LOGGER_PROGNAME) do
           <<~MSG
             Integration '#{name}' is loaded after the SDK is initialized, which can cause unexpected behavior.  Please make sure all integrations are loaded before SDK initialization.
           MSG
@@ -238,6 +243,10 @@ module Sentry
     def init(&block)
       config = Configuration.new
       yield(config) if block_given?
+
+      # Internal SDK logger
+      @sdk_logger = config.sdk_logger
+
       config.detect_release
       apply_patches(config)
       config.validate
@@ -613,11 +622,6 @@ module Sentry
       return if result.nil? || result.empty? || ($CHILD_STATUS && $CHILD_STATUS.exitstatus != 0)
 
       result.strip
-    end
-
-    # @!visibility private
-    def logger
-      configuration.logger
     end
 
     # @!visibility private

--- a/sentry-ruby/lib/sentry/background_worker.rb
+++ b/sentry-ruby/lib/sentry/background_worker.rb
@@ -9,8 +9,7 @@ module Sentry
     include LoggingHelper
 
     attr_reader :max_queue, :number_of_threads
-    # @deprecated Use Sentry.sdk_logger to retrieve the current logger instead.
-    attr_reader :logger
+
     attr_accessor :shutdown_timeout
 
     DEFAULT_MAX_QUEUE = 30
@@ -19,7 +18,7 @@ module Sentry
       @shutdown_timeout = 1
       @number_of_threads = configuration.background_worker_threads
       @max_queue = configuration.background_worker_max_queue
-      @logger = configuration.sdk_logger
+      @sdk_logger = configuration.sdk_logger
       @debug = configuration.debug
       @shutdown_callback = nil
 

--- a/sentry-ruby/lib/sentry/background_worker.rb
+++ b/sentry-ruby/lib/sentry/background_worker.rb
@@ -9,7 +9,7 @@ module Sentry
     include LoggingHelper
 
     attr_reader :max_queue, :number_of_threads
-    # @deprecated Use Sentry.logger to retrieve the current logger instead.
+    # @deprecated Use Sentry.sdk_logger to retrieve the current logger instead.
     attr_reader :logger
     attr_accessor :shutdown_timeout
 
@@ -19,7 +19,7 @@ module Sentry
       @shutdown_timeout = 1
       @number_of_threads = configuration.background_worker_threads
       @max_queue = configuration.background_worker_max_queue
-      @logger = configuration.logger
+      @logger = configuration.sdk_logger
       @debug = configuration.debug
       @shutdown_callback = nil
 

--- a/sentry-ruby/lib/sentry/backpressure_monitor.rb
+++ b/sentry-ruby/lib/sentry/backpressure_monitor.rb
@@ -6,7 +6,7 @@ module Sentry
     MAX_DOWNSAMPLE_FACTOR = 10
 
     def initialize(configuration, client, interval: DEFAULT_INTERVAL)
-      super(configuration.logger, interval)
+      super(configuration.sdk_logger, interval)
       @client = client
 
       @healthy = true

--- a/sentry-ruby/lib/sentry/breadcrumb.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb.rb
@@ -63,7 +63,7 @@ module Sentry
       begin
         ::JSON.parse(::JSON.generate(@data, max_nesting: MAX_NESTING))
       rescue Exception => e
-        Sentry.logger.debug(LOGGER_PROGNAME) do
+        Sentry.sdk_logger.debug(LOGGER_PROGNAME) do
           <<~MSG
 can't serialize breadcrumb data because of error: #{e}
 data: #{@data}

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -19,8 +19,6 @@ module Sentry
     # @!macro configuration
     attr_reader :configuration
 
-    attr_reader :log_event_buffer
-
     # @param configuration [Configuration]
     def initialize(configuration)
       @configuration = configuration

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -22,7 +22,7 @@ module Sentry
     # @param configuration [Configuration]
     def initialize(configuration)
       @configuration = configuration
-      @logger = configuration.sdk_logger
+      @sdk_logger = configuration.sdk_logger
 
       if transport_class = configuration.transport.transport_class
         @transport = transport_class.new(configuration)

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -19,13 +19,12 @@ module Sentry
     # @!macro configuration
     attr_reader :configuration
 
-    # @deprecated Use Sentry.logger to retrieve the current logger instead.
-    attr_reader :logger
+    attr_reader :log_event_buffer
 
     # @param configuration [Configuration]
     def initialize(configuration)
       @configuration = configuration
-      @logger = configuration.logger
+      @logger = configuration.sdk_logger
 
       if transport_class = configuration.transport.transport_class
         @transport = transport_class.new(configuration)

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -324,10 +324,6 @@ module Sentry
     # @return [Integer]
     attr_accessor :max_log_events
 
-    # Experimental features configuration
-    # @return [Hash]
-    attr_accessor :_experiments
-
     # these are not config options
     # @!visibility private
     attr_reader :errors, :gem_specs
@@ -474,7 +470,6 @@ module Sentry
       @cron = Cron::Configuration.new
       @metrics = Metrics::Configuration.new
       @gem_specs = Hash[Gem::Specification.map { |spec| [spec.name, spec.version.to_s] }] if Gem::Specification.respond_to?(:map)
-      @_experiments = { enable_logs: false }
 
       run_post_initialization_callbacks
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -184,7 +184,9 @@ module Sentry
     # Logger used by Sentry. In Rails, this is the Rails logger, otherwise
     # Sentry provides its own Sentry::Logger.
     # @return [Logger]
-    attr_accessor :logger
+    attr_accessor :sdk_logger
+    alias_method :logger, :sdk_logger
+    alias_method :logger=, :sdk_logger=
 
     # Project directory root for in_app detection. Could be Rails root, etc.
     # Set automatically for Rails.
@@ -312,6 +314,10 @@ module Sentry
     # @return [Integer]
     attr_accessor :max_log_events
 
+    # Experimental features configuration
+    # @return [Hash]
+    attr_accessor :_experiments
+
     # these are not config options
     # @!visibility private
     attr_reader :errors, :gem_specs
@@ -424,7 +430,7 @@ module Sentry
       self.excluded_exceptions = IGNORE_DEFAULT + PUMA_IGNORE_DEFAULT
       self.inspect_exception_causes_for_exclusion = true
       self.linecache = ::Sentry::LineCache.new
-      self.logger = ::Sentry::Logger.new(STDOUT)
+      self.sdk_logger = ::Sentry::Logger.new(STDOUT)
       self.project_root = Dir.pwd
       self.propagate_traces = true
 
@@ -458,6 +464,7 @@ module Sentry
       @cron = Cron::Configuration.new
       @metrics = Metrics::Configuration.new
       @gem_specs = Hash[Gem::Specification.map { |spec| [spec.name, spec.version.to_s] }] if Gem::Specification.respond_to?(:map)
+      @_experiments = { enable_logs: false }
 
       run_post_initialization_callbacks
 

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -185,8 +185,18 @@ module Sentry
     # Sentry provides its own Sentry::Logger.
     # @return [Logger]
     attr_accessor :sdk_logger
-    alias_method :logger, :sdk_logger
-    alias_method :logger=, :sdk_logger=
+
+    # @deprecated Use {#sdk_logger=} instead.
+    def logger=(logger)
+      warn "[sentry] `config.logger=` is deprecated. Please use `config.sdk_logger=` instead."
+      self.sdk_logger = logger
+    end
+
+    # @deprecated Use {#sdk_logger} instead.
+    def logger
+      warn "[sentry] `config.logger` is deprecated. Please use `config.sdk_logger` instead."
+      self.sdk_logger = logger
+    end
 
     # Project directory root for in_app detection. Could be Rails root, etc.
     # Set automatically for Rails.

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -195,7 +195,7 @@ module Sentry
     # @deprecated Use {#sdk_logger} instead.
     def logger
       warn "[sentry] `config.logger` is deprecated. Please use `config.sdk_logger` instead."
-      self.sdk_logger = logger
+      self.sdk_logger
     end
 
     # Project directory root for in_app detection. Could be Rails root, etc.

--- a/sentry-ruby/lib/sentry/interfaces/request.rb
+++ b/sentry-ruby/lib/sentry/interfaces/request.rb
@@ -99,7 +99,7 @@ module Sentry
           # Rails adds objects to the Rack env that can sometimes raise exceptions
           # when `to_s` is called.
           # See: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L134
-          Sentry.logger.warn(LOGGER_PROGNAME) { "Error raised while formatting headers: #{e.message}" }
+          Sentry.sdk_logger.warn(LOGGER_PROGNAME) { "Error raised while formatting headers: #{e.message}" }
           next
         end
       end

--- a/sentry-ruby/lib/sentry/log_event_buffer.rb
+++ b/sentry-ruby/lib/sentry/log_event_buffer.rb
@@ -7,8 +7,11 @@ module Sentry
     FLUSH_INTERVAL = 5 # seconds
     DEFAULT_MAX_EVENTS = 100
 
+    attr_reader :pending_events
+
     def initialize(configuration, client)
-      super(configuration.logger, FLUSH_INTERVAL)
+      super(configuration.sdk_logger, FLUSH_INTERVAL)
+
       @client = client
       @pending_events = []
       @max_events = configuration.max_log_events || DEFAULT_MAX_EVENTS
@@ -16,7 +19,7 @@ module Sentry
       @sdk = Sentry.sdk_meta
       @mutex = Mutex.new
 
-      log_debug("[LogEvents] Initialized buffer with max_events=#{@max_events}, flush_interval=#{FLUSH_INTERVAL}s")
+      log_debug("[Logging] Initialized buffer with max_events=#{@max_events}, flush_interval=#{FLUSH_INTERVAL}s")
     end
 
     def start

--- a/sentry-ruby/lib/sentry/log_event_buffer.rb
+++ b/sentry-ruby/lib/sentry/log_event_buffer.rb
@@ -7,8 +7,6 @@ module Sentry
     FLUSH_INTERVAL = 5 # seconds
     DEFAULT_MAX_EVENTS = 100
 
-    attr_reader :pending_events
-
     def initialize(configuration, client)
       super(configuration.sdk_logger, FLUSH_INTERVAL)
 

--- a/sentry-ruby/lib/sentry/metrics/aggregator.rb
+++ b/sentry-ruby/lib/sentry/metrics/aggregator.rb
@@ -34,7 +34,7 @@ module Sentry
       attr_reader :client, :thread, :buckets, :flush_shift, :code_locations
 
       def initialize(configuration, client)
-        super(configuration.logger, FLUSH_INTERVAL)
+        super(configuration.sdk_logger, FLUSH_INTERVAL)
         @client = client
         @before_emit = configuration.metrics.before_emit
         @enable_code_locations = configuration.metrics.enable_code_locations

--- a/sentry-ruby/lib/sentry/profiler.rb
+++ b/sentry-ruby/lib/sentry/profiler.rb
@@ -193,7 +193,7 @@ module Sentry
     private
 
     def log(message)
-      Sentry.logger.debug(LOGGER_PROGNAME) { "[Profiler] #{message}" }
+      Sentry.sdk_logger.debug(LOGGER_PROGNAME) { "[Profiler] #{message}" }
     end
 
     def record_lost_event(reason)

--- a/sentry-ruby/lib/sentry/session_flusher.rb
+++ b/sentry-ruby/lib/sentry/session_flusher.rb
@@ -5,7 +5,7 @@ module Sentry
     FLUSH_INTERVAL = 60
 
     def initialize(configuration, client)
-      super(configuration.logger, FLUSH_INTERVAL)
+      super(configuration.sdk_logger, FLUSH_INTERVAL)
       @client = client
       @pending_aggregates = {}
       @release = configuration.release

--- a/sentry-ruby/lib/sentry/threaded_periodic_worker.rb
+++ b/sentry-ruby/lib/sentry/threaded_periodic_worker.rb
@@ -4,11 +4,11 @@ module Sentry
   class ThreadedPeriodicWorker
     include LoggingHelper
 
-    def initialize(logger, interval)
+    def initialize(sdk_logger, interval)
       @thread = nil
       @exited = false
       @interval = interval
-      @logger = logger
+      @sdk_logger = sdk_logger
     end
 
     def ensure_thread

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -45,7 +45,7 @@ module Sentry
     # @deprecated Use Sentry.configuration instead.
     attr_reader :configuration
 
-    # @deprecated Use Sentry.logger instead.
+    # @deprecated Use Sentry.sdk_logger instead.
     attr_reader :logger
 
     # The effective sample rate at which this transaction was sampled.
@@ -78,7 +78,7 @@ module Sentry
       @tracing_enabled = hub.configuration.tracing_enabled?
       @traces_sampler = hub.configuration.traces_sampler
       @traces_sample_rate = hub.configuration.traces_sample_rate
-      @logger = hub.configuration.logger
+      @logger = hub.configuration.sdk_logger
       @release = hub.configuration.release
       @environment = hub.configuration.environment
       @dsn = hub.configuration.dsn

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -45,9 +45,6 @@ module Sentry
     # @deprecated Use Sentry.configuration instead.
     attr_reader :configuration
 
-    # @deprecated Use Sentry.sdk_logger instead.
-    attr_reader :logger
-
     # The effective sample rate at which this transaction was sampled.
     # @return [Float, nil]
     attr_reader :effective_sample_rate
@@ -78,7 +75,7 @@ module Sentry
       @tracing_enabled = hub.configuration.tracing_enabled?
       @traces_sampler = hub.configuration.traces_sampler
       @traces_sample_rate = hub.configuration.traces_sample_rate
-      @logger = hub.configuration.sdk_logger
+      @sdk_logger = hub.configuration.sdk_logger
       @release = hub.configuration.release
       @environment = hub.configuration.environment
       @dsn = hub.configuration.dsn

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -26,11 +26,8 @@ module Sentry
 
     attr_reader :rate_limits, :discarded_events, :last_client_report_sent
 
-    # @deprecated Use Sentry.sdk_logger to retrieve the current logger instead.
-    attr_reader :logger
-
     def initialize(configuration)
-      @logger = configuration.sdk_logger
+      @sdk_logger = configuration.sdk_logger
       @transport_configuration = configuration.transport
       @dsn = configuration.dsn
       @rate_limits = {}

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -26,11 +26,11 @@ module Sentry
 
     attr_reader :rate_limits, :discarded_events, :last_client_report_sent
 
-    # @deprecated Use Sentry.logger to retrieve the current logger instead.
+    # @deprecated Use Sentry.sdk_logger to retrieve the current logger instead.
     attr_reader :logger
 
     def initialize(configuration)
-      @logger = configuration.logger
+      @logger = configuration.sdk_logger
       @transport_configuration = configuration.transport
       @dsn = configuration.dsn
       @rate_limits = {}

--- a/sentry-ruby/lib/sentry/utils/logging_helper.rb
+++ b/sentry-ruby/lib/sentry/utils/logging_helper.rb
@@ -1,24 +1,29 @@
 # frozen_string_literal: true
 
 module Sentry
+  # @private
   module LoggingHelper
-    attr_reader :logger
+    # @!visibility private
+    attr_reader :sdk_logger
 
+    # @!visibility private
     def log_error(message, exception, debug: false)
       message = "#{message}: #{exception.message}"
       message += "\n#{exception.backtrace.join("\n")}" if debug
 
-      logger.error(LOGGER_PROGNAME) do
+      sdk_logger.error(LOGGER_PROGNAME) do
         message
       end
     end
 
+    # @!visibility private
     def log_debug(message)
-      logger.debug(LOGGER_PROGNAME) { message }
+      sdk_logger.debug(LOGGER_PROGNAME) { message }
     end
 
+    # @!visibility private
     def log_warn(message)
-      logger.warn(LOGGER_PROGNAME) { message }
+      sdk_logger.warn(LOGGER_PROGNAME) { message }
     end
   end
 end

--- a/sentry-ruby/lib/sentry/utils/logging_helper.rb
+++ b/sentry-ruby/lib/sentry/utils/logging_helper.rb
@@ -2,21 +2,23 @@
 
 module Sentry
   module LoggingHelper
+    attr_reader :logger
+
     def log_error(message, exception, debug: false)
       message = "#{message}: #{exception.message}"
       message += "\n#{exception.backtrace.join("\n")}" if debug
 
-      @logger.error(LOGGER_PROGNAME) do
+      logger.error(LOGGER_PROGNAME) do
         message
       end
     end
 
     def log_debug(message)
-      @logger.debug(LOGGER_PROGNAME) { message }
+      logger.debug(LOGGER_PROGNAME) { message }
     end
 
     def log_warn(message)
-      @logger.warn(LOGGER_PROGNAME) { message }
+      logger.warn(LOGGER_PROGNAME) { message }
     end
   end
 end

--- a/sentry-ruby/lib/sentry/vernier/profiler.rb
+++ b/sentry-ruby/lib/sentry/vernier/profiler.rb
@@ -104,7 +104,7 @@ module Sentry
       private
 
       def log(message)
-        Sentry.logger.debug(LOGGER_PROGNAME) { "[Profiler::Vernier] #{message}" }
+        Sentry.sdk_logger.debug(LOGGER_PROGNAME) { "[Profiler::Vernier] #{message}" }
       end
 
       def record_lost_event(reason)

--- a/sentry-ruby/spec/sentry/background_worker_spec.rb
+++ b/sentry-ruby/spec/sentry/background_worker_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Sentry::BackgroundWorker do
 
   let(:configuration) do
     Sentry::Configuration.new.tap do |config|
-      config.logger = Logger.new(string_io)
+      config.sdk_logger = Logger.new(string_io)
     end
   end
 

--- a/sentry-ruby/spec/sentry/backpressure_monitor_spec.rb
+++ b/sentry-ruby/spec/sentry/backpressure_monitor_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Sentry::BackpressureMonitor do
   before do
     perform_basic_setup do |config|
       config.enable_backpressure_handling = true
-      config.logger = Logger.new(string_io)
+      config.sdk_logger = Logger.new(string_io)
     end
   end
 

--- a/sentry-ruby/spec/sentry/breadcrumb/http_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/http_logger_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe :http_logger do
     perform_basic_setup do |config|
       config.breadcrumbs_logger = [:http_logger]
       config.transport.transport_class = Sentry::HTTPTransport
-      config.logger = logger
+      config.sdk_logger = logger
       # the dsn needs to have a real host so we can make a real connection before sending a failed request
       config.dsn = 'http://foobarbaz@o447951.ingest.sentry.io/5434472'
     end

--- a/sentry-ruby/spec/sentry/breadcrumb_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Sentry::Breadcrumb do
 
   before do
     perform_basic_setup do |config|
-      config.logger = ::Logger.new(stringio)
+      config.sdk_logger = ::Logger.new(stringio)
     end
   end
 

--- a/sentry-ruby/spec/sentry/client/event_sending_spec.rb
+++ b/sentry-ruby/spec/sentry/client/event_sending_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Sentry::Client do
   let(:configuration) do
     Sentry::Configuration.new.tap do |config|
-      config.logger = Logger.new(nil)
+      config.sdk_logger = Logger.new(nil)
       config.dsn = Sentry::TestHelper::DUMMY_DSN
       config.transport.transport_class = Sentry::DummyTransport
     end
@@ -390,7 +390,7 @@ RSpec.describe Sentry::Client do
     let(:configuration) do
       Sentry::Configuration.new.tap do |config|
         config.dsn = Sentry::TestHelper::DUMMY_DSN
-        config.logger = logger
+        config.sdk_logger = logger
       end
     end
 

--- a/sentry-ruby/spec/sentry/client/event_sending_spec.rb
+++ b/sentry-ruby/spec/sentry/client/event_sending_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Sentry::Client do
         let(:event) { client.event_from_message("Bad data '\x80\xF8'") }
 
         it "does not mask the exception" do
-          configuration.logger = logger
+          configuration.sdk_logger = logger
 
           client.capture_event(event, scope)
 
@@ -269,7 +269,7 @@ RSpec.describe Sentry::Client do
       it "warns if before_send returns nil" do
         string_io = StringIO.new
         logger = Logger.new(string_io, level: :debug)
-        configuration.logger = logger
+        configuration.sdk_logger = logger
         configuration.before_send = lambda do |_event, _hint|
           nil
         end
@@ -281,7 +281,7 @@ RSpec.describe Sentry::Client do
       it "warns if before_send returns non-Event objects" do
         string_io = StringIO.new
         logger = Logger.new(string_io, level: :debug)
-        configuration.logger = logger
+        configuration.sdk_logger = logger
         configuration.before_send = lambda do |_event, _hint|
           123
         end
@@ -294,7 +294,7 @@ RSpec.describe Sentry::Client do
       it "warns about Hash value's deprecation" do
         string_io = StringIO.new
         logger = Logger.new(string_io, level: :debug)
-        configuration.logger = logger
+        configuration.sdk_logger = logger
         configuration.before_send = lambda do |_event, _hint|
           { foo: "bar" }
         end
@@ -349,7 +349,7 @@ RSpec.describe Sentry::Client do
       it "warns if before_send_transaction returns nil" do
         string_io = StringIO.new
         logger = Logger.new(string_io, level: :debug)
-        configuration.logger = logger
+        configuration.sdk_logger = logger
         configuration.before_send_transaction = lambda do |_event, _hint|
           nil
         end
@@ -362,7 +362,7 @@ RSpec.describe Sentry::Client do
       it "warns about Hash value's deprecation" do
         string_io = StringIO.new
         logger = Logger.new(string_io, level: :debug)
-        configuration.logger = logger
+        configuration.sdk_logger = logger
         configuration.before_send_transaction = lambda do |_event, _hint|
           { foo: "bar" }
         end

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Sentry::Client do
 
       before do
         configuration.debug = true
-        configuration.logger = ::Logger.new(string_io)
+        configuration.sdk_logger = ::Logger.new(string_io)
 
         allow(subject.transport).to receive(:send_envelope).and_raise(Sentry::ExternalError.new("networking error"))
       end
@@ -739,7 +739,7 @@ RSpec.describe Sentry::Client do
     end
 
     before do
-      configuration.logger = logger
+      configuration.sdk_logger = logger
     end
 
     let(:span) { Sentry::Span.new(transaction: transaction) }
@@ -763,7 +763,7 @@ RSpec.describe Sentry::Client do
   end
 
   describe "#generate_baggage" do
-    before { configuration.logger = logger }
+    before { configuration.sdk_logger = logger }
 
     let(:string_io) { StringIO.new }
     let(:logger) { ::Logger.new(string_io) }

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -726,7 +726,7 @@ RSpec.describe Sentry::Configuration do
 
       expect {
         Sentry.init do |config|
-          config.logger = Logger.new($stdout)
+          config.sdk_logger = Logger.new($stdout)
           config.profiles_sample_rate = 1.0
         end
       }.to output(/Please add the 'stackprof' gem to your Gemfile/).to_stdout
@@ -737,7 +737,7 @@ RSpec.describe Sentry::Configuration do
 
       expect {
         Sentry.init do |config|
-          config.logger = Logger.new($stdout)
+          config.sdk_logger = Logger.new($stdout)
           config.profiles_sample_rate = nil
         end
       }.to_not output(/Please add the 'stackprof' gem to your Gemfile/).to_stdout
@@ -748,7 +748,7 @@ RSpec.describe Sentry::Configuration do
 
       expect {
         Sentry.init do |config|
-          config.logger = Logger.new($stdout)
+          config.sdk_logger = Logger.new($stdout)
           config.profiler_class = Sentry::Vernier::Profiler
           config.profiles_sample_rate = 1.0
         end
@@ -760,7 +760,7 @@ RSpec.describe Sentry::Configuration do
 
       expect {
         Sentry.init do |config|
-          config.logger = Logger.new($stdout)
+          config.sdk_logger = Logger.new($stdout)
           config.profiles_sample_rate = nil
         end
       }.to_not output(/Please add the 'vernier' gem to your Gemfile/).to_stdout

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -766,4 +766,20 @@ RSpec.describe Sentry::Configuration do
       }.to_not output(/Please add the 'vernier' gem to your Gemfile/).to_stdout
     end
   end
+
+  describe "#logger" do
+    it "returns configured sdk_logger and prints deprecation warning" do
+      expect {
+        expect(subject.logger).to be(subject.sdk_logger)
+      }.to output(/`config.logger` is deprecated/).to_stderr
+    end
+  end
+
+  describe "#logger=" do
+    it "sets sdk_logger and prints deprecation warning" do
+      expect {
+        subject.logger = Logger.new($stdout)
+      }.to output(/`config.logger=` is deprecated/).to_stderr
+    end
+  end
 end

--- a/sentry-ruby/spec/sentry/excon_spec.rb
+++ b/sentry-ruby/spec/sentry/excon_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Sentry::Excon" do
     before do
       perform_basic_setup do |config|
         config.traces_sample_rate = 1.0
-        config.logger = logger
+        config.sdk_logger = logger
         # the dsn needs to have a real host so we can make a real connection before sending a failed request
         config.dsn = "http://foobarbaz@o447951.ingest.sentry.io/5434472"
         config.enabled_patches += [:excon] unless config.enabled_patches.include?(:excon)

--- a/sentry-ruby/spec/sentry/faraday_spec.rb
+++ b/sentry-ruby/spec/sentry/faraday_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Sentry::Faraday do
       perform_basic_setup do |config|
         config.enabled_patches << :faraday
         config.traces_sample_rate = 1.0
-        config.logger = ::Logger.new(StringIO.new)
+        config.sdk_logger = ::Logger.new(StringIO.new)
       end
     end
 

--- a/sentry-ruby/spec/sentry/graphql_spec.rb
+++ b/sentry-ruby/spec/sentry/graphql_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'GraphQL' do
 
           perform_basic_setup do |config|
             config.enabled_patches << :graphql
-            config.logger = Logger.new(string_io)
+            config.sdk_logger = Logger.new(string_io)
           end
 
           expect(string_io.string).to include('WARN -- sentry: You tried to enable the GraphQL integration but no GraphQL gem was detected. Make sure you have the `graphql` gem (>= 2.2.6) in your Gemfile.')

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Sentry::Hub do
     config.dsn = Sentry::TestHelper::DUMMY_DSN
     config.transport.transport_class = Sentry::DummyTransport
     config.background_worker_threads = 0
-    config.logger = logger
+    config.sdk_logger = logger
     config
   end
   let(:client) { Sentry::Client.new(configuration) }

--- a/sentry-ruby/spec/sentry/integrable_spec.rb
+++ b/sentry-ruby/spec/sentry/integrable_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Sentry::Integrable do
 
     before do
       perform_basic_setup do |config|
-        config.logger = logger
+        config.sdk_logger = logger
       end
     end
 

--- a/sentry-ruby/spec/sentry/log_event_buffer_spec.rb
+++ b/sentry-ruby/spec/sentry/log_event_buffer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Sentry::LogEventBuffer do
 
   before do
     perform_basic_setup do |config|
-      config.logger = logger
+      config.sdk_logger = logger
       config.background_worker_threads = 0
       config.max_log_events = 3
     end

--- a/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Sentry::Metrics::Aggregator do
       config.traces_sample_rate = 1.0
       config.release = 'test-release'
       config.environment = 'test'
-      config.logger = Logger.new(string_io)
+      config.sdk_logger = Logger.new(string_io)
     end
   end
 
@@ -197,7 +197,7 @@ RSpec.describe Sentry::Metrics::Aggregator do
           config.traces_sample_rate = 1.0
           config.release = 'test-release'
           config.environment = 'test'
-          config.logger = Logger.new(string_io)
+          config.sdk_logger = Logger.new(string_io)
 
           config.metrics.before_emit = lambda do |key, tags|
             return nil if key == 'foo'

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Sentry::Net::HTTP do
       perform_basic_setup do |config|
         config.traces_sample_rate = 1.0
         config.transport.transport_class = Sentry::HTTPTransport
-        config.logger = logger
+        config.sdk_logger = logger
         # the dsn needs to have a real host so we can make a real connection before sending a failed request
         config.dsn = 'http://foobarbaz@o447951.ingest.sentry.io/5434472'
       end

--- a/sentry-ruby/spec/sentry/session_flusher_spec.rb
+++ b/sentry-ruby/spec/sentry/session_flusher_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Sentry::SessionFlusher do
       config.environment = 'test'
       config.transport.transport_class = Sentry::DummyTransport
       config.background_worker_threads = 0
-      config.logger = Logger.new(string_io)
+      config.sdk_logger = Logger.new(string_io)
     end
   end
 

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -327,7 +327,7 @@ RSpec.describe Sentry::Transaction do
         end
 
         it "uses the genereted rate for sampling (positive)" do
-          expect(Sentry.configuration.logger).to receive(:debug).exactly(3).and_call_original
+          expect(Sentry.configuration.sdk_logger).to receive(:debug).exactly(3).and_call_original
 
           Sentry.configuration.traces_sampler = ->(_) { true }
           subject = described_class.new(hub: Sentry.get_current_hub)
@@ -353,7 +353,7 @@ RSpec.describe Sentry::Transaction do
         end
 
         it "uses the genereted rate for sampling (negative)" do
-          expect(Sentry.configuration.logger).to receive(:debug).exactly(2).and_call_original
+          expect(Sentry.configuration.sdk_logger).to receive(:debug).exactly(2).and_call_original
 
           Sentry.configuration.traces_sampler = ->(_) { false }
           subject = described_class.new(hub: Sentry.get_current_hub)

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Sentry::Transaction do
 
     before do
       perform_basic_setup do |config|
-        config.logger = logger
+        config.sdk_logger = logger
       end
     end
 

--- a/sentry-ruby/spec/sentry/transport/http_transport_rate_limiting_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_rate_limiting_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "rate limiting" do
 
   before do
     perform_basic_setup do |config|
-      config.logger = Logger.new(string_io)
+      config.sdk_logger = Logger.new(string_io)
     end
   end
 

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Sentry::HTTPTransport do
   let(:configuration) do
     Sentry::Configuration.new.tap do |config|
       config.dsn = Sentry::TestHelper::DUMMY_DSN
-      config.logger = Logger.new(nil)
+      config.sdk_logger = Logger.new(nil)
     end
   end
   let(:client) { Sentry::Client.new(configuration) }
@@ -55,7 +55,7 @@ RSpec.describe Sentry::HTTPTransport do
     let(:configuration) do
       Sentry::Configuration.new.tap do |config|
         config.dsn = dsn
-        config.logger = Logger.new(nil)
+        config.sdk_logger = Logger.new(nil)
       end
     end
 

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Sentry::HTTPTransport do
   it "logs a debug message only during initialization" do
     sentry_stub_request(build_fake_response("200"))
     string_io = StringIO.new
-    configuration.logger = Logger.new(string_io)
+    configuration.sdk_logger = Logger.new(string_io)
 
     subject
 

--- a/sentry-ruby/spec/sentry/transport/spotlight_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/spotlight_transport_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Sentry::SpotlightTransport do
 
   it 'logs a debug message during initialization' do
     string_io = StringIO.new
-    configuration.logger = Logger.new(string_io)
+    configuration.sdk_logger = Logger.new(string_io)
 
     subject
 
@@ -60,8 +60,8 @@ RSpec.describe Sentry::SpotlightTransport do
   describe '#send_data' do
     it 'fails a maximum of three times and logs disable once' do
       string_io = StringIO.new
-      configuration.logger = Logger.new(string_io)
-      configuration.logger.level = :debug
+      configuration.sdk_logger = Logger.new(string_io)
+      configuration.sdk_logger.level = :debug
 
       allow(::Net::HTTP).to receive(:new).and_raise(Errno::ECONNREFUSED)
 

--- a/sentry-ruby/spec/sentry/transport/spotlight_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/spotlight_transport_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Sentry::SpotlightTransport do
   let(:configuration) do
     Sentry::Configuration.new.tap do |config|
       config.spotlight = true
-      config.logger = Logger.new(nil)
+      config.sdk_logger = Logger.new(nil)
     end
   end
 
   let(:custom_configuration) do
     Sentry::Configuration.new.tap do |config|
       config.spotlight = 'http://foobar@test.com'
-      config.logger = Logger.new(nil)
+      config.sdk_logger = Logger.new(nil)
     end
   end
 

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Sentry::Transport do
   let(:configuration) do
     Sentry::Configuration.new.tap do |config|
       config.server = 'http://12345:67890@sentry.localdomain/sentry/42'
-      config.logger = logger
+      config.sdk_logger = logger
     end
   end
 

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Sentry do
       let(:string_io) { StringIO.new }
       before do
         perform_basic_setup do |config|
-          config.logger = Logger.new(string_io)
+          config.sdk_logger = Logger.new(string_io)
           config.transport.transport_class = Sentry::HTTPTransport
         end
 
@@ -576,7 +576,7 @@ RSpec.describe Sentry do
           ::Logger.new(string_io)
         end
         before do
-          Sentry.configuration.logger = logger
+          Sentry.configuration.sdk_logger = logger
           Sentry.configuration.enabled_environments = ["production"]
         end
 
@@ -1104,7 +1104,7 @@ RSpec.describe Sentry do
           logger = Logger.new(string_io)
 
           described_class.init do |config|
-            config.logger = logger
+            config.sdk_logger = logger
           end
 
           expect(described_class.configuration.release).to eq(nil)
@@ -1130,7 +1130,7 @@ RSpec.describe Sentry do
           allow(Sentry::ReleaseDetector).to receive(:detect_release_from_git).and_raise(TypeError.new)
 
           described_class.init do |config|
-            config.logger = logger
+            config.sdk_logger = logger
           end
 
           expect(string_io.string).to include("ERROR -- sentry: Error detecting release: TypeError")

--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -156,7 +156,7 @@ end
 
 def perform_basic_setup
   Sentry.init do |config|
-    config.logger = Logger.new(nil)
+    config.sdk_logger = Logger.new(nil)
     config.dsn = Sentry::TestHelper::DUMMY_DSN
     config.transport.transport_class = Sentry::DummyTransport
     # so the events will be sent synchronously for testing

--- a/sentry-ruby/spec/support/Rakefile.rb
+++ b/sentry-ruby/spec/support/Rakefile.rb
@@ -6,7 +6,7 @@ require "sentry-ruby"
 Sentry.init do |config|
   config.dsn = 'http://12345:67890@sentry.localdomain/sentry/42'
   config.background_worker_threads = 0
-  config.logger.level = Logger::DEBUG
+  config.sdk_logger.level = Logger::DEBUG
 end
 
 task :raise_exception do

--- a/sentry-sidekiq/spec/spec_helper.rb
+++ b/sentry-sidekiq/spec/spec_helper.rb
@@ -341,7 +341,7 @@ end
 def perform_basic_setup
   Sentry.init do |config|
     config.dsn = DUMMY_DSN
-    config.logger = ::Logger.new(nil)
+    config.sdk_logger = ::Logger.new(nil)
     config.background_worker_threads = 0
     config.transport.transport_class = Sentry::DummyTransport
     yield config if block_given?


### PR DESCRIPTION
This is in preparation for #2604 - we have an internal `Sentry.logger` used for warn/error/debug logging with the SDK but with Structured Logging feature we're introducing a public-facing `Sentry.logger` API, so our internal one needs to be renamed.