### PR TITLE
fix: Add block syntax support to StructuredLogger for compatibility

### DIFF
--- a/sentry-ruby/lib/sentry/structured_logger.rb
+++ b/sentry-ruby/lib/sentry/structured_logger.rb
@@ -59,8 +59,8 @@ module Sentry
     # @param attributes [Hash] Additional attributes to include with the log
     #
     # @return [LogEvent, nil] The created log event or nil if logging is disabled
-    def trace(message, parameters = [], **attributes)
-      log(__method__, message, parameters: parameters, **attributes)
+    def trace(message = nil, parameters = [], **attributes, &block)
+      log(__method__, message, parameters: parameters, **attributes, &block)
     end
 
     # Logs a message at DEBUG level
@@ -70,8 +70,8 @@ module Sentry
     # @param attributes [Hash] Additional attributes to include with the log
     #
     # @return [LogEvent, nil] The created log event or nil if logging is disabled
-    def debug(message, parameters = [], **attributes)
-      log(__method__, message, parameters: parameters, **attributes)
+    def debug(message = nil, parameters = [], **attributes, &block)
+      log(__method__, message, parameters: parameters, **attributes, &block)
     end
 
     # Logs a message at INFO level
@@ -81,8 +81,8 @@ module Sentry
     # @param attributes [Hash] Additional attributes to include with the log
     #
     # @return [LogEvent, nil] The created log event or nil if logging is disabled
-    def info(message, parameters = [], **attributes)
-      log(__method__, message, parameters: parameters, **attributes)
+    def info(message = nil, parameters = [], **attributes, &block)
+      log(__method__, message, parameters: parameters, **attributes, &block)
     end
 
     # Logs a message at WARN level
@@ -92,8 +92,8 @@ module Sentry
     # @param attributes [Hash] Additional attributes to include with the log
     #
     # @return [LogEvent, nil] The created log event or nil if logging is disabled
-    def warn(message, parameters = [], **attributes)
-      log(__method__, message, parameters: parameters, **attributes)
+    def warn(message = nil, parameters = [], **attributes, &block)
+      log(__method__, message, parameters: parameters, **attributes, &block)
     end
 
     # Logs a message at ERROR level
@@ -103,8 +103,8 @@ module Sentry
     # @param attributes [Hash] Additional attributes to include with the log
     #
     # @return [LogEvent, nil] The created log event or nil if logging is disabled
-    def error(message, parameters = [], **attributes)
-      log(__method__, message, parameters: parameters, **attributes)
+    def error(message = nil, parameters = [], **attributes, &block)
+      log(__method__, message, parameters: parameters, **attributes, &block)
     end
 
     # Logs a message at FATAL level
@@ -114,8 +114,8 @@ module Sentry
     # @param attributes [Hash] Additional attributes to include with the log
     #
     # @return [LogEvent, nil] The created log event or nil if logging is disabled
-    def fatal(message, parameters = [], **attributes)
-      log(__method__, message, parameters: parameters, **attributes)
+    def fatal(message = nil, parameters = [], **attributes, &block)
+      log(__method__, message, parameters: parameters, **attributes, &block)
     end
 
     # Logs a message at the specified level
@@ -126,7 +126,8 @@ module Sentry
     # @param attributes [Hash] Additional attributes to include with the log
     #
     # @return [LogEvent, nil] The created log event or nil if logging is disabled
-    def log(level, message, parameters:, **attributes)
+    def log(level, message = nil, parameters:, **attributes, &block)
+      message = yield if message.nil? && block_given?
       case parameters
       when Array then
         Sentry.capture_log(message, level: level, severity: LEVELS[level], parameters: parameters, **attributes)

--- a/sentry-ruby/spec/sentry/structured_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/structured_logger_spec.rb
@@ -135,6 +135,17 @@ RSpec.describe Sentry::StructuredLogger do
           expect(log_event[:attributes]["sentry.message.parameter.day"]).to eql({ value: "Monday", type: "string" })
         end
 
+        it "logs with block syntax for compatibility with ruby Logger" do
+          Sentry.logger.public_send(level) { "Hello world" }
+
+          expect(sentry_logs).to_not be_empty
+
+          log_event = sentry_logs.last
+
+          expect(log_event[:level]).to eql(level)
+          expect(log_event[:body]).to eql("Hello world")
+        end
+
         context "handling of malformed strings" do
           let(:malformed_string_default) do
             Sentry::Utils::EncodingHelper::MALFORMED_STRING


### PR DESCRIPTION
## Description

Ruby's Logger supports [passing the message as a block](https://ruby.github.io/logger/Logger.html#class-Logger-label-How+to+log+a+message). For Sentry's structured logger to be used interchangeably with Ruby's logger, it should also support this syntax.

For example, I wanted to pass `Sentry.logger` in our Rails app configured with `config.rails.structured_logging.subscribers = { ... }` to Faraday's logging middleware but that did not work because that middleware uses the block syntax:
https://github.com/lostisland/faraday/blob/8b4d1fd06fd47dd33f3720794d4df38498c240ec/lib/faraday/logging/formatter.rb#L26:L28


