### PR TITLE
[on-hold] fix(rails): make Action Cable handle_open/handle_close overrides public for Rails 8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes 🐛
+
+- (rails) Make Action Cable `handle_open`/`handle_close` overrides public so Rails 8.2's `ActionCable::Server::Socket` can invoke them ([rails/rails#50979](https://github.com/rails/rails/pull/50979)); the private overrides raised `NoMethodError` on every cable connection, killing all websocket traffic
+
 ## 6.6.2
 
 ### Bug Fixes 🐛

--- a/sentry-rails/lib/sentry/rails/action_cable.rb
+++ b/sentry-rails/lib/sentry/rails/action_cable.rb
@@ -57,8 +57,13 @@ module Sentry
       end
 
       module Connection
-        private
-
+        # These overrides must stay public: Rails 8.2 decoupled the Action
+        # Cable connection from the socket (rails/rails#50979), and
+        # ActionCable::Server::Socket now invokes connection.handle_open and
+        # connection.handle_close from outside the connection. With private
+        # overrides every cable connection raises NoMethodError before the
+        # welcome message is sent. On older Rails versions these methods are
+        # only called internally, so public visibility is harmless there.
         def handle_open
           ErrorHandler.capture(self, transaction_name: "#{self.class.name}#connect") do
             super

--- a/sentry-rails/spec/sentry/rails/action_cable_spec.rb
+++ b/sentry-rails/spec/sentry/rails/action_cable_spec.rb
@@ -73,6 +73,20 @@ if defined?(ActionCable) && ActionCable.version >= Gem::Version.new('6.0.0')
       transport.events = []
     end
 
+    describe "Connection method visibility" do
+      before do
+        make_basic_app
+      end
+
+      # Rails 8.2 (rails/rails#50979) invokes connection.handle_open and
+      # connection.handle_close from ActionCable::Server::Socket, outside the
+      # connection — private overrides break every cable connection there.
+      it "keeps handle_open and handle_close public" do
+        expect(Sentry::Rails::ActionCableExtensions::Connection.public_method_defined?(:handle_open)).to eq(true)
+        expect(Sentry::Rails::ActionCableExtensions::Connection.public_method_defined?(:handle_close)).to eq(true)
+      end
+    end
+
     describe "Connection" do
       before do
         make_basic_app


### PR DESCRIPTION
⚠️ this is on hold until we get at least `8.2.0.beta` released, so that we can add it to the matrix™

---

### Description

Rails 8.2 decoupled the Action Cable connection from the socket in [rails/rails#50979](https://github.com/rails/rails/pull/50979) (merged 2026-05-28): `ActionCable::Server::Socket` now invokes `connection.handle_open` and `connection.handle_close` from **outside** the connection object.

`Sentry::Rails::ActionCableExtensions::Connection` declares its `handle_open`/`handle_close` overrides as `private`, which shadows the (public) framework methods through the prepend chain. On Rails main / 8.2, every cable connection then raises:

```
NoMethodError (private method 'handle_open' called for an instance of ApplicationCable::Connection)
  actioncable/lib/action_cable/server/socket.rb:127:in 'ActionCable::Server::Socket#handle_open'
```

before the `welcome` message is sent. The practical effect is severe and **silent**: the WebSocket upgrade succeeds (101), but clients never receive `welcome` or pings, so they treat the connection as stale and reconnect in a loop forever — no broadcasts (e.g. Turbo Streams) are ever delivered. The exception only hits the Rails logger, not Sentry, since it occurs in the instrumentation wrapper itself.

We hit this in production on a Rails edge app with sentry-rails 6.6.0 and confirmed the root cause by inspecting method visibility:

```ruby
ApplicationCable::Connection.instance_method(:handle_open).owner
# => Sentry::Rails::ActionCableExtensions::Connection
ApplicationCable::Connection.private_method_defined?(:handle_open)
# => true
```

### Fix

Make the two overrides public. On Rails < 8.2 they are only invoked internally on `self` (visibility is irrelevant there), so this is safe across all supported Rails versions. Added a regression spec asserting the visibility and a changelog entry.

`bundle exec rspec spec/sentry/rails/action_cable_spec.rb` → 12 examples, 0 failures.