### PR TITLE
doc: fix default rails version on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ This file defines which specific image and Ruby version will be used to run the 
   ```
 - Install any additional dependencies. `sentry-sidekiq` assumes you have `redis` running.
 - Use `bundle exec rake` to run tests.
-  - In `sentry-rails`, you can use `RAILS_VERSION=version` to specify the Rails version to test against. Default is `7.0`
+  - In `sentry-rails`, you can use `RAILS_VERSION=version` to specify the Rails version to test against. Default is `8.0`
   - In `sentry-sidekiq`, you can use `SIDEKIQ_VERSION=version` to specify what version of Sidekiq to install when you run `bundle install`. Default is `7.0`
 - Use example apps under the `example` or `examples` folder to test the change. (Remember to change the DSN first)
 - To learn more about `sentry-ruby`'s structure, you can read the [Sentry SDK spec]


### PR DESCRIPTION
## Description

Now, default rails version in sentry-rails is `8.0`.

cf. https://github.com/getsentry/sentry-ruby/blob/5.24.0/sentry-rails/Gemfile#L20

But written on CONTRIBUTING.md is `7.0`. So I fixed it.

#skip-changelog