### PR TITLE
chore(ci): add ruby 4.0 and bump rails 8.1.x to latest

### DIFF
--- a/.github/workflows/sentry_rails_test.yml
+++ b/.github/workflows/sentry_rails_test.yml
@@ -52,8 +52,12 @@ jobs:
             rails_version: "8.0.0"
           - ruby_version: "3.4"
             rails_version: "8.0.0"
+          - ruby_version: "4.0"
+            rails_version: "8.0.0"
           - ruby_version: "3.4"
-            rails_version: "8.1.0"
+            rails_version: "8.1.3"
+          - ruby_version: "4.0"
+            rails_version: "8.1.3"
           - ruby_version: "3.2"
             rails_version: 7.1.0
             options:


### PR DESCRIPTION
Updates matrix accordingly.