### PR TITLE
Remove sentry-raven folder from VS Code workspace configuration

### DIFF
--- a/sentry-ruby.code-workspace
+++ b/sentry-ruby.code-workspace
@@ -21,16 +21,12 @@
     },
     {
       "path": "sentry-opentelemetry"
-    },
-    {
-      "path": "sentry-raven"
     }
   ],
   "settings": {
     "files.exclude": {
       "sentry-delayed_job": true,
       "sentry-rails": true,
-      "sentry-raven": true,
       "sentry-resque": true,
       "sentry-ruby": true,
       "sentry-sidekiq": true,


### PR DESCRIPTION
We barely touch this project so it makes no sense to have it in the workspace because it adds clutter and friction to development, as its files overlap with many sentry-ruby files.

#skip-changelog