### PR TITLE
Update install step in README

### DIFF
--- a/sentry-ruby/README.md
+++ b/sentry-ruby/README.md
@@ -59,6 +59,8 @@ gem "sentry-opentelemetry"
 
 You need to use Sentry.init to initialize and configure your SDK:
 ```ruby
+require "sentry-ruby"
+
 Sentry.init do |config|
   config.dsn = "MY_DSN"
 end


### PR DESCRIPTION
Mention requiring the gem. This may be especially helpful for the users
of the old `sentry-raven` gem as someone can accidently forget updating
`require` statement as a part of a migration.