### PR TITLE
perf: cache Frame objects in StacktraceBuilder by Line identity

### DIFF
--- a/sentry-ruby/lib/sentry/interfaces/stacktrace_builder.rb
+++ b/sentry-ruby/lib/sentry/interfaces/stacktrace_builder.rb
@@ -78,8 +78,16 @@ module Sentry
     private
 
     def convert_parsed_line_into_frame(line)
+      # Cache frames by Line object identity — same Line produces same Frame
+      cache_key = line.object_id
+      cached_frame = @frame_cache&.[](cache_key)
+      return cached_frame if cached_frame
+
       frame = StacktraceInterface::Frame.new(project_root, line, strip_backtrace_load_path)
       frame.set_context(linecache, context_lines) if context_lines
+
+      @frame_cache ||= {}
+      @frame_cache[cache_key] = frame if @frame_cache.size < 2048
       frame
     end
 


### PR DESCRIPTION
## ⚠️ Needs closer review — caches Frame objects by Line object_id

Part of #2901 (reduce memory allocations by ~53%)

### Changes

Cache Frame objects in `StacktraceBuilder#convert_parsed_line_into_frame` keyed by `Line#object_id`. When combined with Line object caching (#2905), the same cached Line instances produce the same Frame instances, eliminating ~72 duplicate Frame creations per exception.

- Cache is per-`StacktraceBuilder` instance (not class-level)
- Bounded to 2048 entries
- Frame objects are effectively read-only after context is set — attributes are only read during `to_h` serialization

### Review focus

- Keying by `object_id` — works correctly when Line objects are cached (same object = same id). For non-cached Lines, unique ids mean no false cache hits. Is this assumption documented clearly enough?
- Most effective when paired with #2905 (Line caching), but provides modest benefit independently within a single exception's backtrace.