### PR TITLE
Ignore vernier on ruby 4.1.0

### DIFF
--- a/sentry-ruby/Gemfile
+++ b/sentry-ruby/Gemfile
@@ -21,7 +21,7 @@ gem "puma"
 
 gem "timecop"
 gem "stackprof" unless RUBY_PLATFORM == "java"
-gem "vernier", platforms: :ruby if RUBY_VERSION >= "3.2.1"
+gem "vernier", platforms: :ruby if ruby_version >= Gem::Version.new("3.3") && ruby_version < Gem::Version.new("4.1.0")
 
 gem "graphql", ">= 2.2.6"
 

--- a/sentry-ruby/spec/sentry/vernier/profiler_spec.rb
+++ b/sentry-ruby/spec/sentry/vernier/profiler_spec.rb
@@ -2,7 +2,7 @@
 
 require "sentry/vernier/profiler"
 
-RSpec.describe Sentry::Vernier::Profiler, when: { ruby_version?: [:>=, "3.3"], ruby_engine?: "ruby" } do
+RSpec.describe Sentry::Vernier::Profiler, when: :vernier_installed? do
   subject(:profiler) { described_class.new(Sentry.configuration) }
 
   before do
@@ -283,7 +283,7 @@ RSpec.describe Sentry::Vernier::Profiler, when: { ruby_version?: [:>=, "3.3"], r
           expect(thread2[:name]).to eq("thread-bar-1")
         end
 
-        it 'has correct frames', when: { ruby_version?: [:>=, "3.3"], ruby_engine?: "ruby" } do
+        it 'has correct frames' do
           frames = profiler.to_h[:profile][:frames]
 
           foo_frame = frames.find { |f| f[:function] =~ /foo/ }
@@ -296,7 +296,7 @@ RSpec.describe Sentry::Vernier::Profiler, when: { ruby_version?: [:>=, "3.3"], r
           expect(foo_frame[:abs_path]).to include('sentry-ruby/spec/support/profiler.rb')
         end
 
-        it 'has correct stacks', when: { ruby_version?: [:>=, "3.3"], ruby_engine?: "ruby" } do
+        it 'has correct stacks' do
           profile = profiler.to_h[:profile]
           frames = profile[:frames]
           stacks = profile[:stacks]

--- a/sentry-ruby/spec/spec_helper.rb
+++ b/sentry-ruby/spec/spec_helper.rb
@@ -10,7 +10,10 @@ require "simplecov"
 require "rspec/retry"
 require "redis"
 require "stackprof" unless RUBY_PLATFORM == "java"
-require "vernier" unless RUBY_PLATFORM == "java" || RUBY_VERSION < "3.2"
+begin
+  require "vernier"
+rescue LoadError
+end
 
 SimpleCov.start do
   project_name "sentry-ruby"


### PR DESCRIPTION
remove when https://github.com/jhawthorn/vernier/pull/177 lands
also unified a bunch of stuff to `vernier_installed?` and increased min version to `3.3` since we have some random checks anyway


#skip-changelog

