### PR TITLE
sentry-sidekiq: fix 'occured' -> 'occurred' typo in error handler YARD doc

### DIFF
--- a/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
+++ b/sentry-sidekiq/lib/sentry/sidekiq/error_handler.rb
@@ -7,7 +7,7 @@ module Sentry
     class ErrorHandler
       WITH_SIDEKIQ_7 = ::Gem::Version.new(::Sidekiq::VERSION) >= ::Gem::Version.new("7.0")
 
-      # @param ex [Exception] the exception / error that occured
+      # @param ex [Exception] the exception / error that occurred
       # @param context [Hash or Array] Sidekiq error context
       # @param sidekiq_config [Sidekiq::Config, Hash] Sidekiq configuration,
       #   Defaults to nil.


### PR DESCRIPTION
Fixes a typo in the YARD `@param` doc for the sidekiq error handler.