### PR TITLE
Fix flaky net/http spec

### DIFF
--- a/sentry-ruby/spec/contexts/with_request_mock.rb
+++ b/sentry-ruby/spec/contexts/with_request_mock.rb
@@ -36,4 +36,14 @@ RSpec.shared_context "with request mock" do
   def stub_normal_response(code: "200", &block)
     sentry_stub_request(build_fake_response(code), &block)
   end
+
+  def stub_response(http, code: "200", &block)
+    fake_response = build_fake_response(code)
+
+    allow(http).to receive(:connect)
+
+    allow(http).to receive(:transport_request) do |http_obj, request|
+      block.call(request, http_obj) if block
+    end.and_return(fake_response)
+  end
 end

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -370,13 +370,15 @@ RSpec.describe Sentry::Net::HTTP do
       end
 
       it "doesn't mess different requests' data together when making multiple requests with Net::HTTP.start" do
+        allow_any_instance_of(Net::HTTP).to receive(:connect)
+
         Net::HTTP.start("example.com") do |http|
-          stub_normal_response(code: "200")
+          stub_response(http, code: "200")
           request = Net::HTTP::Get.new("/path?foo=bar")
           response = http.request(request)
           expect(response.code).to eq("200")
 
-          stub_normal_response(code: "404")
+          stub_response(http, code: "404")
           request = Net::HTTP::Get.new("/path?foo=bar")
           response = http.request(request)
           expect(response.code).to eq("404")


### PR DESCRIPTION
Fixes this:

```
  1) Sentry::Net::HTTP with tracing enabled when there're multiple requests doesn't mess different requests' data together when making multiple requests with Net::HTTP.start
     Failure/Error:
               Net::HTTP.start("example.com") do |http|
                 stub_normal_response(code: "200")
                 request = Net::HTTP::Get.new("/path?foo=bar")
                 response = http.request(request)
                 expect(response.code).to eq("200")
       
                 stub_normal_response(code: "404")
                 request = Net::HTTP::Get.new("/path?foo=bar")
                 response = http.request(request)
                 expect(response.code).to eq("404")

     Net::OpenTimeout:
       Failed to open TCP connection to example.com:80 (execution expired)
```

#skip-changelog