### PR TITLE
patch

### DIFF
--- a/lib/concurrent_ruby.rb
+++ b/lib/concurrent_ruby.rb
@@ -1,0 +1,58 @@
+require 'sentry-ruby'
+require 'concurrent-ruby'
+
+module Sentry
+  module ConcurrentRuby
+    SENTRY_THREAD_KEY = :sentry_hub
+    SENTRY_SPAN_KEY = :sentry_span
+
+    def self.install
+      patch_futures
+      patch_promises
+    end
+
+
+    def self.patch_futures
+      ::Concurrent::Promises.singleton_class.class_eval do
+        alias_method :original_future, :future
+
+        def future(*args, &block)
+          current_hub = Sentry.get_current_hub
+          current_span = Sentry.get_current_scope.get_span
+          original_future(*args) do    
+            #set the hub and span
+            Thread.current.thread_variable_set(Sentry::ConcurrentRuby::SENTRY_THREAD_KEY, current_hub)
+            Thread.current.thread_variable_set(Sentry::ConcurrentRuby::SENTRY_SPAN_KEY, current_span)
+            Sentry.with_child_span(op: "api.request", description: "Concurrent::Future") do |child_span|
+              Sentry.get_current_scope.set_span(child_span)
+              block.call
+            end
+          end
+        end
+      end
+    end
+
+
+    def self.patch_promises
+      ::Concurrent::Promises::Future.class_eval do
+        alias_method :original_on_resolution, :on_resolution
+
+        def on_resolution(&block)
+          current_hub = Thread.current.thread_variable_get(Sentry::ConcurrentRuby::SENTRY_THREAD_KEY) || Sentry.get_current_hub
+          current_span = Sentry.get_current_scope.get_span
+          original_on_resolution do |*args|
+            Thread.current.thread_variable_set(Sentry::ConcurrentRuby::SENTRY_THREAD_KEY, current_hub)
+            Thread.current.thread_variable_set(Sentry::ConcurrentRuby::SENTRY_SPAN_KEY, current_span)
+            Sentry.with_child_span(op: "api.request", description: "Concurrent::Promise") do |child_span|
+              Sentry.get_current_scope.set_span(child_span)
+              block.call(*args)
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+# Install after Sentry loaded
+Sentry::ConcurrentRuby.install if defined?(Sentry)


### PR DESCRIPTION
Thanks for your Pull Request 🎉 

**Please keep these instructions in mind so we can review it more efficiently:**

- Issue Ref: -
-   - https://github.com/getsentry/sentry-ruby/issues/2593#issuecomment-2789569242
-   - https://github.com/getsentry/sentry-ruby/issues/2596
- Whether it's a new feature or a bug fix, make sure they're covered by new test cases
- If this PR contains any refactoring work, please give it its own commit(s)
- Finally, please add an entry to the corresponding changelog
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)

**Other Notes**
- We squash all commits before merging
- We generally try to review new PRs within a week
- If you have any question, you can ask for feedback in our [discord community](https://discord.gg/Ww9hbqr) first or consult [CONTRIBUTING.md](https://github.com/getsentry/sentry-ruby/blob/master/CONTRIBUTING.md) or [Sentry SDK development docs](https://develop.sentry.dev/sdk/)

## Description
Describe your changes:

This introduces a custom Sentry integration for the concurrent-ruby library, ensuring proper hub and span propagation across background threads created by Concurrent::Promises.future and Concurrent::Promises::Promise.

Key changes:

Added a Sentry::ConcurrentRuby module that patches:

Concurrent::Promises.future

Concurrent::Promises::Future#on_resolution

Automatically propagates the current Sentry hub and active span to background threads.

Wraps each future/promise execution inside Sentry.with_child_span, creating a child span for async tasks.

Sets the child span as the current span for that thread to preserve the correct trace hierarchy.

Removes the need for manually calling Sentry.with_child_span inside individual futures.

Result:

<img width="677" height="285" alt="image" src="https://github.com/user-attachments/assets/5f2beed7-8981-47d3-acb7-63a303fcf6f2" />


<!--
* resolves: #1234
* resolves: LIN-1234
-->
