### PR TITLE
fix(telemetry): Convert DSN to string in envelope header

### DIFF
--- a/sentry-ruby/lib/sentry/telemetry_event_buffer.rb
+++ b/sentry-ruby/lib/sentry/telemetry_event_buffer.rb
@@ -84,7 +84,6 @@ module Sentry
       envelope = Envelope.new(
         event_id: Sentry::Utils.uuid,
         sent_at: Sentry.utc_now.iso8601,
-        dsn: @dsn,
         sdk: Sentry.sdk_meta
       )
 

--- a/sentry-ruby/lib/sentry/telemetry_event_buffer.rb
+++ b/sentry-ruby/lib/sentry/telemetry_event_buffer.rb
@@ -84,6 +84,7 @@ module Sentry
       envelope = Envelope.new(
         event_id: Sentry::Utils.uuid,
         sent_at: Sentry.utc_now.iso8601,
+        dsn: @dsn.to_s,
         sdk: Sentry.sdk_meta
       )
 

--- a/sentry-ruby/spec/sentry/metrics_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe "Sentry Metrics" do
 
           expect(headers[:event_id]).to match(/\A[0-9a-f]{32}\z/) # UUID format
           expect(headers[:sent_at]).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/) # ISO8601 timestamp
-          expect(headers[:dsn]).to eq(Sentry.configuration.dsn)
+          expect(headers[:dsn]).to eq(Sentry.configuration.dsn.to_s)
           expect(headers[:sdk]).to eq(Sentry.sdk_meta)
         end
 


### PR DESCRIPTION
# Fix: Convert DSN to string in telemetry envelope header

## Problem

When enabling log ingestion with `config.enable_logs = true`, the application crashes with the following error:

```
[Sentry::LogEventBuffer] Failed to send Sentry::LogEvent: the server responded with status 400
body: {"detail":"invalid event envelope","causes":["invalid envelope header","invalid type: map, expected a string at line 1 column 360"]}
```

## Root Cause

The `TelemetryEventBuffer#send_items` method incorrectly passes the DSN as a Ruby object instead of a string:

```ruby
envelope = Envelope.new(
  event_id: Sentry::Utils.uuid,
  sent_at: Sentry.utc_now.iso8601,
  dsn: @dsn,  # ← DSN is a Ruby object, not a string!
  sdk: Sentry.sdk_meta
)
```

When the envelope is serialized in `Transport#serialize_envelope`, it calls `JSON.generate(envelope.headers)`, which fails because the DSN is a complex Ruby object (instance of `Sentry::DSN`), not a primitive JSON-serializable type.

The Sentry server expects all envelope header values to be strings, numbers, or booleans - not maps/objects.

## Solution

Convert the DSN to a string using `.to_s` before adding it to the envelope header:

```ruby
envelope = Envelope.new(
  event_id: Sentry::Utils.uuid,
  sent_at: Sentry.utc_now.iso8601,
  dsn: @dsn.to_s,  # ← Convert to string!
  sdk: Sentry.sdk_meta
)
```

**Why this approach:**
- This aligns with the existing implementation in `Transport#envelope_from_event` (line 122), which uses `dsn: @dsn.to_s`
- The DSN is included in envelope headers for other event types (events, transactions) - see `transport_spec.rb` tests
- Ensures consistency across all envelope types in the codebase
- Properly serializes to JSON while maintaining the DSN information in the envelope

## Changes

1. **`sentry-ruby/lib/sentry/telemetry_event_buffer.rb`**: Convert DSN to string with `.to_s` in envelope header
2. **`sentry-ruby/spec/sentry/metrics_spec.rb`**: Fix test to expect string DSN instead of DSN object

## Testing

1. Enable log ingestion: `config.enable_logs = true`
2. Configure log subscribers (e.g., ActiveRecord, ActionController)
3. Trigger a log event
4. Verify logs are successfully sent to Sentry without the 400 error

## Affected Versions

This bug affects all versions with the telemetry event buffer, including:
- sentry-ruby 6.3.0+
- Any version with `config.enable_logs` or `config.enable_metrics` features

## Related Files

- `sentry-ruby/lib/sentry/telemetry_event_buffer.rb` (fixed)
- `sentry-ruby/lib/sentry/transport.rb` (reference implementation at line 122)
- `sentry-ruby/spec/sentry/transport_spec.rb` (shows DSN as string in tests)