### PR TITLE
Silence `_perform` method redefinition warning

### DIFF
--- a/sentry-rails/lib/sentry/rails/background_worker.rb
+++ b/sentry-rails/lib/sentry/rails/background_worker.rb
@@ -2,14 +2,18 @@
 
 module Sentry
   class BackgroundWorker
-    def _perform(&block)
-      block.call
-    ensure
-      # some applications have partial or even no AR connection
-      if ActiveRecord::Base.connected?
-        # make sure the background worker returns AR connection if it accidentally acquire one during serialization
-        ActiveRecord::Base.connection_pool.release_connection
+    module ActiveRecordConnectionPatch
+      def _perform(&block)
+        super(&block)
+      ensure
+        # some applications have partial or even no AR connection
+        if ActiveRecord::Base.connected?
+          # make sure the background worker returns AR connection if it accidentally acquire one during serialization
+          ActiveRecord::Base.connection_pool.release_connection
+        end
       end
     end
   end
 end
+
+Sentry::BackgroundWorker.prepend(Sentry::BackgroundWorker::ActiveRecordConnectionPatch)


### PR DESCRIPTION
I'd like to get rid of this noisy warning:

```
gems/sentry-rails-5.26.0/lib/sentry/rails/background_worker.rb:5: warning: method redefined; discarding old _perform
gems/sentry-ruby-5.26.0/lib/sentry/background_worker.rb:74: warning: previous definition of _perform was here
```

#skip-changelog