### PR TITLE
Fix spec suite on CI

### DIFF
--- a/sentry-ruby/.rspec
+++ b/sentry-ruby/.rspec
@@ -1,2 +1,4 @@
---format documentation
+--require spec_helper
+--format progress
 --color
+--order rand

--- a/sentry-ruby/Rakefile
+++ b/sentry-ruby/Rakefile
@@ -8,15 +8,14 @@ Bundler::GemHelper.install_tasks(name: "sentry-ruby")
 
 require "rspec/core/rake_task"
 
+ISOLATED_SPECS = "spec/isolated/**/*_spec.rb"
+
 RSpec::Core::RakeTask.new(:spec).tap do |task|
-  task.rspec_opts = "--order rand"
-  task.exclude_pattern = "spec/isolated/**/*_spec.rb"
+  task.exclude_pattern = ISOLATED_SPECS
 end
 
-task :isolated_specs do
-  Dir["spec/isolated/**/*_spec.rb"].each do |file|
-    sh "bundle exec rspec #{file}"
-  end
+RSpec::Core::RakeTask.new(:isolated_specs).tap do |task|
+  task.pattern = ISOLATED_SPECS
 end
 
 task default: [:spec, :isolated_specs]

--- a/sentry-ruby/spec/initialization_check_spec.rb
+++ b/sentry-ruby/spec/initialization_check_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe "with uninitialized SDK" do
   before do
     # completely nuke any initialized hubs

--- a/sentry-ruby/spec/isolated/init_spec.rb
+++ b/sentry-ruby/spec/isolated/init_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../spec_helper"
-
 # isolated tests need a SimpleCov name otherwise they will overwrite coverage
 SimpleCov.command_name "RSpecIsolatedInit"
 

--- a/sentry-ruby/spec/isolated/puma_spec.rb
+++ b/sentry-ruby/spec/isolated/puma_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require "puma"
-require_relative "../spec_helper"
+
+# Force-load the patches so that we don't depend on require order
+load Pathname(__FILE__).join("../../../lib/sentry/puma.rb").realpath
 
 # Because puma doesn't have any dependency, if Rack is not installed the entire test won't work
 return if ENV["RACK_VERSION"] == "0"

--- a/sentry-ruby/spec/sentry/background_worker_spec.rb
+++ b/sentry-ruby/spec/sentry/background_worker_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::BackgroundWorker do
   let(:string_io) { StringIO.new }
 

--- a/sentry-ruby/spec/sentry/backpressure_monitor_spec.rb
+++ b/sentry-ruby/spec/sentry/backpressure_monitor_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::BackpressureMonitor do
   let(:string_io) { StringIO.new }
 

--- a/sentry-ruby/spec/sentry/backtrace/lines_spec.rb
+++ b/sentry-ruby/spec/sentry/backtrace/lines_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::Backtrace::Line do
   before do
     perform_basic_setup

--- a/sentry-ruby/spec/sentry/backtrace_spec.rb
+++ b/sentry-ruby/spec/sentry/backtrace_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Backtrace do
   let(:fixture_root) { File.join(Dir.pwd, "spec", "support") }
   let(:fixture_file) { File.join(fixture_root, "stacktrace_test_fixture.rb") }

--- a/sentry-ruby/spec/sentry/baggage_spec.rb
+++ b/sentry-ruby/spec/sentry/baggage_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::Baggage do
   let(:malformed_baggage) { "," }
   let(:third_party_baggage) { "other-vendor-value-1=foo;bar;baz, other-vendor-value-2=foo;bar;" }

--- a/sentry-ruby/spec/sentry/breadcrumb/http_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/http_logger_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require 'contexts/with_request_mock'
 
 RSpec.describe :http_logger do

--- a/sentry-ruby/spec/sentry/breadcrumb/redis_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/redis_logger_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe :redis_logger do
   let(:redis) { Redis.new(host: REDIS_HOST) }
 

--- a/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb/sentry_logger_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe "Sentry::Breadcrumbs::SentryLogger" do
   before do
     perform_basic_setup do |config|

--- a/sentry-ruby/spec/sentry/breadcrumb_buffer_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb_buffer_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::BreadcrumbBuffer do
   before do
     perform_basic_setup

--- a/sentry-ruby/spec/sentry/breadcrumb_spec.rb
+++ b/sentry-ruby/spec/sentry/breadcrumb_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::Breadcrumb do
   let(:stringio) { StringIO.new }
 

--- a/sentry-ruby/spec/sentry/client/event_sending_spec.rb
+++ b/sentry-ruby/spec/sentry/client/event_sending_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Client do
   let(:configuration) do
     Sentry::Configuration.new.tap do |config|

--- a/sentry-ruby/spec/sentry/client_spec.rb
+++ b/sentry-ruby/spec/sentry/client_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 class ExceptionWithContext < StandardError
   def sentry_context
     {

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Configuration do
   describe "#capture_exception_frame_locals" do
     it "passes/received the value to #include_local_variables" do

--- a/sentry-ruby/spec/sentry/cron/monitor_check_ins_spec.rb
+++ b/sentry-ruby/spec/sentry/cron/monitor_check_ins_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Cron::MonitorCheckIns do
   before { perform_basic_setup }
 

--- a/sentry-ruby/spec/sentry/cron/monitor_config_spec.rb
+++ b/sentry-ruby/spec/sentry/cron/monitor_config_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Cron::MonitorConfig do
   before { perform_basic_setup }
 

--- a/sentry-ruby/spec/sentry/cron/monitor_schedule_spec.rb
+++ b/sentry-ruby/spec/sentry/cron/monitor_schedule_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Cron::MonitorSchedule::Crontab do
   let(:subject) { described_class.new('5 * * * *') }
 

--- a/sentry-ruby/spec/sentry/dsn_spec.rb
+++ b/sentry-ruby/spec/sentry/dsn_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::DSN do
   subject do
     described_class.new(

--- a/sentry-ruby/spec/sentry/envelope/item_spec.rb
+++ b/sentry-ruby/spec/sentry/envelope/item_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::Envelope::Item do
   describe '.data_category' do
     [

--- a/sentry-ruby/spec/sentry/event_spec.rb
+++ b/sentry-ruby/spec/sentry/event_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Event do
   let(:configuration) do
     Sentry::Configuration.new.tap do |config|

--- a/sentry-ruby/spec/sentry/excon_spec.rb
+++ b/sentry-ruby/spec/sentry/excon_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "contexts/with_request_mock"
 require "excon"
 

--- a/sentry-ruby/spec/sentry/graphql_spec.rb
+++ b/sentry-ruby/spec/sentry/graphql_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 with_graphql = begin
                  require 'graphql'
                  true

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Hub do
   let(:string_io) { StringIO.new }
   let(:logger) do
@@ -259,7 +257,6 @@ RSpec.describe Sentry::Hub do
             exception
           end
         end
-
 
       it "raises error when passing a non-exception object" do
         expect do

--- a/sentry-ruby/spec/sentry/integrable_spec.rb
+++ b/sentry-ruby/spec/sentry/integrable_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "sentry/integrable"
 
 RSpec.describe Sentry::Integrable do

--- a/sentry-ruby/spec/sentry/interface_spec.rb
+++ b/sentry-ruby/spec/sentry/interface_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
 require 'sentry/interface'
 
 class TestInterface < Sentry::Interface

--- a/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/request_interface_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 return unless defined?(Rack)
 
 RSpec.describe Sentry::RequestInterface do

--- a/sentry-ruby/spec/sentry/interfaces/stacktrace_builder_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/stacktrace_builder_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::StacktraceBuilder do
   let(:fixture_root) { File.join(Dir.pwd, "spec", "support") }
   let(:fixture_file) { File.join(fixture_root, "stacktrace_test_fixture.rb") }

--- a/sentry-ruby/spec/sentry/interfaces/stacktrace_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/stacktrace_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::StacktraceInterface::Frame do
   describe "#initialize" do
     let(:configuration) { Sentry::Configuration.new }

--- a/sentry-ruby/spec/sentry/linecache_spec.rb
+++ b/sentry-ruby/spec/sentry/linecache_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
 # rubocop:disable Style/WordArray
 RSpec.describe Sentry::LineCache do
   describe "#get_file_context" do

--- a/sentry-ruby/spec/sentry/log_event_buffer_spec.rb
+++ b/sentry-ruby/spec/sentry/log_event_buffer_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::LogEventBuffer do
   subject(:log_event_buffer) { described_class.new(Sentry.configuration, client) }
 

--- a/sentry-ruby/spec/sentry/log_event_spec.rb
+++ b/sentry-ruby/spec/sentry/log_event_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::LogEvent do
   let(:configuration) do
     Sentry::Configuration.new.tap do |config|

--- a/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/aggregator_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Metrics::Aggregator do
   let(:string_io) { StringIO.new }
 

--- a/sentry-ruby/spec/sentry/metrics/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/configuration_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Metrics::Configuration do
   describe '#before_emit=' do
     it 'raises error when setting before_emit to anything other than callable or nil' do

--- a/sentry-ruby/spec/sentry/metrics/counter_metric_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/counter_metric_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Metrics::CounterMetric do
   subject { described_class.new(1) }
   before { subject.add(2) }

--- a/sentry-ruby/spec/sentry/metrics/distribution_metric_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/distribution_metric_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Metrics::DistributionMetric do
   subject { described_class.new(1) }
   before { subject.add(2) }

--- a/sentry-ruby/spec/sentry/metrics/gauge_metric_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/gauge_metric_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Metrics::GaugeMetric do
   subject { described_class.new(0) }
   before { 9.times { |i| subject.add(i + 1) } }

--- a/sentry-ruby/spec/sentry/metrics/local_aggregator_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/local_aggregator_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Metrics::LocalAggregator do
   let(:tags) { [['foo', 1], ['foo', 2], ['bar', 'baz']] }
   let(:key) { [:c, 'incr', 'second', tags] }

--- a/sentry-ruby/spec/sentry/metrics/metric_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/metric_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Metrics::Metric do
   describe '#add' do
     it 'raises not implemented error' do

--- a/sentry-ruby/spec/sentry/metrics/set_metric_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/set_metric_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Metrics::SetMetric do
   subject { described_class.new('foo') }
 

--- a/sentry-ruby/spec/sentry/metrics/timing_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics/timing_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Metrics::Timing do
   let(:fake_time) { Time.new(2024, 1, 2, 3, 4, 5) }
   before { allow(Time).to receive(:now).and_return(fake_time) }

--- a/sentry-ruby/spec/sentry/metrics_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Metrics do
   before do
     perform_basic_setup do |config|

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require 'contexts/with_request_mock'
 
 RSpec.describe Sentry::Net::HTTP do
@@ -112,7 +111,6 @@ RSpec.describe Sentry::Net::HTTP do
 
       transaction = Sentry.start_transaction
       Sentry.get_current_scope.set_span(transaction)
-
 
       response = http.request(request)
 

--- a/sentry-ruby/spec/sentry/profiler_spec.rb
+++ b/sentry-ruby/spec/sentry/profiler_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::Profiler, when: :stack_prof_installed? do
   before do
     perform_basic_setup do |config|

--- a/sentry-ruby/spec/sentry/propagation_context_spec.rb
+++ b/sentry-ruby/spec/sentry/propagation_context_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::PropagationContext do
   before do
     perform_basic_setup

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
 require 'sentry/vernier/profiler'
 
 RSpec.describe 'Sentry::Rack::CaptureExceptions', when: :rack_available? do
@@ -526,7 +525,6 @@ RSpec.describe 'Sentry::Rack::CaptureExceptions', when: :rack_available? do
         transaction = last_sentry_event
         expect(event.contexts.dig(:trace, :trace_id).length).to eq(32)
         expect(event.contexts.dig(:trace, :trace_id)).to eq(transaction.contexts.dig(:trace, :trace_id))
-
 
         expect(transaction.type).to eq("transaction")
         expect(transaction.timestamp).not_to be_nil

--- a/sentry-ruby/spec/sentry/rake_spec.rb
+++ b/sentry-ruby/spec/sentry/rake_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe "rake auto-reporting" do
   it "sends a report to Sentry" do
     message = ""

--- a/sentry-ruby/spec/sentry/redis_spec.rb
+++ b/sentry-ruby/spec/sentry/redis_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::Redis do
   let(:redis) { Redis.new(host: REDIS_HOST) }
 

--- a/sentry-ruby/spec/sentry/rspec/matchers_spec.rb
+++ b/sentry-ruby/spec/sentry/rspec/matchers_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "sentry/rspec"
 
 RSpec.describe "Sentry RSpec Matchers" do

--- a/sentry-ruby/spec/sentry/scope/setters_spec.rb
+++ b/sentry-ruby/spec/sentry/scope/setters_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::Scope do
   let(:new_breadcrumb) do
     new_breadcrumb = Sentry::Breadcrumb.new

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::Scope do
   let(:new_breadcrumb) do
     new_breadcrumb = Sentry::Breadcrumb.new

--- a/sentry-ruby/spec/sentry/session_flusher_spec.rb
+++ b/sentry-ruby/spec/sentry/session_flusher_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::SessionFlusher do
   let(:string_io) { StringIO.new }
 

--- a/sentry-ruby/spec/sentry/span_spec.rb
+++ b/sentry-ruby/spec/sentry/span_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::Span do
   let(:hub) do
     client = Sentry::Client.new(Sentry::Configuration.new)

--- a/sentry-ruby/spec/sentry/structured_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/structured_logger_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::StructuredLogger do
   context "when enable_logs is set to false" do
     before do

--- a/sentry-ruby/spec/sentry/test_helper_spec.rb
+++ b/sentry-ruby/spec/sentry/test_helper_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::TestHelper do
   include described_class
 

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::Transaction do
   before do
     perform_basic_setup

--- a/sentry-ruby/spec/sentry/transactions/profiler_spec.rb
+++ b/sentry-ruby/spec/sentry/transactions/profiler_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require 'contexts/with_request_mock'
 
 RSpec.describe Sentry, 'transactions / profiler', when: [:vernier_installed?, :rack_available?] do

--- a/sentry-ruby/spec/sentry/transport/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/configuration_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::Transport::Configuration do
   describe "#transport_class=" do
     it "doesn't accept non-class argument" do

--- a/sentry-ruby/spec/sentry/transport/http_transport_rate_limiting_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_rate_limiting_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
 require 'contexts/with_request_mock'
 
 RSpec.describe "rate limiting" do

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
 require 'contexts/with_request_mock'
 
 RSpec.describe Sentry::HTTPTransport do

--- a/sentry-ruby/spec/sentry/transport/spotlight_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/spotlight_transport_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::SpotlightTransport do
   let(:configuration) do
     Sentry::Configuration.new.tap do |config|

--- a/sentry-ruby/spec/sentry/transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Transport do
   let(:io) { StringIO.new }
   let(:logger) { Logger.new(io) }

--- a/sentry-ruby/spec/sentry/utils/real_ip_spec.rb
+++ b/sentry-ruby/spec/sentry/utils/real_ip_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Sentry::Utils::RealIp do
   context "when no ip addresses are provided other than REMOTE_ADDR" do
     subject { Sentry::Utils::RealIp.new(remote_addr: "1.1.1.1") }

--- a/sentry-ruby/spec/sentry/utils/request_id_spec.rb
+++ b/sentry-ruby/spec/sentry/utils/request_id_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Sentry::Utils::RequestId do
   describe ".read_from" do
     subject { Sentry::Utils::RequestId.read_from(env_hash) }

--- a/sentry-ruby/spec/sentry/vernier/profiler_spec.rb
+++ b/sentry-ruby/spec/sentry/vernier/profiler_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 require "sentry/vernier/profiler"
 
 RSpec.describe Sentry::Vernier::Profiler, when: { ruby_version?: [:>=, "3.3"] } do
@@ -151,7 +149,6 @@ RSpec.describe Sentry::Vernier::Profiler, when: { ruby_version?: [:>=, "3.3"] } 
 
   describe "#to_hash" do
     let (:transport) { Sentry.get_current_client.transport }
-
 
     it "records lost event if not sampled" do
       expect(transport).to receive(:record_lost_event).with(:sample_rate, "profile")

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require 'contexts/with_request_mock'
 
 RSpec.describe Sentry do


### PR DESCRIPTION
This makes our spec suite better but I'm doing this because our tests started to fail recently with Excon adapter from webmock trying to mutate an array that is defined in Excon. This led me to discovering that load order of spec_helper is significant and we want to load it as soon as possible to get more consistent environment setup.

So this PR:

- Adds `--require spec_helper` to `.rspec`
- Removes all manual requires of `spec_helper` from sentry-ruby spec suite
- Tweaks puma spec so that it force-loads its patches so that we don't care that sentry-ruby was already required by spec helper (a nice discovery)
- Tweaks Rakefile to define `isolated_specs` task as a regular `RSpec::Core::Task` which is another small win here
- Consolidates RSpec opts in `.rspec` so that we have the same settings when running isolated and regular specs

Not strictly needed but:

- Changed rspec format to `progress` because it's faster, and you can see various warnings

#skip-changelog