### PR TITLE
chore(transport): Handle HTTP 413 response for oversized envelopes

### DIFF
--- a/sentry-ruby/lib/sentry/exceptions.rb
+++ b/sentry-ruby/lib/sentry/exceptions.rb
@@ -6,4 +6,7 @@ module Sentry
 
   class ExternalError < Error
   end
+
+  class SizeExceededError < ExternalError
+  end
 end

--- a/sentry-ruby/lib/sentry/transport.rb
+++ b/sentry-ruby/lib/sentry/transport.rb
@@ -19,7 +19,8 @@ module Sentry
       :before_send,
       :event_processor,
       :insufficient_data,
-      :backpressure
+      :backpressure,
+      :send_error
     ]
 
     include LoggingHelper
@@ -60,6 +61,10 @@ module Sentry
       if data
         log_debug("[Transport] Sending envelope with items [#{serialized_items.map(&:type).join(', ')}] #{envelope.event_id} to Sentry")
         send_data(data)
+      end
+    rescue Sentry::SizeExceededError
+      serialized_items&.each do |item|
+        record_lost_event(:send_error, item.data_category)
       end
     end
 

--- a/sentry-ruby/lib/sentry/transport/http_transport.rb
+++ b/sentry-ruby/lib/sentry/transport/http_transport.rb
@@ -49,6 +49,12 @@ module Sentry
 
       if response.code.match?(/\A2\d{2}/)
         handle_rate_limited_response(response) if has_rate_limited_header?(response)
+      elsif response.code == "413"
+        error_message = "HTTP 413: Envelope dropped due to exceeded size limit"
+        error_message += " (body: #{response.body})" if response.body && !response.body.empty?
+        log_warn(error_message)
+
+        raise Sentry::SizeExceededError, error_message
       elsif response.code == "429"
         log_debug("the server responded with status 429")
         handle_rate_limited_response(response)

--- a/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
+++ b/sentry-ruby/spec/sentry/transport/http_transport_spec.rb
@@ -291,6 +291,79 @@ RSpec.describe Sentry::HTTPTransport do
   end
 
   describe "failed request handling" do
+    context "receive 413 response" do
+      let(:string_io) { StringIO.new }
+
+      before do
+        configuration.sdk_logger = Logger.new(string_io)
+      end
+
+      context "with response body" do
+        let(:fake_response) { build_fake_response("413", body: { detail: "Envelope too large" }) }
+
+        it "raises SizeExceededError with body in message" do
+          sentry_stub_request(fake_response)
+
+          expect { subject.send_data(data) }.to raise_error(
+            Sentry::SizeExceededError,
+            /HTTP 413: Envelope dropped due to exceeded size limit.*body:.*Envelope too large/
+          )
+        end
+
+        it "logs a warning message with body" do
+          sentry_stub_request(fake_response)
+
+          expect { subject.send_data(data) }.to raise_error(Sentry::SizeExceededError)
+          expect(string_io.string).to include("HTTP 413: Envelope dropped due to exceeded size limit")
+          expect(string_io.string).to include("Envelope too large")
+        end
+      end
+
+      context "with empty response body" do
+        let(:fake_response) do
+          Net::HTTPResponse.new("1.0", "413", "").tap do |response|
+            allow(response).to receive(:body).and_return("")
+          end
+        end
+
+        it "raises SizeExceededError without body in message" do
+          sentry_stub_request(fake_response)
+
+          expect { subject.send_data(data) }.to raise_error(
+            Sentry::SizeExceededError,
+            "HTTP 413: Envelope dropped due to exceeded size limit"
+          )
+        end
+      end
+
+      context "records client reports via send_envelope" do
+        let(:fake_response) { build_fake_response("413", body: { detail: "too large" }) }
+
+        it "records send_error for each item in the envelope" do
+          sentry_stub_request(fake_response)
+
+          configuration.send_client_reports = true
+          transport = Sentry::HTTPTransport.new(configuration)
+          envelope = transport.envelope_from_event(event)
+
+          transport.send_envelope(envelope)
+
+          # Should have recorded send_error for the event item
+          expect(transport.discarded_events[[:send_error, "error"]]).to eq(1)
+        end
+
+        it "does not raise the error to the caller" do
+          sentry_stub_request(fake_response)
+
+          configuration.send_client_reports = true
+          transport = Sentry::HTTPTransport.new(configuration)
+          envelope = transport.envelope_from_event(event)
+
+          expect { transport.send_envelope(envelope) }.not_to raise_error
+        end
+      end
+    end
+
     context "receive 4xx responses" do
       let(:fake_response) { build_fake_response("404") }
 


### PR DESCRIPTION
## Description

Handle HTTP 413 (Content Too Large) responses from Relay. Previously, oversized envelopes returned HTTP 400 from Relay. Now that Relay returns 413, the SDK can distinguish size-related rejections from other errors.

**Changes:**
- When the transport receives an HTTP 413 response, log a warning: "HTTP 413: Envelope dropped due to exceeded size limit" (with response body if available)
- Record client reports with reason `send_error` for each dropped item (so Sentry can track data loss)
- Do NOT retry on 413 — the data is definitively too large
- The 413 check comes before the existing 429 rate-limit check in the response handling flow
- Added `SizeExceededError` exception class (subclass of `ExternalError`) for internal flow control
- Added `:send_error` to the `CLIENT_REPORT_REASONS` list

Closes getsentry/sentry-ruby#2844

## References
- Python: https://github.com/getsentry/sentry-python/pull/5380
- Go: https://github.com/getsentry/sentry-go/pull/1185

## Test plan
- [x] Added tests for 413 response handling with body present
- [x] Added tests for 413 response handling with empty body
- [x] Added tests verifying client reports are recorded with `send_error` reason
- [x] Added tests verifying `send_envelope` does not re-raise the error
- [x] All existing transport tests continue to pass (65 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)