### PR TITLE
perf: use shallow dup instead of deep_dup for Scope and BreadcrumbBuffer

### DIFF
--- a/sentry-ruby/lib/sentry/breadcrumb_buffer.rb
+++ b/sentry-ruby/lib/sentry/breadcrumb_buffer.rb
@@ -57,7 +57,7 @@ module Sentry
     # @return [BreadcrumbBuffer]
     def dup
       copy = super
-      copy.buffer = buffer.deep_dup
+      copy.buffer = buffer.dup
       copy
     end
   end

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -124,13 +124,15 @@ module Sentry
     def dup
       copy = super
       copy.breadcrumbs = breadcrumbs.dup
-      copy.contexts = contexts.deep_dup
-      copy.extra = extra.deep_dup
-      copy.tags = tags.deep_dup
-      copy.user = user.deep_dup
+      # Shallow dup is sufficient for these containers — inner values are not
+      # mutated after scope duplication, only replaced via merge! or assignment
+      copy.contexts = contexts.dup
+      copy.extra = extra.dup
+      copy.tags = tags.dup
+      copy.user = user.dup
       copy.transaction_name = transaction_name.dup
       copy.transaction_source = transaction_source.dup
-      copy.fingerprint = fingerprint.deep_dup
+      copy.fingerprint = fingerprint.dup
       copy.span = span.deep_dup
       copy.session = session.deep_dup
       copy.propagation_context = propagation_context.deep_dup


### PR DESCRIPTION
## ⚠️ Needs closer review — changes copy semantics for scope containers

Part of #2901 (reduce memory allocations by ~53%)

### Changes

Replace `deep_dup` with `dup` for:
- **Scope:** `contexts`, `extra`, `tags`, `user`, `fingerprint`
- **BreadcrumbBuffer:** `buffer` array

### Rationale

**Scope:** These containers are not mutated in-place after duplication. Scope methods like `set_tags`, `set_extras`, `set_user` all use assignment (replacing the entire hash) or `merge!` on the copy's own hash. The inner values (strings, numbers, symbols) are immutable or treated as such.

**BreadcrumbBuffer:** Individual `Breadcrumb` objects in the buffer are not mutated after being recorded — they are only read during serialization. A shallow `dup` of the buffer array is sufficient to prevent the copy from seeing new breadcrumbs added to the original.

`span`, `session`, and `propagation_context` still use `deep_dup` as they contain mutable nested state that may be modified in-place.

### Review focus

- Are there any code paths where inner hash values in `contexts`/`extra`/`tags`/`user` are mutated in-place (rather than replaced)?
- Are breadcrumbs ever modified after being added to the buffer?
- All existing tests pass with this change.