### PR TITLE
fix(metrics): Dup attributes in capture_metric

### DIFF
--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -249,7 +249,7 @@ module Sentry
         value: value,
         type: type,
         unit: unit,
-        attributes: attributes,
+        attributes: attributes&.dup,
       )
 
       current_client.buffer_metric_event(metric, current_scope)


### PR DESCRIPTION
See https://github.com/getsentry/repro/pull/47

causes memory growth with yabeda reported in #2963 