### PR TITLE
feat: include otel as custom sampling contex

### DIFF
--- a/sentry-opentelemetry/lib/sentry/opentelemetry/span_processor.rb
+++ b/sentry-opentelemetry/lib/sentry/opentelemetry/span_processor.rb
@@ -48,7 +48,16 @@ module Sentry
             parent_sampled: trace_data.parent_sampled,
             baggage: trace_data.baggage,
             start_timestamp: otel_span.start_timestamp / 1e9,
-            origin: SPAN_ORIGIN
+            origin: SPAN_ORIGIN,
+            custom_sampling_context: {
+              otel: otel_context_hash(otel_span).merge(
+                kind: otel_span.kind,
+                instrumentation_scope: {
+                  name: otel_span.instrumentation_scope.name,
+                  version: otel_span.instrumentation_scope.version
+                }
+              )
+            }
           }
 
           Sentry.start_transaction(**options)

--- a/sentry-opentelemetry/spec/sentry/opentelemetry/span_processor_spec.rb
+++ b/sentry-opentelemetry/spec/sentry/opentelemetry/span_processor_spec.rb
@@ -154,6 +154,20 @@ RSpec.describe Sentry::OpenTelemetry::SpanProcessor do
 
     it 'starts a sentry transaction on otel root span' do
       expect(Sentry).to receive(:start_transaction).and_call_original
+      expect_any_instance_of(Sentry::Transaction).to receive(:set_initial_sample_decision).with(
+        sampling_context: a_hash_including(
+          otel: {
+            attributes: root_span.attributes,
+            resource: root_span.resource.attribute_enumerator.to_h,
+            kind: root_span.kind,
+            instrumentation_scope: {
+              name: root_span.instrumentation_scope.name,
+              version: root_span.instrumentation_scope.version
+            }
+          }
+        )
+      )
+
       subject.on_start(root_span, empty_context)
 
       span_id = root_span.context.hex_span_id


### PR DESCRIPTION
Sentry's OpenTelemetry (OTel) adapter does not do the greatest job in adapting the OTel span to a semantically correct sentry span, nor does it expose the OTel span in the context for sampling decisions. This PR adds a OTel span as an additional custom sampling context so it can be used for sampling decisions. This gives clients more opportunities to use the entire context of the OTel span for sampling decisions, and allows replicating sampling mechanisms as originally suggested by the Sentry team via the "Sampling Function".

https://docs.sentry.io/platforms/ruby/configuration/sampling/#setting-a-sampling-function

Thanks for your Pull Request 🎉 

**Please keep these instructions in mind so we can review it more efficiently:**

- Add the references of all the related issues/PRs in the description
- Whether it's a new feature or a bug fix, make sure they're covered by new test cases
- If this PR contains any refactoring work, please give it its own commit(s)
- Finally, please add an entry to the corresponding changelog


**Other Notes**
- We squash all commits before merging
- We generally review new PRs within a week
- If you have any question, you can ask for feedback in our [discord community](https://discord.gg/Ww9hbqr) first

## Description
Describe your changes:
