### PR TITLE
fix(stacktrace): stop leaking internal frame state into event payload

### DIFF
--- a/sentry-ruby/lib/sentry/interfaces/stacktrace.rb
+++ b/sentry-ruby/lib/sentry/interfaces/stacktrace.rb
@@ -28,23 +28,16 @@ module Sentry
                   :lineno, :module, :pre_context, :post_context, :vars
 
       def initialize(project_root, line, strip_backtrace_load_path = true, filename_cache: nil)
-        @strip_backtrace_load_path = strip_backtrace_load_path
-        @filename_cache = filename_cache
-
         @abs_path = line.file
         @function = line.method if line.method
         @lineno = line.number
         @in_app = line.in_app
         @module = line.module_name if line.module_name
-        @filename = compute_filename
+        @filename = filename_cache&.compute_filename(@abs_path, @in_app, strip_backtrace_load_path)
       end
 
       def to_s
         "#{@filename}:#{@lineno}"
-      end
-
-      def compute_filename
-        @filename_cache&.compute_filename(abs_path, in_app, @strip_backtrace_load_path)
       end
 
       def set_context(linecache, context_lines)

--- a/sentry-ruby/spec/sentry/interfaces/stacktrace_spec.rb
+++ b/sentry-ruby/spec/sentry/interfaces/stacktrace_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe Sentry::StacktraceInterface::Frame do
       expect(second_frame.lineno).to eq(5)
     end
 
+    it "does not leak internal state into the serialized frame payload" do
+      frame = Sentry::StacktraceInterface::Frame.new(configuration.project_root, lines.last, true, filename_cache: filename_cache)
+
+      expect(frame.to_h.keys).to contain_exactly(:abs_path, :function, :lineno, :in_app, :filename)
+      expect(frame.to_h).not_to include(:project_root, :strip_backtrace_load_path, :filename_cache)
+    end
+
     it "does not strip load path when strip_backtrace_load_path is false" do
       first_frame = Sentry::StacktraceInterface::Frame.new(configuration.project_root, lines.first, false, filename_cache: filename_cache)
       expect(first_frame.filename).to eq(first_frame.abs_path)


### PR DESCRIPTION
## Summary

`Interface#to_h` serializes **every** instance variable, so helper ivars stored on `StacktraceInterface::Frame` leak into the event payload sent to Sentry. The `FilenameCache` change (#2904) made this worse: it serialized `"#<Sentry::FilenameCache:0x...>"` — a **memory address that changes on every run** — into every stack frame.

| Version | Junk leaked into every frame |
|---|---|
| 6.5.0 | `project_root`, `strip_backtrace_load_path` |
| HEAD (before this PR) | `strip_backtrace_load_path`, `filename_cache` |

This passes `filename_cache`/`strip_backtrace_load_path` through the constructor instead of storing them as ivars, so they never reach `to_h`. The now-unused private `compute_filename` helper is removed (the public `FilenameCache#compute_filename` is untouched). This also drops the pre-existing `project_root`/`strip_backtrace_load_path` leaks — none of these were part of Sentry's frame schema.

All real frame fields (`abs_path`, `function`, `lineno`, `in_app`, `module`, `filename`, `*_context`) are unchanged.

## Verification

Replayed an identical fixed backtrace through `Sentry.capture_exception` on 6.5.0 and on this branch and diffed the serialized event: every meaningful frame field is byte-identical; only the leaked internal keys are gone. Added a regression spec asserting `frame.to_h` exposes only the real frame keys. Existing interface/backtrace/event/profiler specs pass; RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)