### PR TITLE
fix(sidekiq): Report error when retry limit is below attempt_threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes 🐛
+
+- (sidekiq) Report final attempt when retry limit is below `attempt_threshold` by @marcboquet in [#XXXX](https://github.com/getsentry/sentry-ruby/pull/XXXX)
+
 ## 6.5.0
 
 ### New Features ✨

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## Unreleased
-
-### Bug Fixes 🐛
-
-- (sidekiq) Report final attempt when retry limit is below `attempt_threshold` by @marcboquet in [#XXXX](https://github.com/getsentry/sentry-ruby/pull/XXXX)
-
 ## 6.5.0
 
 ### New Features ✨

--- a/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
@@ -43,8 +43,10 @@ module Sentry
           # attempt 2 - this is your first retry so retry_count is 0
           # attempt 3 - you have retried once, retry_count is 1
           attempt = retry_count.nil? ? 1 : retry_count.to_i + 2
+          # Cap at the final attempt so jobs with fewer retries than the threshold still report.
+          effective_threshold = [attempt_threshold, retry_limit(context, sidekiq_config) + 1].min
 
-          return if attempt < attempt_threshold
+          return if attempt < effective_threshold
         end
 
         Sentry::Sidekiq.capture_exception(

--- a/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
@@ -21,12 +21,14 @@ module Sentry
         scope = Sentry.get_current_scope
         scope.set_transaction_name(context_filter.transaction_name, source: :task) unless scope.transaction_name
 
+        retry_lim = retry_limit(context, sidekiq_config)
+
         # If Sentry is configured to only report an error _after_ all retries have been exhausted,
         # and if the job is retryable, and have not exceeded the retry_limit,
         # return early.
         if Sentry.configuration.sidekiq.report_after_job_retries && retryable?(context)
           retry_count = context.dig(:job, "retry_count")
-          if retry_count.nil? || retry_count < retry_limit(context, sidekiq_config) - 1
+          if retry_count.nil? || retry_count < retry_lim - 1
             return
           end
         end
@@ -44,7 +46,7 @@ module Sentry
           # attempt 3 - you have retried once, retry_count is 1
           attempt = retry_count.nil? ? 1 : retry_count.to_i + 2
           # Cap at the final attempt so jobs with fewer retries than the threshold still report.
-          effective_threshold = [attempt_threshold, retry_limit(context, sidekiq_config) + 1].min
+          effective_threshold = [attempt_threshold, retry_lim + 1].min
 
           return if attempt < effective_threshold
         end

--- a/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
+++ b/sentry-sidekiq/spec/sentry/sidekiq_spec.rb
@@ -141,6 +141,17 @@ RSpec.describe Sentry::Sidekiq do
       retry_last_failed_job
       expect(transport.events.count).to eq(0)
     end
+
+    it "reports on the final attempt when retry limit is below the threshold" do
+      worker = Class.new(SadWorker)
+      worker.sidekiq_options attempt_threshold: 3, retry: 1
+
+      execute_worker(processor, worker)
+      expect(transport.events.count).to eq(0)
+
+      retry_last_failed_job
+      expect(transport.events.count).to eq(1)
+    end
   end
 
   context "with config.report_only_dead_jobs = true" do


### PR DESCRIPTION
## Description

Fix https://github.com/getsentry/sentry-ruby/issues/2939

The `attempt_threshold` (added in https://github.com/getsentry/sentry-ruby/pull/2503) has a bug when a job's `retry` option is lower than its `attempt_threshold` (e.g. `retry: 1` with `attempt_threshold: 3`).

In those cases the error handler skipped every attempt and the job was silently dropped.

This PR caps the threshold at the job's final attempt so these jobs still report before entering the dead set. Jobs whose retry count meets or exceeds the threshold behave exactly as before.
