### PR TITLE
Add `config.trace_ignore_status_codes` to control which status codes don't get traced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Gemfile.lock
 .idea
 *.rdb
 .rgignore
+.claude
 
 node_modules
 .vite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@
 - Remove stacktrace trimming ([#2714](https://github.com/getsentry/sentry-ruby/pull/2714))
 - `config.enabled_environments` now defaults to `nil` instead of `[]` for sending to all environments ([#2716](https://github.com/getsentry/sentry-ruby/pull/2716))
 - Remove `:monotonic_active_support_logger` from `config.breadcrumbs_logger` ([#2717](https://github.com/getsentry/sentry-ruby/pull/2717))
+- Requests which have response status codes in the inclusive ranges `[[301, 303], [305, 399], [401, 404]]` will no longer create transactions by default. See `config.trace_ignore_status_codes` below to control what gets traced.
+
+### Features
+
+- Add `config.trace_ignore_status_codes` to control which response codes to ignore for tracing ([#2725](https://github.com/getsentry/sentry-ruby/pull/2725))
+
+  You can pass in an Array of individual status codes or inclusive ranges.
+
+  ```ruby
+  Sentry.init do |config|
+      # ...
+      # will ignore 404, 501, 502, 503
+      config.trace_ignore_status_codes = [404, [501, 503]]
+  end
+  ```
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,19 @@
 - Remove stacktrace trimming ([#2714](https://github.com/getsentry/sentry-ruby/pull/2714))
 - `config.enabled_environments` now defaults to `nil` instead of `[]` for sending to all environments ([#2716](https://github.com/getsentry/sentry-ruby/pull/2716))
 - Remove `:monotonic_active_support_logger` from `config.breadcrumbs_logger` ([#2717](https://github.com/getsentry/sentry-ruby/pull/2717))
-- Requests which have response status codes in the inclusive ranges `[[301, 303], [305, 399], [401, 404]]` will no longer create transactions by default. See `config.trace_ignore_status_codes` below to control what gets traced.
+- Requests which have response status codes in the inclusive ranges `[(301..303), (305..399), (401..404)]` will no longer create transactions by default. See `config.trace_ignore_status_codes` below to control what gets traced.
 
 ### Features
 
 - Add `config.trace_ignore_status_codes` to control which response codes to ignore for tracing ([#2725](https://github.com/getsentry/sentry-ruby/pull/2725))
 
-  You can pass in an Array of individual status codes or inclusive ranges.
+  You can pass in an Array of individual status codes or ranges of status codes.
 
   ```ruby
   Sentry.init do |config|
       # ...
       # will ignore 404, 501, 502, 503
-      config.trace_ignore_status_codes = [404, [501, 503]]
+      config.trace_ignore_status_codes = [404, (501..503)]
   end
   ```
 

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -81,6 +81,7 @@ module Sentry
       @tracing_enabled = hub.configuration.tracing_enabled?
       @traces_sampler = hub.configuration.traces_sampler
       @traces_sample_rate = hub.configuration.traces_sample_rate
+      @trace_ignore_status_codes = hub.configuration.trace_ignore_status_codes
       @sdk_logger = hub.configuration.sdk_logger
       @release = hub.configuration.release
       @environment = hub.configuration.environment
@@ -287,7 +288,15 @@ module Sentry
 
       @hub.stop_profiler!(self)
 
-      if @sampled
+      if @sampled && ignore_status_code?
+        @sampled = false
+
+        status_code = get_http_status_code
+        log_debug("#{MESSAGE_PREFIX} Discarding #{generate_transaction_description} due to ignored HTTP status code: #{status_code}")
+
+        @hub.current_client.transport.record_lost_event(:event_processor, "transaction")
+        @hub.current_client.transport.record_lost_event(:event_processor, "span")
+      elsif @sampled
         event = hub.current_client.event_from_transaction(self)
         hub.capture_event(event)
       else
@@ -369,6 +378,28 @@ module Sentry
 
       items.compact!
       @baggage = Baggage.new(items, mutable: false)
+    end
+
+    def ignore_status_code?
+      return false unless @trace_ignore_status_codes
+
+      status_code = get_http_status_code
+      return false unless status_code
+
+      @trace_ignore_status_codes.any? do |ignored|
+        if ignored.is_a?(Array) && ignored.size == 2
+          # Range format: [start, end]
+          start_code, end_code = ignored
+          status_code >= start_code && status_code <= end_code
+        else
+          # Individual status code
+          status_code == ignored
+        end
+      end
+    end
+
+    def get_http_status_code
+      @data && @data[Span::DataConventions::HTTP_STATUS_CODE]
     end
 
     class SpanRecorder

--- a/sentry-ruby/lib/sentry/transaction.rb
+++ b/sentry-ruby/lib/sentry/transaction.rb
@@ -387,14 +387,7 @@ module Sentry
       return false unless status_code
 
       @trace_ignore_status_codes.any? do |ignored|
-        if ignored.is_a?(Array) && ignored.size == 2
-          # Range format: [start, end]
-          start_code, end_code = ignored
-          status_code >= start_code && status_code <= end_code
-        else
-          # Individual status code
-          status_code == ignored
-        end
+        ignored.is_a?(Range) ? ignored.include?(status_code) : status_code == ignored
       end
     end
 

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -775,7 +775,7 @@ RSpec.describe Sentry::Configuration do
 
   describe "#trace_ignore_status_codes" do
     it "has default values" do
-      expect(subject.trace_ignore_status_codes).to eq([[301, 303], [305, 399], [401, 404]])
+      expect(subject.trace_ignore_status_codes).to eq([(301..303), (305..399), (401..404)])
     end
 
     it "can be configured with individual status codes" do
@@ -784,13 +784,13 @@ RSpec.describe Sentry::Configuration do
     end
 
     it "can be configured with ranges" do
-      subject.trace_ignore_status_codes = [[300, 399], [500, 599]]
-      expect(subject.trace_ignore_status_codes).to eq([[300, 399], [500, 599]])
+      subject.trace_ignore_status_codes = [(300..399), (500..599)]
+      expect(subject.trace_ignore_status_codes).to eq([(300..399), (500..599)])
     end
 
     it "can be configured with mixed individual codes and ranges" do
-      subject.trace_ignore_status_codes = [404, [500, 599]]
-      expect(subject.trace_ignore_status_codes).to eq([404, [500, 599]])
+      subject.trace_ignore_status_codes = [404, (500..599)]
+      expect(subject.trace_ignore_status_codes).to eq([404, (500..599)])
     end
 
     it "raises ArgumentError when not an Array" do
@@ -799,17 +799,17 @@ RSpec.describe Sentry::Configuration do
     end
 
     it "raises ArgumentError for invalid status codes" do
-      expect { subject.trace_ignore_status_codes = [99] }.to raise_error(ArgumentError, /must be an Array of integers \(100-599\)/)
-      expect { subject.trace_ignore_status_codes = [600] }.to raise_error(ArgumentError, /must be an Array of integers \(100-599\)/)
+      expect { subject.trace_ignore_status_codes = [99] }.to raise_error(ArgumentError, /must be.* between \(100-599\)/)
+      expect { subject.trace_ignore_status_codes = [600] }.to raise_error(ArgumentError, /must be.* between \(100-599\)/)
       expect { subject.trace_ignore_status_codes = ["404"] }.to raise_error(ArgumentError, /must be an Array of integers/)
     end
 
     it "raises ArgumentError for invalid ranges" do
-      expect { subject.trace_ignore_status_codes = [[400]] }.to raise_error(ArgumentError, /arrays of two integers/)
-      expect { subject.trace_ignore_status_codes = [[400, 500, 600]] }.to raise_error(ArgumentError, /arrays of two integers/)
-      expect { subject.trace_ignore_status_codes = [[500, 400]] }.to raise_error(ArgumentError, /start <= end/)
-      expect { subject.trace_ignore_status_codes = [[99, 200]] }.to raise_error(ArgumentError, /100-599/)
-      expect { subject.trace_ignore_status_codes = [[400, 600]] }.to raise_error(ArgumentError, /100-599/)
+      expect { subject.trace_ignore_status_codes = [[400]] }.to raise_error(ArgumentError, /must be.* ranges/)
+      expect { subject.trace_ignore_status_codes = [[400, 500, 600]] }.to raise_error(ArgumentError, /must be.* ranges/)
+      expect { subject.trace_ignore_status_codes = [[500, 400]] }.to raise_error(ArgumentError, /must be.* begin <= end/)
+      expect { subject.trace_ignore_status_codes = [[99, 200]] }.to raise_error(ArgumentError, /must be.* between \(100-599\)/)
+      expect { subject.trace_ignore_status_codes = [[400, 600]] }.to raise_error(ArgumentError, /must be.* between \(100-599\)/)
     end
   end
 end

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -772,4 +772,44 @@ RSpec.describe Sentry::Configuration do
       }.to output(/`config.logger=` is deprecated/).to_stderr
     end
   end
+
+  describe "#trace_ignore_status_codes" do
+    it "has default values" do
+      expect(subject.trace_ignore_status_codes).to eq([[301, 303], [305, 399], [401, 404]])
+    end
+
+    it "can be configured with individual status codes" do
+      subject.trace_ignore_status_codes = [404, 500]
+      expect(subject.trace_ignore_status_codes).to eq([404, 500])
+    end
+
+    it "can be configured with ranges" do
+      subject.trace_ignore_status_codes = [[300, 399], [500, 599]]
+      expect(subject.trace_ignore_status_codes).to eq([[300, 399], [500, 599]])
+    end
+
+    it "can be configured with mixed individual codes and ranges" do
+      subject.trace_ignore_status_codes = [404, [500, 599]]
+      expect(subject.trace_ignore_status_codes).to eq([404, [500, 599]])
+    end
+
+    it "raises ArgumentError when not an Array" do
+      expect { subject.trace_ignore_status_codes = 404 }.to raise_error(ArgumentError, /must be an Array/)
+      expect { subject.trace_ignore_status_codes = "404" }.to raise_error(ArgumentError, /must be an Array/)
+    end
+
+    it "raises ArgumentError for invalid status codes" do
+      expect { subject.trace_ignore_status_codes = [99] }.to raise_error(ArgumentError, /must be an Array of integers \(100-599\)/)
+      expect { subject.trace_ignore_status_codes = [600] }.to raise_error(ArgumentError, /must be an Array of integers \(100-599\)/)
+      expect { subject.trace_ignore_status_codes = ["404"] }.to raise_error(ArgumentError, /must be an Array of integers/)
+    end
+
+    it "raises ArgumentError for invalid ranges" do
+      expect { subject.trace_ignore_status_codes = [[400]] }.to raise_error(ArgumentError, /arrays of two integers/)
+      expect { subject.trace_ignore_status_codes = [[400, 500, 600]] }.to raise_error(ArgumentError, /arrays of two integers/)
+      expect { subject.trace_ignore_status_codes = [[500, 400]] }.to raise_error(ArgumentError, /start <= end/)
+      expect { subject.trace_ignore_status_codes = [[99, 200]] }.to raise_error(ArgumentError, /100-599/)
+      expect { subject.trace_ignore_status_codes = [[400, 600]] }.to raise_error(ArgumentError, /100-599/)
+    end
+  end
 end

--- a/sentry-ruby/spec/sentry/transaction_spec.rb
+++ b/sentry-ruby/spec/sentry/transaction_spec.rb
@@ -560,7 +560,7 @@ RSpec.describe Sentry::Transaction do
         perform_basic_setup do |config|
           config.traces_sample_rate = 1.0
           config.sdk_logger = sdk_logger
-          config.trace_ignore_status_codes = [404, [500, 503]]
+          config.trace_ignore_status_codes = [404, (500..503)]
         end
       end
 


### PR DESCRIPTION
### Issues
* resolves: #2693, #2694 
* resolves: RUBY-89, RUBY-90