### PR TITLE
Stop running vernier specs under 3.2 due to a bug in Vernier

### DIFF
--- a/sentry-ruby/spec/sentry/vernier/profiler_spec.rb
+++ b/sentry-ruby/spec/sentry/vernier/profiler_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 require "sentry/vernier/profiler"
 
-RSpec.describe Sentry::Vernier::Profiler, when: { ruby_version?: [:>=, "3.2.1"] } do
+RSpec.describe Sentry::Vernier::Profiler, when: { ruby_version?: [:>=, "3.3"] } do
   subject(:profiler) { described_class.new(Sentry.configuration) }
 
   before do


### PR DESCRIPTION
It's randomly segfaulting under 3.2.8

https://github.com/getsentry/sentry-ruby/actions/runs/14878875245/job/41782086390?pr=2621#step:6:2009

#skip-changelog