### PR TITLE
Update common gem deps

### DIFF
--- a/Gemfile.dev
+++ b/Gemfile.dev
@@ -20,12 +20,30 @@ if RUBY_VERSION >= "3.5"
   gem "cgi"
 end
 
+if RUBY_VERSION >= "3.4"
+  gem "drb"
+  gem "mutex_m"
+  gem "benchmark"
+  gem "base64"
+  gem "ostruct"
+end
+
 # For RSpec
 gem "rspec", "~> 3.0"
 gem "rspec-retry"
+
+# Coverage
 gem "simplecov"
-gem "simplecov-cobertura", "~> 1.4"
-gem "rexml"
+
+# Do not change it without checking that `CI=true COVERAGE=true bundle exec rake` passes
+# in all projects
+if RUBY_VERSION >= "2.5.0"
+  gem "rexml", "3.4.1"
+  gem "simplecov-cobertura", "~> 3.0"
+else
+  gem "rexml", "3.2.5"
+  gem "simplecov-cobertura", "~> 1.4.0"
+end
 
 if ruby_version >= Gem::Version.new("3.4")
   gem "ostruct"

--- a/Gemfile.dev
+++ b/Gemfile.dev
@@ -13,14 +13,13 @@ ruby_version = Gem::Version.new(RUBY_VERSION)
 if ruby_version >= Gem::Version.new("2.7.0")
   gem "debug", github: "ruby/debug", platform: :ruby
   gem "irb"
-  gem "ruby-lsp-rspec" if ruby_version >= Gem::Version.new("3.0.0") && RUBY_PLATFORM != "java"
 end
 
-if RUBY_VERSION >= "3.5"
+if ruby_version >= Gem::Version.new("2.5")
   gem "cgi"
 end
 
-if RUBY_VERSION >= "3.4"
+if ruby_version >= Gem::Version.new("3.4")
   gem "drb"
   gem "mutex_m"
   gem "benchmark"
@@ -28,25 +27,25 @@ if RUBY_VERSION >= "3.4"
   gem "ostruct"
 end
 
-# For RSpec
-gem "rspec", "~> 3.0"
+# RSpec
+gem "rspec"
 gem "rspec-retry"
+
+if ruby_version >= Gem::Version.new("3.0") && RUBY_PLATFORM != "java"
+  gem "ruby-lsp-rspec"
+end
 
 # Coverage
 gem "simplecov"
 
-# Do not change it without checking that `CI=true COVERAGE=true bundle exec rake` passes
-# in all projects
-if RUBY_VERSION >= "2.5.0"
+# Do not change it without checking that `CI=true COVERAGE=true bundle exec rake`
+# passes in all projects
+if ruby_version >= Gem::Version.new("2.5")
   gem "rexml", "3.4.1"
   gem "simplecov-cobertura", "~> 3.0"
 else
   gem "rexml", "3.2.5"
   gem "simplecov-cobertura", "~> 1.4.0"
-end
-
-if ruby_version >= Gem::Version.new("3.4")
-  gem "ostruct"
 end
 
 group :rubocop do

--- a/sentry-rails/Gemfile
+++ b/sentry-rails/Gemfile
@@ -47,6 +47,7 @@ elsif rails_version >= Gem::Version.new("6.1.0")
     gem "sqlite3", "~> 1.6.9", platform: :ruby
   end
 else
+  gem "psych", "~> 3.0.0"
   gem "rspec-rails", "~> 4.0"
   gem "psych", "~> 3.0.0"
 


### PR DESCRIPTION
These updates are needed to be able to run all ruby / rails combinations, otherwise in various cases gems would NOT bundle, build (sqlite), or processing coverage results would crash (rexml).

#skip-changelog