### PR TITLE
Map `trilogy` database adapter to `mysql` for Query Insights compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Skip creating `LogEventBuffer` if logging is not enabled ([#2652](https://github.com/getsentry/sentry-ruby/pull/2652))
+- Map `trilogy` database adapter to `mysql` for Query Insights compatibility ([#2656](https://github.com/getsentry/sentry-ruby/pull/2656))
 
 ## 5.25.0
 

--- a/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/tracing/active_record_subscriber.rb
@@ -56,7 +56,10 @@ module Sentry
 
                 next unless db_config
 
-                span.set_data(Span::DataConventions::DB_SYSTEM, db_config[:adapter]) if db_config[:adapter]
+                adapter = db_config[:adapter]
+                adapter = "mysql" if adapter == "trilogy"
+
+                span.set_data(Span::DataConventions::DB_SYSTEM, adapter) if adapter
                 span.set_data(Span::DataConventions::DB_NAME, db_config[:database]) if db_config[:database]
                 span.set_data(Span::DataConventions::SERVER_ADDRESS, db_config[:host]) if db_config[:host]
                 span.set_data(Span::DataConventions::SERVER_PORT, db_config[:port]) if db_config[:port]


### PR DESCRIPTION
## Description

When using `trilogy` adapter in Rails app, Query Insights view in Sentry did not show any data.

The problem is that `trilogy` is not in the allowed system db name list:
https://github.com/getsentry/semantic-conventions/blob/main/docs/attributes-registry/db.md
despite being just a different MySQL adapter, and hence does not meet the criteria for span eligibility:
https://docs.sentry.io/product/insights/backend/queries/#span-eligibility

The simple fix is to just map `trilogy` to `mysql` for the db system name.

## Current Behavior
No query data is displayed because `trilogy` is not recognized as a valid database system.

## Expected Behavior
Query data from `trilogy` adapter should appear in Sentry's Query Insights view, similar to other MySQL adapters.

## Alternative solution (how I tested it worked)

The same result can be achieved using `before_send_transaction`:

```ruby
# Workaround: Map trilogy spans to mysql for Sentry compatibility
config.before_send_transaction = lambda do |event, _hint|
  event.spans.select { |span| span[:op].start_with?("db.") }.each do |span|
    span[:data]["db.system"] = "mysql" if span[:data]&.fetch("db.system", nil) == "trilogy"
  end
end
```