### PR TITLE
fix: Do not overwrite baggage header contents if it already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes 🐛
 
+- Do not overwrite baggage header contents if it already exists by @jakubsomonday in [#2894](https://github.com/getsentry/sentry-ruby/pull/2894)
 - (rails) Set mechanism.handled based on error handling status by @solnic in [#2892](https://github.com/getsentry/sentry-ruby/pull/2892)
 - Copy event processors on Scope#dup by @sl0thentr0py in [#2893](https://github.com/getsentry/sentry-ruby/pull/2893)
 - Map `trilogy` database adapter to `mysql` for Query Insights compatibility by @krismichalski in [#2656](https://github.com/getsentry/sentry-ruby/pull/2656)

--- a/sentry-ruby/lib/sentry/utils/http_tracing.rb
+++ b/sentry-ruby/lib/sentry/utils/http_tracing.rb
@@ -12,7 +12,13 @@ module Sentry
       end
 
       def set_propagation_headers(req)
-        Sentry.get_trace_propagation_headers&.each { |k, v| req[k] = v }
+        Sentry.get_trace_propagation_headers&.each do |k, v|
+          if k == BAGGAGE_HEADER_NAME && req[k]
+            req[k] = "#{v},#{req[k]}"
+          else
+            req[k] = v
+          end
+        end
       end
 
       def record_sentry_breadcrumb(request_info, response_status)

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -192,6 +192,45 @@ RSpec.describe Sentry::Net::HTTP do
       )
     end
 
+    it "merges baggage header with pre-existing baggage on the request" do
+      stub_normal_response
+
+      uri = URI("http://example.com/path")
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Get.new(uri.request_uri)
+      request["baggage"] = "routingKey=myvalue,tenantId=123"
+
+      transaction = Sentry.start_transaction
+      Sentry.get_current_scope.set_span(transaction)
+
+      response = http.request(request)
+
+      expect(response.code).to eq("200")
+      request_span = transaction.span_recorder.spans.last
+      sentry_baggage = request_span.to_baggage
+
+      expect(request["baggage"]).to include(sentry_baggage)
+      expect(request["baggage"]).to include("routingKey=myvalue,tenantId=123")
+      expect(request["baggage"]).to eq("#{sentry_baggage},routingKey=myvalue,tenantId=123")
+    end
+
+    it "sets baggage header normally when no pre-existing baggage on the request" do
+      stub_normal_response
+
+      uri = URI("http://example.com/path")
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Get.new(uri.request_uri)
+
+      transaction = Sentry.start_transaction
+      Sentry.get_current_scope.set_span(transaction)
+
+      response = http.request(request)
+
+      expect(response.code).to eq("200")
+      request_span = transaction.span_recorder.spans.last
+      expect(request["baggage"]).to eq(request_span.to_baggage)
+    end
+
     context "with config.propagate_traces = false" do
       before do
         Sentry.configuration.propagate_traces = false


### PR DESCRIPTION
When making outgoing HTTP requests, the SDK was overwriting any pre-existing baggage header on the request with Sentry's own baggage values. This caused loss of third-party baggage entries (e.g., routingKey, tenantId) that were already set on the request.

This fix updates set_propagation_headers to merge Sentry's baggage with any existing baggage on the request instead of replacing it, following the W3C Baggage specification which allows comma-separated list entries from multiple providers.

A similar issue was previously identified and fixed in the Python SDK: https://github.com/getsentry/sentry-python/pull/2191

Changes

- Modified Sentry::Utils::HttpTracing#set_propagation_headers to check for an existing baggage header and merge values instead of overwriting
- Added test cases covering both the merge scenario and the default (no pre-existing baggage) scenario

Fixes https://github.com/getsentry/sentry-ruby/issues/2894

<!--
* resolves: #2894
* resolves: RUBY-159
-->
