### PR TITLE
fix(tests): skip vernier on Ruby head due to compilation issues

### DIFF
--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -10,7 +10,8 @@ require "simplecov"
 require "rspec/retry"
 require "redis"
 require "stackprof" unless RUBY_PLATFORM == "java"
-require "vernier" unless RUBY_PLATFORM == "java" || RUBY_VERSION < "3.2"
+# XXX: vernier does not currently compile on Ruby head (4.1)
+require "vernier" unless RUBY_PLATFORM == "java" || RUBY_VERSION < "3.2" || RUBY_VERSION.start_with?("4.1")
 
 SimpleCov.start do
   project_name "sentry-ruby"


### PR DESCRIPTION
It seemed better to me to temporarily skip vernier on Ruby head so that we still get the actual test runs, rather than have them fail upfront when vernier fails to load.

---

## Summary
- Skip loading the `vernier` gem on Ruby head (>= 4.1) to fix test failures
- The vernier gem's native extension currently fails to compile on Ruby head (4.1.0+1)

## Root Cause
The vernier gem (v1.9.0) has a native C extension that fails to load on Ruby head:
```
LoadError: cannot load such file -- /path/to/gems/vernier-1.9.0/lib/vernier/vernier
```

This was causing all "Ruby head" test matrix runs to fail on master.

## Solution
Updated `sentry-ruby/spec/spec_helper.rb` to skip requiring vernier when `RUBY_VERSION >= "4.1"`.

This is a temporary workaround until vernier is updated to support Ruby 4.1 development versions.

## Test Plan
✅ All existing tests on Ruby 2.7 - 4.0 should continue to pass (vernier still loads)
✅ Ruby head tests should now pass (vernier is skipped)

Fixes the Ruby head test failures seen in #2855 and on master branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)