### PR TITLE
feat: Add release detection from Kamal deployment

### DIFF
--- a/sentry-ruby/lib/sentry/release_detector.rb
+++ b/sentry-ruby/lib/sentry/release_detector.rb
@@ -6,6 +6,7 @@ module Sentry
     class << self
       def detect_release(project_root:, running_on_heroku:)
         detect_release_from_env ||
+        detect_release_from_kamal ||
         detect_release_from_git ||
         detect_release_from_capistrano(project_root) ||
         detect_release_from_heroku(running_on_heroku)
@@ -29,6 +30,10 @@ module Sentry
 
       def detect_release_from_git
         Sentry.sys_command("git rev-parse HEAD") if File.directory?(".git")
+      end
+
+      def detect_release_from_kamal
+        ENV["KAMAL_VERSION"]
       end
 
       def detect_release_from_env

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -1235,6 +1235,15 @@ RSpec.describe Sentry do
       end
     end
 
+    it 'uses `KAMAL_VERSION` env variable' do
+      ENV['KAMAL_VERSION'] = 'GIT_SHA'
+
+      described_class.init
+      expect(described_class.configuration.release).to eq('GIT_SHA')
+
+      ENV.delete('KAMAL_VERSION')
+    end
+
     context "when git is available" do
       before do
         allow(File).to receive(:directory?).and_return(false)


### PR DESCRIPTION
## Description

Kamal provides a KAMAL_VERSION environment variable in the containers it builds and deploys. It's the SHA of the commit the release is based on.

- Added a path to use the environment variable in ReleaseDetector if set. It's done after looking for SENTRY_RELEASE, but before looking for a git repo.
- Added spec for coverage.
