### PR TITLE
Remove redundant `attr_reader` pragmas

### DIFF
--- a/sentry-ruby/lib/sentry/log_event.rb
+++ b/sentry-ruby/lib/sentry/log_event.rb
@@ -42,7 +42,7 @@ module Sentry
 
     attr_accessor :level, :body, :template, :attributes, :user
 
-    attr_reader :configuration, *SERIALIZEABLE_ATTRIBUTES
+    attr_reader :configuration, *(SERIALIZEABLE_ATTRIBUTES - %i[level body attributes])
 
     SERIALIZERS = %i[
       attributes


### PR DESCRIPTION
These are leading to noisy warnings:

```shell
sentry-ruby-5.26.0/lib/sentry/log_event.rb:45: warning: method redefined; discarding old level
sentry-ruby-5.26.0/lib/sentry/log_event.rb:45: warning: method redefined; discarding old body
sentry-ruby-5.26.0/lib/sentry/log_event.rb:45: warning: method redefined; discarding old attributes
```

#skip-changelog