### PR TITLE
[devcontainer] switch to /workspace/sentry

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "sentry-ruby",
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
-  "workspaceFolder": "/workspace/sentry-ruby",
+  "workspaceFolder": "/workspace/sentry",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         IMAGE: ${IMAGE}
         TAG: ${TAG}
     volumes:
-      - ..:/workspace/sentry-ruby:cached
+      - ..:/workspace/sentry:cached
     command: sleep infinity
     environment:
       - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}

--- a/sentry-ruby/spec/sentry/profiler_spec.rb
+++ b/sentry-ruby/spec/sentry/profiler_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe Sentry::Profiler, when: :stack_prof_installed? do
         expect(foo_frame[:in_app]).to eq(true)
         expect(foo_frame[:lineno]).to eq(7)
         expect(foo_frame[:filename]).to eq('spec/sentry/profiler_spec.rb')
-        expect(foo_frame[:abs_path]).to include('sentry-ruby/sentry-ruby/spec/sentry/profiler_spec.rb')
+        expect(foo_frame[:abs_path]).to include('sentry-ruby/spec/sentry/profiler_spec.rb')
 
         bar_frame = frames.find { |f| f[:function] =~ /bar/ }
         expect(bar_frame[:function]).to eq('Bar.bar')
@@ -247,7 +247,7 @@ RSpec.describe Sentry::Profiler, when: :stack_prof_installed? do
         expect(bar_frame[:in_app]).to eq(true)
         expect(bar_frame[:lineno]).to eq(12)
         expect(bar_frame[:filename]).to eq('spec/sentry/profiler_spec.rb')
-        expect(bar_frame[:abs_path]).to include('sentry-ruby/sentry-ruby/spec/sentry/profiler_spec.rb')
+        expect(bar_frame[:abs_path]).to include('sentry-ruby/spec/sentry/profiler_spec.rb')
 
         sleep_frame = frames.find { |f| f[:function] =~ /sleep/ }
         expect(sleep_frame[:function]).to eq('Kernel#sleep')

--- a/sentry-ruby/spec/sentry/vernier/profiler_spec.rb
+++ b/sentry-ruby/spec/sentry/vernier/profiler_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe Sentry::Vernier::Profiler, when: { ruby_version?: [:>=, "3.3"] } 
           expect(foo_frame[:in_app]).to eq(true)
           expect(foo_frame[:lineno]).to eq(6)
           expect(foo_frame[:filename]).to eq('spec/support/profiler.rb')
-          expect(foo_frame[:abs_path]).to include('sentry-ruby/sentry-ruby/spec/support/profiler.rb')
+          expect(foo_frame[:abs_path]).to include('sentry-ruby/spec/support/profiler.rb')
         end
 
         it 'has correct stacks' do
@@ -274,7 +274,7 @@ RSpec.describe Sentry::Vernier::Profiler, when: { ruby_version?: [:>=, "3.3"] } 
           expect(foo_frame[:in_app]).to eq(true)
           expect(foo_frame[:lineno]).to eq(6)
           expect(foo_frame[:filename]).to eq('spec/support/profiler.rb')
-          expect(foo_frame[:abs_path]).to include('sentry-ruby/sentry-ruby/spec/support/profiler.rb')
+          expect(foo_frame[:abs_path]).to include('sentry-ruby/spec/support/profiler.rb')
         end
 
         it 'has correct stacks', when: { ruby_version?: [:>=, "3.3"] } do


### PR DESCRIPTION
This is less confusing otherwise we had:

   /workspace/sentry-ruby/sentry-ruby

Which looked bad and was a bit harder to work with.

#skip-changelog
