### PR TITLE
Exclude ruby head in CI matrix for now

### DIFF
--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -53,6 +53,7 @@ jobs:
             rack_version: 3.1
             redis_rb_version: 5.3
         exclude:
+          - ruby_version: 'head' # all rack versions are broken now under head
           - ruby_version: 'jruby'
           - ruby_version: 'jruby-head'
     steps:


### PR DESCRIPTION
Rack broke (all versions) raising this:

      LoadError:
        cannot load such file -- cgi/cookie

#skip-changelog