### PR TITLE
Fix initialized check in Sentry::Rails::CaptureExceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 6.1.1
 
 ### Improvements
 
@@ -8,6 +8,7 @@
 
 - Properly skip silenced `ActiveRecord::Base.logger`'s log entries in the ActiveRecord log subscriber ([#2775](https://github.com/getsentry/sentry-ruby/pull/2775))
 - Skip malformed utf-8 messages ([#2777](https://github.com/getsentry/sentry-ruby/pull/2777))
+- Fix initialized check in Sentry::Rails::CaptureExceptions ([#2783](https://github.com/getsentry/sentry-ruby/pull/2783))
 
 ## 6.1.0
 

--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -27,6 +27,7 @@ module Sentry
 
       def capture_exception(exception, env)
         # the exception will be swallowed by ShowExceptions middleware
+        return unless Sentry.initialized?
         return if show_exceptions?(exception, env) && !Sentry.configuration.rails.report_rescued_exceptions
 
         Sentry::Rails.capture_exception(exception).tap do |event|


### PR DESCRIPTION
* resolves: #2782 
* resolves: RUBY-114

#skip-changelog