### PR TITLE
chore: Ignore npm for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
   - package-ecosystem: "bundler"
     schedule:
       interval: "daily"


### PR DESCRIPTION
this is a ruby repo, we don't care about JS deps since they're just for specs