### PR TITLE
Fix CGI imports for ruby 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Bug Fixes
 
 - Fix `MetricEvent` timestamp serialization to float ([#2862](https://github.com/getsentry/sentry-ruby/pull/2862))
+- Fix CGI imports for ruby 4.x ([#2863](https://github.com/getsentry/sentry-ruby/pull/2863))
 
 ## 6.3.1
 

--- a/sentry-ruby/lib/sentry/baggage.rb
+++ b/sentry-ruby/lib/sentry/baggage.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "cgi"
+require "cgi/escape"
 
 module Sentry
   # A {https://www.w3.org/TR/baggage W3C Baggage Header} implementation.

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cgi/escape"
 require "concurrent/utility/processor_counter"
 
 require "sentry/utils/exception_cause_chain"


### PR DESCRIPTION
see https://rubyreferences.github.io/rubychanges/4.0.html#removals


* resolves: #2858
* resolves: RUBY-148