### PR TITLE
fix(delayed_job): fix tests for DJ 4.2.0

### DIFF
--- a/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
+++ b/sentry-delayed_job/spec/sentry/delayed_job_spec.rb
@@ -181,6 +181,15 @@ RSpec.describe Sentry::DelayedJob do
     require "active_job"
     require "sentry-rails"
 
+    # delayed_job 4.2.0 adapter references AbstractAdapter which was removed in newer ActiveJob versions
+    # Define it as a compatibility shim
+    module ActiveJob
+      module QueueAdapters
+        class AbstractAdapter
+        end
+      end
+    end
+
     class ReportingJob < ActiveJob::Base
       self.queue_adapter = :delayed_job
 


### PR DESCRIPTION
Otherwise:

```
/usr/local/bin/ruby -I/workspace/sentry/vendor/gems/2.7.8/gems/rspec-core-3.13.6/lib:/workspace/sentry/vendor/gems/2.7.8/gems/rspec-support-3.13.6/lib /workspace/sentry/vendor/gems/2.7.8/gems/rspec-core-3.13.6/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb --order rand
-- create_table(:delayed_jobs)
   -> 0.0141s

An error occurred while loading ./spec/sentry/delayed_job_spec.rb.
Failure/Error: self.queue_adapter = :delayed_job

NameError:
  uninitialized constant ActiveJob::QueueAdapters::AbstractAdapter
# /workspace/sentry/vendor/gems/2.7.8/gems/delayed_job-4.2.0/lib/active_job/queue_adapters/delayed_job_adapter.rb:10:in `<module:QueueAdapters>'
# /workspace/sentry/vendor/gems/2.7.8/gems/delayed_job-4.2.0/lib/active_job/queue_adapters/delayed_job_adapter.rb:4:in `<module:ActiveJob>'
# /workspace/sentry/vendor/gems/2.7.8/gems/delayed_job-4.2.0/lib/active_job/queue_adapters/delayed_job_adapter.rb:3:in `<top (required)>'
# /workspace/sentry/vendor/gems/2.7.8/gems/activejob-7.1.6/lib/active_job/queue_adapters.rb:138:in `const_get'
# /workspace/sentry/vendor/gems/2.7.8/gems/activejob-7.1.6/lib/active_job/queue_adapters.rb:138:in `lookup'
# /workspace/sentry/vendor/gems/2.7.8/gems/activejob-7.1.6/lib/active_job/queue_adapter.rb:51:in `queue_adapter='
# ./spec/sentry/delayed_job_spec.rb:186:in `<class:ReportingJob>'
# ./spec/sentry/delayed_job_spec.rb:185:in `block (2 levels) in <top (required)>'
# ./spec/sentry/delayed_job_spec.rb:180:in `block in <top (required)>'
# ./spec/sentry/delayed_job_spec.rb:6:in `<top (required)>'

Finished in 0.00004 seconds (files took 1.55 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```

#skip-changelog