### PR TITLE
fix: Don't transform attributes in place in metrics

### DIFF
--- a/sentry-ruby/lib/sentry/metric_event.rb
+++ b/sentry-ruby/lib/sentry/metric_event.rb
@@ -43,7 +43,7 @@ module Sentry
     private
 
     def serialize_attributes
-      @attributes.transform_values! { |v| attribute_hash(v) }
+      @attributes.transform_values { |v| attribute_hash(v) }
     end
   end
 end

--- a/sentry-ruby/spec/sentry/metric_event_spec.rb
+++ b/sentry-ruby/spec/sentry/metric_event_spec.rb
@@ -117,6 +117,18 @@ RSpec.describe Sentry::MetricEvent do
       expect(attributes["unknown"][:value]).to include("Object")
     end
 
+    it "does not mutate the original attributes hash" do
+      attributes = { "foo" => "bar" }
+      event1 = described_class.new(name: "test.metric", type: :counter, value: 1, attributes: attributes)
+      event1.to_h
+
+      event2 = described_class.new(name: "test.metric", type: :counter, value: 1, attributes: attributes)
+      hash = event2.to_h
+
+      expect(attributes).to eq({ "foo" => "bar" })
+      expect(hash[:attributes]["foo"]).to eq({ type: "string", value: "bar" })
+    end
+
     it "merges custom attributes with default attributes" do
       event = described_class.new(
         name: "test.metric",


### PR DESCRIPTION
* resolves: #2880
* resolves: RUBY-154
