### PR TITLE
ci: use ghcr image mirror for redis service

### DIFF
--- a/.github/workflows/sentry_resque_test.yml
+++ b/.github/workflows/sentry_resque_test.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 10
     services:
       redis:
-        image: redis:5
+        image: ghcr.io/getsentry/image-mirror-library-redis:7.0.8-bullseye
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/sentry_ruby_test.yml
+++ b/.github/workflows/sentry_ruby_test.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 10
     services:
       redis:
-        image: redis:6
+        image: ghcr.io/getsentry/image-mirror-library-redis:7.0.8-bullseye
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/sentry_sidekiq_test.yml
+++ b/.github/workflows/sentry_sidekiq_test.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 10
     services:
       redis:
-        image: redis:${{ (contains(matrix.sidekiq_version, '7.0') || contains(matrix.sidekiq_version, '8.0')) && '6' || '5' }}
+        image: ghcr.io/getsentry/image-mirror-library-redis:7.0.8-bullseye
         ports:
           - 6379:6379
         options: >-


### PR DESCRIPTION
Replaces all Docker Hub `redis` references in CI with `ghcr.io/getsentry/image-mirror-library-redis:7.0.8-bullseye`.

## Changes

| Workflow | Before | After |
|---|---|---|
| `sentry_ruby_test` | `redis:6` | `ghcr.io/getsentry/image-mirror-library-redis:7.0.8-bullseye` |
| `sentry_sidekiq_test` | `redis:${{ ... && '6' || '5' }}` | `ghcr.io/getsentry/image-mirror-library-redis:7.0.8-bullseye` |
| `sentry_resque_test` | `redis:5` | `ghcr.io/getsentry/image-mirror-library-redis:7.0.8-bullseye` |

Mirror source: [getsentry/image-mirror](https://github.com/getsentry/image-mirror)

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC09M26BC6A1%3A1781169862.709999%22)