### PR TITLE
fix: Copy event processors on Scope#dup

### DIFF
--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -135,6 +135,7 @@ module Sentry
       copy.session = session.deep_dup
       copy.propagation_context = propagation_context.deep_dup
       copy.attachments = attachments.dup
+      copy.event_processors = event_processors.dup
       copy
     end
 

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -402,6 +402,23 @@ RSpec.describe Sentry::Hub do
       expect(outter_event.tags).to eq({ level: 1 })
     end
 
+    it "doesn't leak event processors to the outer scope" do
+      processor_calls = 0
+
+      2.times do
+        subject.with_scope do |scope|
+          scope.add_event_processor do |event, _hint|
+            processor_calls += 1
+            event
+          end
+
+          subject.capture_message("test")
+        end
+      end
+
+      expect(processor_calls).to eq(2)
+    end
+
     it "doesn't leak data mutation" do
       inner_event = nil
       scope.set_tags({ level: 1 })

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -57,6 +57,16 @@ RSpec.describe Sentry::Scope do
       expect(subject.span).to eq(nil)
     end
 
+    it "copies event_processors so mutations don't affect the original" do
+      subject.add_event_processor { |event, _hint| event }
+      copy = subject.dup
+
+      copy.add_event_processor { |event, _hint| event }
+
+      expect(subject.event_processors.length).to eq(1)
+      expect(copy.event_processors.length).to eq(2)
+    end
+
     it "deep-copies span as well" do
       perform_basic_setup
 


### PR DESCRIPTION
* resolves: #2891
* resolves: RUBY-158

