### PR TITLE
ci(release): Switch from action-prepare-release to Craft

### DIFF
--- a/.github/workflows/prepare_batch_release.yml
+++ b/.github/workflows/prepare_batch_release.yml
@@ -24,7 +24,7 @@ jobs:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0
       - name: Prepare release
-        uses: getsentry/craft@1c58bfd57bfd6a967b6f3fc92bead2c42ee698ce
+        uses: getsentry/craft@c6e2f04939b6ee67030588afbb5af76b127d8203
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:


### PR DESCRIPTION
## Summary

This PR migrates from the deprecated `action-prepare-release` to the new Craft GitHub Actions.

## Changes

- Migrated `.github/workflows/prepare_batch_release.yml` to Craft reusable workflow

## Documentation

See https://getsentry.github.io/craft/github-actions/ for more information.
