### PR TITLE
Include span status in HTTP client spans based on the response's status

### DIFF
--- a/sentry-ruby/lib/sentry/utils/http_tracing.rb
+++ b/sentry-ruby/lib/sentry/utils/http_tracing.rb
@@ -8,7 +8,7 @@ module Sentry
         sentry_span.set_data(Span::DataConventions::URL, request_info[:url])
         sentry_span.set_data(Span::DataConventions::HTTP_METHOD, request_info[:method])
         sentry_span.set_data(Span::DataConventions::HTTP_QUERY, request_info[:query]) if request_info[:query]
-        sentry_span.set_data(Span::DataConventions::HTTP_STATUS_CODE, response_status)
+        sentry_span.set_http_status(response_status)
       end
 
       def set_propagation_headers(req)

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Sentry::Net::HTTP do
         expect(request_span.data).to eq(
           { "url" => "http://[::1]/path", "http.request.method" => "GET", "http.response.status_code" => 200 }
         )
+        expect(request_span.status).to eq("ok")
       end
     end
 
@@ -68,6 +69,7 @@ RSpec.describe Sentry::Net::HTTP do
           "http.request.method" => "GET",
           "http.query" => "foo=bar"
         })
+        expect(request_span.status).to eq("ok")
       end
     end
 
@@ -99,6 +101,7 @@ RSpec.describe Sentry::Net::HTTP do
           "url" => "http://example.com/path",
           "http.request.method" => "GET"
         })
+        expect(request_span.status).to eq("ok")
       end
     end
 
@@ -342,6 +345,7 @@ RSpec.describe Sentry::Net::HTTP do
           "url" => "http://example.com/path",
           "http.request.method" => "GET"
         })
+        expect(request_span.status).to eq("ok")
 
         request_span = transaction.span_recorder.spans[2]
         expect(request_span.op).to eq("http.client")
@@ -355,6 +359,7 @@ RSpec.describe Sentry::Net::HTTP do
           "url" => "http://example.com/path",
           "http.request.method" => "GET"
         })
+        expect(request_span.status).to eq("not_found")
       end
 
       it "doesn't mess different requests' data together" do


### PR DESCRIPTION
This change updates `Utils::HttpTracing` so that it uses `set_http_status` so that the spans include the status. Without this change, graphs such as `failure_rate()` for spans for HTTP requests, for example, with the `:faraday` patch. Other usages within sentry-ruby look to already be correct.