### PR TITLE
Optimize LogEvent to reduce memory consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Support for `before_send_log` ([#2634](https://github.com/getsentry/sentry-ruby/pull/2634))
 
+### Bug Fixes
+
+- Structured logging consumes way less memory now ([#2643](https://github.com/getsentry/sentry-ruby/pull/2643))
+
 ## 5.24.0
 
 ### Features

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -195,12 +195,7 @@ module Sentry
 
       attributes = options.reject { |k, _| k == :level || k == :severity }
 
-      LogEvent.new(
-        level: level,
-        body: message,
-        timestamp: Time.now.to_f,
-        attributes: attributes
-      )
+      LogEvent.new(level: level, body: message, attributes: attributes)
     end
 
     # Initializes an Event object with the given Transaction object.

--- a/sentry-ruby/lib/sentry/log_event.rb
+++ b/sentry-ruby/lib/sentry/log_event.rb
@@ -9,7 +9,6 @@ module Sentry
 
     DEFAULT_PARAMETERS = [].freeze
     DEFAULT_ATTRIBUTES = {}.freeze
-    DEFAULT_CONTEXT = {}.freeze
 
     SERIALIZEABLE_ATTRIBUTES = %i[
       level

--- a/sentry-ruby/lib/sentry/log_event.rb
+++ b/sentry-ruby/lib/sentry/log_event.rb
@@ -39,6 +39,17 @@ module Sentry
 
     attr_reader :configuration, *SERIALIZEABLE_ATTRIBUTES
 
+    SERIALIZERS = %i[
+      attributes
+      body
+      level
+      parent_span_id
+      sdk_name
+      sdk_version
+      timestamp
+      trace_id
+    ].map { |name| [name, :"serialize_#{name}"] }.to_h
+
     def initialize(configuration: Sentry.configuration, **options)
       @configuration = configuration
       @type = TYPE
@@ -62,9 +73,9 @@ module Sentry
     private
 
     def serialize(name)
-      serializer = :"serialize_#{name}"
+      serializer = SERIALIZERS[name]
 
-      if respond_to?(serializer, true)
+      if serializer
         __send__(serializer)
       else
         public_send(name)

--- a/sentry-ruby/lib/sentry/log_event.rb
+++ b/sentry-ruby/lib/sentry/log_event.rb
@@ -50,6 +50,13 @@ module Sentry
       trace_id
     ].map { |name| [name, :"serialize_#{name}"] }.to_h
 
+    VALUE_TYPES = Hash.new("string").merge!({
+      TrueClass => "boolean",
+      FalseClass => "boolean",
+      Integer => "integer",
+      Float => "double"
+    }).freeze
+
     def initialize(configuration: Sentry.configuration, **options)
       @configuration = configuration
       @type = TYPE
@@ -135,13 +142,6 @@ module Sentry
     def attribute_hash(value)
       { value: value, type: value_type(value) }
     end
-
-    VALUE_TYPES = Hash.new("string").merge!({
-      Integer => "integer",
-      TrueClass => "boolean",
-      FalseClass => "boolean",
-      Float => "double"
-    }).freeze
 
     def value_type(value)
       VALUE_TYPES[value.class]

--- a/sentry-ruby/lib/sentry/log_event.rb
+++ b/sentry-ruby/lib/sentry/log_event.rb
@@ -117,8 +117,10 @@ module Sentry
     end
 
     def serialize_attributes
-      hash = attributes.each_with_object({}) do |(key, value), memo|
-        memo[key] = attribute_hash(value)
+      hash = {}
+
+      attributes.each do |key, value|
+        hash[key] = attribute_hash(value)
       end
 
       SENTRY_ATTRIBUTES.each do |key, name|

--- a/sentry-ruby/lib/sentry/log_event.rb
+++ b/sentry-ruby/lib/sentry/log_event.rb
@@ -123,17 +123,15 @@ module Sentry
       { value: value, type: value_type(value) }
     end
 
+    VALUE_TYPES = Hash.new("string").merge!({
+      Integer => "integer",
+      TrueClass => "boolean",
+      FalseClass => "boolean",
+      Float => "double"
+    }).freeze
+
     def value_type(value)
-      case value
-      when Integer
-        "integer"
-      when TrueClass, FalseClass
-        "boolean"
-      when Float
-        "double"
-      else
-        "string"
-      end
+      VALUE_TYPES[value.class]
     end
 
     def parameters

--- a/sentry-ruby/lib/sentry/log_event.rb
+++ b/sentry-ruby/lib/sentry/log_event.rb
@@ -57,6 +57,8 @@ module Sentry
       Float => "double"
     }).freeze
 
+    TOKEN_REGEXP = /%\{(\w+)\}/
+
     def initialize(configuration: Sentry.configuration, **options)
       @configuration = configuration
       @type = TYPE
@@ -165,8 +167,6 @@ module Sentry
         end
       end
     end
-
-    TOKEN_REGEXP = /%\{(\w+)\}/
 
     def template_tokens
       @template_tokens ||= body.scan(TOKEN_REGEXP).flatten.map(&:to_sym)

--- a/sentry-ruby/lib/sentry/log_event.rb
+++ b/sentry-ruby/lib/sentry/log_event.rb
@@ -4,7 +4,7 @@ module Sentry
   # Event type that represents a log entry with its attributes
   #
   # @see https://develop.sentry.dev/sdk/telemetry/logs/#log-envelope-item-payload
-  class LogEvent < Event
+  class LogEvent
     TYPE = "log"
 
     DEFAULT_PARAMETERS = [].freeze
@@ -15,8 +15,12 @@ module Sentry
       level
       body
       timestamp
+      environment
+      release
+      server_name
       trace_id
       attributes
+      contexts
     ]
 
     SENTRY_ATTRIBUTES = {
@@ -33,15 +37,20 @@ module Sentry
 
     attr_accessor :level, :body, :template, :attributes
 
-    def initialize(configuration: Sentry.configuration, **options)
-      super(configuration: configuration)
+    attr_reader :configuration, *SERIALIZEABLE_ATTRIBUTES
 
+    def initialize(configuration: Sentry.configuration, **options)
+      @configuration = configuration
       @type = TYPE
+      @server_name = configuration.server_name
+      @environment = configuration.environment
+      @release = configuration.release
+      @timestamp = Sentry.utc_now.iso8601
       @level = options.fetch(:level)
       @body = options[:body]
       @template = @body if is_template?
       @attributes = options[:attributes] || DEFAULT_ATTRIBUTES
-      @contexts = DEFAULT_CONTEXT
+      @contexts = {}
     end
 
     def to_hash

--- a/sentry-ruby/lib/sentry/log_event.rb
+++ b/sentry-ruby/lib/sentry/log_event.rb
@@ -56,7 +56,7 @@ module Sentry
       @server_name = configuration.server_name
       @environment = configuration.environment
       @release = configuration.release
-      @timestamp = Sentry.utc_now.iso8601
+      @timestamp = Sentry.utc_now
       @level = options.fetch(:level)
       @body = options[:body]
       @template = @body if is_template?
@@ -95,7 +95,7 @@ module Sentry
     end
 
     def serialize_timestamp
-      Time.parse(timestamp).to_f
+      timestamp.to_f
     end
 
     def serialize_trace_id


### PR DESCRIPTION
## Current status

```
Git SHA      Branch     Iter     Allocated    Retained     Alloc Mem    Ret Mem     
------------------------------------------------------------------------------------------
213558f3     master     100,000  9,681,713    1,395,346    921.32 MB    217.9 MB    
cafd4cdc     2641-incre 100,000  2,920,177    1,598,060    445.48 MB    285.83 MB   

=== Performance Trends ===

Comparing latest (cafd4cdc) vs baseline (213558f3):

Object Allocation: 📉 -69.84% (decrease)
Object Retention: 📈 +14.53% (increase)
Memory Usage: 📉 -51.65% (decrease)

Memory per iteration:
  Baseline: 9.43 KB
  Latest:   4.56 KB
  Change:   📉 -51.65% (decrease)

=== Recent Commits ===

213558f3 (2025-06-09 12:15)
  [sentry-ruby] fix and improve spec suite setup (#2640)
  Memory: 921.32 MB allocated, 217.9 MB retained

cafd4cdc (2025-06-09 12:15)
  Update CHANGELOG
  Memory: 445.48 MB allocated, 285.83 MB retained
```

Closes #2641