### PR TITLE
Support for before send log

### DIFF
--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -285,7 +285,7 @@ module Sentry
       )
 
       items = if configuration.before_send_log
-        log_events.map { |log_event| configuration.before_send_log.call(log_event) }
+        log_events.map { |log_event| configuration.before_send_log.call(log_event) }.compact
       else
         log_events
       end

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -101,6 +101,15 @@ module Sentry
     # @return [Proc]
     attr_reader :before_send_transaction
 
+    # Optional Proc, called before sending an event to the server
+    # @example
+    #   config.before_send_log = lambda do |log|
+    #     log.attributes["sentry"] = true
+    #     log
+    #   end
+    # @return [Proc]
+    attr_accessor :before_send_log
+
     # An array of breadcrumbs loggers to be used. Available options are:
     # - :sentry_logger
     # - :http_logger
@@ -465,6 +474,7 @@ module Sentry
 
       self.before_send = nil
       self.before_send_transaction = nil
+      self.before_send_log = nil
       self.rack_env_whitelist = RACK_ENV_WHITELIST_DEFAULT
       self.traces_sampler = nil
       self.enable_tracing = nil

--- a/sentry-ruby/spec/sentry/log_event_buffer_spec.rb
+++ b/sentry-ruby/spec/sentry/log_event_buffer_spec.rb
@@ -42,13 +42,13 @@ RSpec.describe Sentry::LogEventBuffer do
     end
 
     it "does nothing when the number of events is less than max_events " do
-      expect(client).to_not receive(:send_envelope)
+      expect(client).to_not receive(:send_logs)
 
       2.times { log_event_buffer.add_event(log_event) }
     end
 
     it "auto-flushes pending events to the client when the number of events reaches max_events" do
-      expect(client).to receive(:send_envelope)
+      expect(client).to receive(:send_logs)
 
       3.times { log_event_buffer.add_event(log_event) }
 
@@ -60,7 +60,7 @@ RSpec.describe Sentry::LogEventBuffer do
     let(:max_log_events) { 30 }
 
     it "thread-safely handles concurrent access" do
-      expect(client).to receive(:send_envelope).exactly(3).times
+      expect(client).to receive(:send_logs).exactly(3).times
 
       threads = 3.times.map do
         Thread.new do

--- a/sentry-ruby/spec/sentry/structured_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/structured_logger_spec.rb
@@ -127,6 +127,18 @@ RSpec.describe Sentry::StructuredLogger do
           expect(log_event[:attributes]["hello"]).to eql({ value: "world", type: "string" })
         end
       end
+
+      context "when the callback returns nil" do
+        let(:before_send_log) do
+          ->(_log) { nil }
+        end
+
+        it "skips the processed log event" do
+          Sentry.logger.info("Hello World", user_id: 123, action: "create")
+
+          expect(sentry_logs).to be_empty
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This adds support for a new configuration option called `before_send_log`.

Closes #2633 