### PR TITLE
Inherit secrets to fix CODECOV_TOKEN not present in sub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,42 +19,49 @@ jobs:
       engine: cruby-jruby
       min_version: 2.7
       versions: '["jruby-9.4.12.0"]'
+    secrets: inherit
 
   delayed_job-tests:
     needs: ruby-versions
     uses: ./.github/workflows/sentry_delayed_job_test.yml
     with:
       versions: ${{ needs.ruby-versions.outputs.versions }}
+    secrets: inherit
 
   opentelemetry-tests:
     needs: ruby-versions
     uses: ./.github/workflows/sentry_opentelemetry_test.yml
     with:
       versions: ${{ needs.ruby-versions.outputs.versions }}
+    secrets: inherit
 
   rails-tests:
     needs: ruby-versions
     uses: ./.github/workflows/sentry_rails_test.yml
     with:
       versions: ${{ needs.ruby-versions.outputs.versions }}
+    secrets: inherit
 
   resque-tests:
     needs: ruby-versions
     uses: ./.github/workflows/sentry_resque_test.yml
     with:
       versions: ${{ needs.ruby-versions.outputs.versions }}
+    secrets: inherit
 
   ruby-tests:
     needs: ruby-versions
     uses: ./.github/workflows/sentry_ruby_test.yml
     with:
       versions: ${{ needs.ruby-versions.outputs.versions }}
+    secrets: inherit
 
   sidekiq-tests:
     needs: ruby-versions
     uses: ./.github/workflows/sentry_sidekiq_test.yml
     with:
       versions: ${{ needs.ruby-versions.outputs.versions }}
+    secrets: inherit
 
   codecov:
     name: CodeCov


### PR DESCRIPTION
without this, `CODECOV_TOKEN` is not present in the sub workflows and coverage uploading fails
https://github.com/getsentry/sentry-ruby/actions/runs/15042765819/job/42278160770#step:7:240

#skip-changelog
