### PR TITLE
Handle empty frames case gracefully with local vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Handle empty frames case gracefully with local vars ([#2807](https://github.com/getsentry/sentry-ruby/pull/2807))
+
 ## 6.2.0
 
 ### Features

--- a/sentry-ruby/lib/sentry/interfaces/single_exception.rb
+++ b/sentry-ruby/lib/sentry/interfaces/single_exception.rb
@@ -60,7 +60,7 @@ module Sentry
             end
         end
 
-        stacktrace.frames.last.vars = locals
+        stacktrace.frames.last&.vars = locals
       end
 
       new(exception: exception, stacktrace: stacktrace, mechanism: mechanism)

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -310,6 +310,16 @@ RSpec.describe Sentry do
         last_frame = event.dig(:exception, :values, 0, :stacktrace, :frames).last
         expect(last_frame[:vars]).to include({ a: "1", b: "0" })
       end
+
+      it 'does not throw SDK internal exception with empty frames' do
+        expect do
+          begin
+            raise StandardError, 'Stuff', []
+          rescue => e
+            Sentry.capture_exception(e)
+          end
+        end.not_to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
* resolves: #2806 
* resolves: RUBY-124