### PR TITLE
feat(sentry-rails): Allow `severity` to pass what is available at `level` when using ActiveSupport::ErrorReporter

### DIFF
--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -140,6 +140,9 @@ module Sentry
 
     def register_error_subscriber(app)
       require "sentry/rails/error_subscriber"
+      ActiveSupport::ErrorReporter::SEVERITIES.push(
+        *%i[fatal log debug warn].reject { |severity| ActiveSupport::ErrorReporter::SEVERITIES.include?(severity) }
+      )
       app.executor.error_reporter.subscribe(Sentry::Rails::ErrorSubscriber.new)
     end
   end

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -366,6 +366,106 @@ RSpec.describe Sentry::Rails, type: :request do
 
         expect(transport.events.count).to eq(0)
       end
+
+      context "when passed a severity" do
+        context "when severity is fatal" do
+          it "sets fatal level to the reported event" do
+            Rails.error.handle(severity: :fatal) do
+              1/0
+            end
+
+            expect(transport.events.count).to eq(1)
+
+            event = transport.events.first
+
+            expect(event.level).to eq(:fatal)
+          end
+        end
+
+        context "when severity is error" do
+          it "sets error level to the reported event" do
+            Rails.error.handle(severity: :error) do
+              1/0
+            end
+
+            expect(transport.events.count).to eq(1)
+
+            event = transport.events.first
+
+            expect(event.level).to eq(:error)
+          end
+        end
+
+        context "when severity is warning" do
+          it "sets warning level to the reported event" do
+            Rails.error.handle(severity: :warning) do
+              1/0
+            end
+
+            expect(transport.events.count).to eq(1)
+
+            event = transport.events.first
+
+            expect(event.level).to eq(:warning)
+          end
+        end
+
+        context "when severity is warn" do
+          it "sets warning level to the reported event" do
+            Rails.error.handle(severity: :warn) do
+              1/0
+            end
+
+            expect(transport.events.count).to eq(1)
+
+            event = transport.events.first
+
+            expect(event.level).to eq(:warning)
+          end
+        end
+
+        context "when severity is log" do
+          it "sets log level to the reported event" do
+            Rails.error.handle(severity: :log) do
+              1/0
+            end
+
+            expect(transport.events.count).to eq(1)
+
+            event = transport.events.first
+
+            expect(event.level).to eq(:log)
+          end
+        end
+
+        context "when severity is info" do
+          it "sets info level to the reported event" do
+            Rails.error.handle(severity: :info) do
+              1/0
+            end
+
+            expect(transport.events.count).to eq(1)
+
+            event = transport.events.first
+
+            expect(event.level).to eq(:info)
+          end
+        end
+
+        context "when severity is debug" do
+          it "sets debug level to the reported event" do
+            Rails.error.handle(severity: :debug) do
+              1/0
+            end
+
+            expect(transport.events.count).to eq(1)
+
+            event = transport.events.first
+
+            expect(event.level).to eq(:debug)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

The following are available for `level` in `sentry-rails`.

- :fatal
- :error
- :warning
- :log
- :info
- :debug

cf. https://docs.sentry.io/platforms/ruby/guides/rails/usage/set-level/

But in the case of `severity` in ActiveSupport::ErrorReporter#report, ArgumentError is raised if anything other than the following is passed.

- :error
- :warning
- :info

cf. https://github.com/rails/rails/blob/v8.0.2/activesupport/lib/active_support/error_reporter.rb#L220-L222 cf. https://github.com/rails/rails/blob/v8.0.2/activesupport/lib/active_support/error_reporter.rb#L27

So I added symbols to ActiveSupport::ErrorReporter::SEVERITIES that is allowed as `level` when registering Sentry::Rails::ErrorSubscriber.

It also supports the behavior that `warn` is considered as `warning`.

cf. https://github.com/getsentry/sentry-ruby/blame/5.24.0/sentry-ruby/lib/sentry/event.rb#L100-L102
