### PR TITLE
fix(specs): stop sidekiq-scheduler after each test

### DIFF
--- a/sentry-sidekiq/spec/sentry/sidekiq-scheduler/scheduler_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq-scheduler/scheduler_spec.rb
@@ -19,8 +19,12 @@ RSpec.describe Sentry::SidekiqScheduler::Scheduler do
     scheduler_config = SidekiqScheduler::Config.new(sidekiq_config: sidekiq_config(config_options))
 
     # Making and starting a Manager instance will load the jobs
-    schedule_manager = SidekiqScheduler::Manager.new(scheduler_config)
-    schedule_manager.start
+    @schedule_manager = SidekiqScheduler::Manager.new(scheduler_config)
+    @schedule_manager.start
+  end
+
+  after do
+    @schedule_manager&.stop
   end
 
   it 'patches class' do


### PR DESCRIPTION
Otherwise this may happen:

```
    1) Sentry::Sidekiq::Cron::Job sidekiq-cron adds job to sidekiq within transaction
      Failure/Error: expect(::Sidekiq::Queue.new.size).to eq(2)

        expected: 2
              got: 5

        (compared using ==)
      # ./spec/sentry/sidekiq/cron/job_spec.rb:124:in `block in <main>'

  Finished in 6.23 seconds (files took 4.01 seconds to load)
  75 examples, 1 failure, 2 pending

  Failed examples:

  rspec ./spec/sentry/sidekiq/cron/job_spec.rb:118 # Sentry::Sidekiq::Cron::Job sidekiq-cron adds job to sidekiq within transaction
```