### PR TITLE
Fix MetricEvent timestamp serialization to float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
   If you were using the `SpanProcessor` before, we recommend migrating over to `config.otlp` since it's a much simpler setup.
 
+### Bug Fixes
+
+- Fix `MetricEvent` timestamp serialization to float ([#2862](https://github.com/getsentry/sentry-ruby/pull/2862))
+
 ## 6.3.1
 
 ### Bug Fixes

--- a/sentry-ruby/lib/sentry/metric_event.rb
+++ b/sentry-ruby/lib/sentry/metric_event.rb
@@ -33,7 +33,7 @@ module Sentry
         type: @type,
         value: @value,
         unit: @unit,
-        timestamp: @timestamp,
+        timestamp: @timestamp.to_f,
         trace_id: @trace_id,
         span_id: @span_id,
         attributes: serialize_attributes

--- a/sentry-ruby/spec/sentry/metric_event_spec.rb
+++ b/sentry-ruby/spec/sentry/metric_event_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Sentry::MetricEvent do
       expect(hash[:type]).to eq(:distribution)
       expect(hash[:value]).to eq(5.0)
       expect(hash[:unit]).to eq("seconds")
-      expect(hash[:timestamp]).to be_a(Time)
+      expect(hash[:timestamp]).to be_a(Float)
     end
 
     it "includes trace info if provided" do


### PR DESCRIPTION
* resolves: #2857 
* resolves: RUBY-147
