### PR TITLE
chore: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out current commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Generate short image name and extract version
         id: image_name
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build and push devcontainer image
         id: build
-        uses: getsentry/action-build-and-push-images@main
+        uses: getsentry/action-build-and-push-images@8fc75e483c09a68721f2c8951292ee17f8821766 # main
         with:
           image_name: "${{ steps.image_name.outputs.short_name }}"
           dockerfile_path: ".devcontainer/Dockerfile"

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -9,15 +9,15 @@ jobs:
     name: Build gems
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
       with:
         ruby-version: 3.4
     - name: Build gem source
       run:  ruby .scripts/batch_build.rb
     - name: Archive Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.sha }}
         path: sentry*/*.gem

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,11 +42,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@8dca8a82e2fa1a2c8908956f711300f9c4a4f4f6 # v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +57,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@8dca8a82e2fa1a2c8908956f711300f9c4a4f4f6 # v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
@@ -71,4 +71,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@8dca8a82e2fa1a2c8908956f711300f9c4a4f4f6 # v2

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up `.env` file
         run: |
@@ -39,7 +39,7 @@ jobs:
           cp .env.example .env
 
       - name: Restore rubygems cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: vendor/gems
           key: ${{ runner.os }}-${{ matrix.ruby_version }}-gems-${{ hashFiles('Gemfile.lock', '*/Gemfile.lock', 'spec/apps/**/Gemfile.lock') }}
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.ruby_version }}-gems-
 
       - name: Restore node_modules cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: spec/apps/svelte-mini/node_modules
           key: ${{ runner.os }}-${{ runner.arch }}-node-modules-${{ hashFiles('spec/apps/svelte-mini/package-lock.json') }}
@@ -70,7 +70,7 @@ jobs:
             up -d sentry-test
 
       - name: "Wait for rails-mini app to be ready"
-        uses: nev7n/wait_for_response@v1
+        uses: nev7n/wait_for_response@81b0b0eded16435202e126beb3e704fc00430f5b # v1
         with:
           url: 'http://localhost:4000/health'
           responseCode: 200
@@ -78,7 +78,7 @@ jobs:
           interval: 500
 
       - name: "Wait for svelte-mini app to be ready"
-        uses: nev7n/wait_for_response@v1
+        uses: nev7n/wait_for_response@81b0b0eded16435202e126beb3e704fc00430f5b # v1
         with:
           url: 'http://localhost:4001/health'
           responseCode: 200
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload test artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: e2e-test-logs-ruby-${{ matrix.ruby_version }}
           path: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
         with:
           ruby-version: "3.4"
           bundler-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/sentry_delayed_job_test.yml
+++ b/.github/workflows/sentry_delayed_job_test.yml
@@ -44,7 +44,7 @@ jobs:
           - { ruby_version: "head" }
           - { ruby_version: 'jruby-head' }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install sqlite
         run: |
           # See https://github.community/t5/GitHub-Actions/ubuntu-latest-Apt-repository-list-issues/td-p/41122/page/2
@@ -53,7 +53,7 @@ jobs:
           sudo apt-get install libsqlite3-dev
 
       - name: Set up Ruby ${{ matrix.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
@@ -62,6 +62,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sentry_opentelemetry_test.yml
+++ b/.github/workflows/sentry_opentelemetry_test.yml
@@ -42,10 +42,10 @@ jobs:
         exclude:
           - { ruby_version: 'jruby-head' }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Ruby ${{ matrix.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
@@ -54,6 +54,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -69,7 +69,7 @@ jobs:
             rails_version: "7.0.0"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install sqlite and ImageMagick
         run: |
           # See https://github.community/t5/GitHub-Actions/ubuntu-latest-Apt-repository-list-issues/td-p/41122/page/2
@@ -77,7 +77,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libsqlite3-dev imagemagick
       - name: Set up Ruby ${{ matrix.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
@@ -86,6 +86,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -41,15 +41,15 @@ jobs:
           - ruby_version: 'jruby'
           - ruby_version: 'jruby-head'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Ruby ${{ matrix.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
 
       - name: Start Redis
-        uses: supercharge/redis-github-action@1.8.1
+        uses: supercharge/redis-github-action@105b02b0ae87d7c6a8bb8debaf94b553a593327b # 1.8.1
         with:
           redis-version: 5
 
@@ -64,6 +64,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -57,16 +57,16 @@ jobs:
           - ruby_version: 'jruby'
           - ruby_version: 'jruby-head'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Ruby ${{ matrix.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
 
       - name: Start Redis
-        uses: supercharge/redis-github-action@1.8.1
+        uses: supercharge/redis-github-action@105b02b0ae87d7c6a8bb8debaf94b553a593327b # 1.8.1
         with:
           redis-version: 6
 
@@ -74,6 +74,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -57,16 +57,16 @@ jobs:
           - ruby_version: jruby
           - ruby_version: jruby-head
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Ruby ${{ matrix.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
 
       - name: Start Redis
-        uses: supercharge/redis-github-action@1.8.1
+        uses: supercharge/redis-github-action@105b02b0ae87d7c6a8bb8debaf94b553a593327b # 1.8.1
         with:
           redis-version: ${{ (contains(matrix.sidekiq_version, '7.0') || contains(matrix.sidekiq_version, '8.0')) && 6 || 5 }}
 
@@ -74,6 +74,6 @@ jobs:
         run: bundle exec rake
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
       - resque-tests
       - opentelemetry-tests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Codecov
         uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references in `.github/` workflow files to full-length commit SHAs

Generated by `devenv pin_gha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)