### PR TITLE
Fix coverage by making sure isolated specs have SimpleCov.command_name

### DIFF
--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -35,9 +35,6 @@ jobs:
           - ruby_version: "3.2"
             options:
               rubyopt: "--enable-frozen-string-literal --debug=frozen-string-literal"
-          - ruby_version: "3.2"
-            options:
-              codecov: 1
         exclude:
           # Because Rails 7.0 currently doesn't work with Ruby head
           # LoadError:
@@ -63,7 +60,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        if: ${{ matrix.options.codecov }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/sentry-rails/spec/versioned/2.7/activejob_spec.rb
+++ b/sentry-rails/spec/versioned/2.7/activejob_spec.rb
@@ -2,6 +2,9 @@
 
 require "spec_helper"
 
+# isolated tests need a SimpleCov name otherwise they will overwrite coverage
+SimpleCov.command_name "RSpecVersioned_2.7_ActiveJob"
+
 RSpec.describe "ActiveJob integration", type: :job do
   before do
     make_basic_app

--- a/sentry-ruby/Rakefile
+++ b/sentry-ruby/Rakefile
@@ -14,7 +14,7 @@ RSpec::Core::RakeTask.new(:spec).tap do |task|
 end
 
 task :isolated_specs do
-  Dir["spec/isolated/*"].each do |file|
+  Dir["spec/isolated/**/*_spec.rb"].each do |file|
     sh "bundle exec rspec #{file}"
   end
 end

--- a/sentry-ruby/spec/isolated/init.rb
+++ b/sentry-ruby/spec/isolated/init.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "../spec_helper"
+require "sentry-ruby"
+require "sentry/test_helper"
 
 Sentry.init do |config|
   config.dsn = Sentry::TestHelper::DUMMY_DSN

--- a/sentry-ruby/spec/isolated/init_spec.rb
+++ b/sentry-ruby/spec/isolated/init_spec.rb
@@ -2,7 +2,8 @@
 
 require_relative "../spec_helper"
 
-SimpleCov.command_name "RSpecIsolated"
+# isolated tests need a SimpleCov name otherwise they will overwrite coverage
+SimpleCov.command_name "RSpecIsolatedInit"
 
 RSpec.describe Sentry do
   context "works within a trap context", when: { ruby_engine?: "ruby" } do

--- a/sentry-ruby/spec/isolated/puma_spec.rb
+++ b/sentry-ruby/spec/isolated/puma_spec.rb
@@ -6,7 +6,8 @@ require_relative "../spec_helper"
 # Because puma doesn't have any dependency, if Rack is not installed the entire test won't work
 return if ENV["RACK_VERSION"] == "0"
 
-SimpleCov.command_name "RSpecIsolated"
+# isolated tests need a SimpleCov name otherwise they will overwrite coverage
+SimpleCov.command_name "RSpecIsolatedPuma"
 
 RSpec.describe Puma::Server do
   class TestServer


### PR DESCRIPTION
also
* make sure only spec files are run by the `:isolated_specs` task (and not the helper ruby init file)
* upload coverage for all delayed_job runs

see https://github.com/simplecov-ruby/simplecov?tab=readme-ov-file#merging-results

#skip-changelog

