### PR TITLE
perf: Optimize lowercase check in RequestInterface

### DIFF
--- a/sentry-ruby/lib/sentry/interfaces/request.rb
+++ b/sentry-ruby/lib/sentry/interfaces/request.rb
@@ -107,8 +107,11 @@ module Sentry
       end
     end
 
+    # Regex to detect lowercase chars — match? is allocation-free (no MatchData/String)
+    LOWERCASE_PATTERN = /[a-z]/.freeze
+
     def is_skippable_header?(key)
-      key.upcase != key || # lower-case envs aren't real http headers
+      key.match?(LOWERCASE_PATTERN) || # lower-case envs aren't real http headers
         key == "HTTP_COOKIE" || # Cookies don't go here, they go somewhere else
         !(key.start_with?("HTTP_") || CONTENT_HEADERS.include?(key))
     end


### PR DESCRIPTION
EDIT: only kept the lowercase check from here, leaving it in for reference

## ⚡ Medium risk — removes env.dup, adds header name cache

Part of #2901 (reduce memory allocations by ~53%)

### Changes

- **Remove `env.dup`:** Instead of duplicating the entire Rack env hash and deleting IP headers, filter them inline in both `filter_and_format_headers` and `filter_and_format_env` when `send_default_pii` is false. Avoids duplicating ~40+ entry hash on every request.

- **Cache header name transformations:** `HTTP_ACCEPT_LANGUAGE → Accept-Language` conversions are cached at the class level. Header names are deterministic and repeat on every request.

- **ASCII fast-path:** `ascii_only?` strings are already valid UTF-8 — skip the `dup` + `force_encoding` dance for header values.

- **`hint: nil` default in Hub#add_breadcrumb:** The empty `{}` was allocated on every breadcrumb call even though most callers don't use hints. Lazily materialized with `|| {}` only when `before_breadcrumb` callback is configured.

### Review focus

- The `env.dup` removal: we no longer modify the Rack env at all (no deleting IP headers). Instead we skip them during iteration. The original env hash is unchanged. Is there any code path that relied on the IP headers being removed from the env after RequestInterface creation?
- Header name cache is unbounded but naturally limited by the number of unique Rack env keys (typically < 50).