### PR TITLE
Make devcontainer work with ancient Ruby/Rails

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libffi-dev \
   libgdbm-dev \
   sqlite3 \
+  libsqlite3-dev \
   nodejs \
   npm \
   chromium \

--- a/.devcontainer/run
+++ b/.devcontainer/run
@@ -7,8 +7,8 @@ cd /workspace/sentry
 sudo mkdir -p vendor/gems
 sudo chown -R sentry:sentry vendor/gems
 
-git config --global --add safe.directory /workspace/sentry
-git config --global --add safe.directory /workspace/sentry/vendor/gems/*
+git config --global safe.directory /workspace/sentry
+git config --global safe.directory /workspace/sentry/vendor/gems/*
 
 sudo chown -R sentry:sentry .
 

--- a/.devcontainer/setup
+++ b/.devcontainer/setup
@@ -35,6 +35,7 @@ class SetupScript
 
     if should_run_bundle?
       cleanup_ruby_lsp_directories
+      update_rubygems_and_bundler
       install_bundle_dependencies
       install_foreman_gem if @options[:with_foreman]
     end
@@ -121,7 +122,8 @@ class SetupScript
       if Dir.exist?(folder_path) && File.exist?(gemfile_path)
         Dir.chdir(folder_path) do
           puts "   Installing dependencies for #{folder_path}..."
-          unless system('bundle install')
+
+          unless system("[ -f Gemfile.lock ] && rm Gemfile.lock; bundle install")
             puts "❌ Bundle install failed for #{folder}"
             exit 1
           end
@@ -130,6 +132,28 @@ class SetupScript
         Dir.chdir(@workspace_root)
       else
         puts "  Skipping #{folder} (no Gemfile found or directory doesn't exist)"
+      end
+    end
+  end
+
+  def update_rubygems_and_bundler
+    puts "📦 Updating RubyGems and Bundler..."
+
+    if RUBY_VERSION >= "3.0"
+      unless system("sudo gem update --system --silent")
+        puts "❌ RubyGems update failed"
+        exit 1
+      end
+    else
+      unless system("sudo gem update --silent --system 3.4.22")
+        puts "❌ RubyGems update failed"
+        exit 1
+      end
+
+      # sentry-sidekiq does not bundle with Bundler 2.5.x that ships with RubyGems 3.4.22
+      unless system("sudo gem install bundler -v 2.4.22")
+        puts "❌ Bundler installation failed"
+        exit 1
       end
     end
   end

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -16,8 +16,18 @@ end
 
 ruby_version = Gem::Version.new(RUBY_VERSION)
 
-rails_version = ENV["RAILS_VERSION"]
-rails_version = "8.0.0" if rails_version.nil?
+rails_version = ENV.fetch("RAILS_VERSION") do
+  if ruby_version >= Gem::Version.new("3.2")
+    "8.0"
+  elsif ruby_version >= Gem::Version.new("3.1")
+    "7.2"
+  elsif ruby_version >= Gem::Version.new("2.7")
+    "7.1"
+  elsif ruby_version >= Gem::Version.new("2.4")
+    "5.2"
+  end
+end
+
 rails_version = Gem::Version.new(rails_version)
 
 gem "rails", "~> #{rails_version}"

--- a/spec/apps/rails-mini/Gemfile
+++ b/spec/apps/rails-mini/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gem "rake"
 gem "puma"
-gem 'railties', '~> 8.0'
-gem 'actionpack', '~> 8.0'
+gem 'railties'
+gem 'actionpack'
 gem 'sentry-ruby', path: Pathname(__dir__).join("../../..").realpath
 gem 'sentry-rails', path: Pathname(__dir__).join("../../..").realpath


### PR DESCRIPTION
oooof that was a chore 🙂

I had to debug and fix structured logging issues for #2676 under 2.7 + Rails 5.1 and it turned out devcontainer did not manage to bundle anything due to conflicts with rubygem/bundle versions and various deps that we use in development/testing.

I tried to change as little as possible just to make it bundle. It works now, I promise 🙃

One thing that would be nice to do in the future is creating separate locks for ruby/rails combinations, because dep resolution on older rubies/bundlers not only takes time, but sometimes it can literally get stuck for whatever reason 🙈

#skip-changelog
