### PR TITLE
Track request queue time in sentry-rails

### DIFF
--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -36,19 +36,11 @@ module Sentry
       end
 
       def start_transaction(env, scope)
-        options = {
-          name: scope.transaction_name,
-          source: scope.transaction_source,
-          op: transaction_op,
-          origin: SPAN_ORIGIN
-        }
-
-        if @assets_regexp && scope.transaction_name.match?(@assets_regexp)
-          options.merge!(sampled: false)
+        super do |options|
+          if @assets_regexp && scope.transaction_name.match?(@assets_regexp)
+            options.merge!(sampled: false)
+          end
         end
-
-        transaction = Sentry.continue_trace(env, **options)
-        Sentry.start_transaction(transaction: transaction, custom_sampling_context: { env: env }, **options)
       end
 
       def show_exceptions?(exception, env)

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -71,6 +71,8 @@ module Sentry
           origin: SPAN_ORIGIN
         }
 
+        yield(options) if block_given?
+
         transaction = Sentry.continue_trace(env, **options)
         transaction = Sentry.start_transaction(transaction: transaction, custom_sampling_context: { env: env }, **options)
 


### PR DESCRIPTION
Ensure the default behavior of start_transaction from the parent class `Sentry::Rack::CaptureExceptions` is executed when using Rails.

Resolves https://github.com/getsentry/sentry-ruby/issues/2873

However, I have not tested this at all. I opened this more as a starting point and possible solution. Note that prior to https://github.com/getsentry/sentry-ruby/pull/1405, the `start_transaction` method did call `super`. I don't have strong enough familiarity with the code to know whether this change makes sense or if another solution is better.