### PR TITLE
fix(rails): Track request queue time in Rails middleware

### DIFF
--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -43,12 +43,12 @@ module Sentry
           origin: SPAN_ORIGIN
         }
 
-        if @assets_regexp && scope.transaction_name.match?(@assets_regexp)
-          options.merge!(sampled: false)
-        end
+        options.merge!(sampled: false) if @assets_regexp && scope.transaction_name.match?(@assets_regexp)
 
         transaction = Sentry.continue_trace(env, **options)
-        Sentry.start_transaction(transaction: transaction, custom_sampling_context: { env: env }, **options)
+        transaction = Sentry.start_transaction(transaction: transaction, custom_sampling_context: { env: env }, **options)
+        attach_queue_time(transaction, env)
+        transaction
       end
 
       def show_exceptions?(exception, env)

--- a/sentry-rails/spec/sentry/rails/tracing_spec.rb
+++ b/sentry-rails/spec/sentry/rails/tracing_spec.rb
@@ -110,6 +110,33 @@ RSpec.describe Sentry::Rails::Tracing, type: :request do
 
       expect(transport.events.count).to eq(1)
     end
+
+    context "with X-Request-Start header" do
+      it "attaches queue time to the Rails transaction" do
+        p = Post.create!
+        timestamp = Time.now.to_f - 0.05  # 50ms ago
+
+        get "/posts/#{p.id}", headers: { "X-Request-Start" => "t=#{timestamp}" }
+
+        expect(response).to have_http_status(:ok)
+        transaction = transport.events.last
+        queue_time = transaction.contexts.dig(:trace, :data, "http.server.request.time_in_queue")
+        expect(queue_time).not_to be_nil
+        expect(queue_time).to be >= 0
+      end
+
+      it "does not attach queue time when capture_queue_time is disabled" do
+        p = Post.create!
+        timestamp = Time.now.to_f - 0.05
+
+        Sentry.configuration.capture_queue_time = false
+        get "/posts/#{p.id}", headers: { "X-Request-Start" => "t=#{timestamp}" }
+
+        transaction = transport.events.last
+        queue_time = transaction.contexts.dig(:trace, :data, "http.server.request.time_in_queue")
+        expect(queue_time).to be_nil
+      end
+    end
   end
 
   context "with report_rescued_exceptions and public error pages" do

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -73,13 +73,15 @@ module Sentry
 
         transaction = Sentry.continue_trace(env, **options)
         transaction = Sentry.start_transaction(transaction: transaction, custom_sampling_context: { env: env }, **options)
-
-        # attach queue time if available
-        if transaction && (queue_time = extract_queue_time(env))
-          transaction.set_data(Span::DataConventions::HTTP_QUEUE_TIME_MS, queue_time)
-        end
-
+        attach_queue_time(transaction, env)
         transaction
+      end
+
+      def attach_queue_time(transaction, env)
+        return unless transaction
+        return unless (queue_time = extract_queue_time(env))
+
+        transaction.set_data(Span::DataConventions::HTTP_QUEUE_TIME_MS, queue_time)
       end
 
 


### PR DESCRIPTION
The Rails CaptureExceptions middleware subclass overrode start_transaction without calling super, so the `http.server.request.time_in_queue` attachment added in #2838 was silently skipped for all Rails apps.

Extract queue time attachment into a private `attach_queue_time` method on the Rack base class so the Rails subclass can invoke it explicitly while keeping its own options hash (preserving the correct SPAN_ORIGIN constant "auto.http.rails" via lexical scoping).

Fixes #2873 
