### PR TITLE
ci: Move all rubies to a separate mise 'ci' env

### DIFF
--- a/.devcontainer/run
+++ b/.devcontainer/run
@@ -22,10 +22,6 @@ if [[ ! -x "$MISE_BIN" ]]; then
   exit 1
 fi
 
-# .mise.toml lists the whole Ruby matrix for bin/relock; the devcontainer profile
-# overrides it to pin the single Ruby baked into the image.
-export MISE_ENV=devcontainer
-
 # Activate mise for this shell so PATH/shims are resolved correctly.
 eval "$("$MISE_BIN" activate bash)"
 

--- a/.github/workflows/update_lockfiles.yml
+++ b/.github/workflows/update_lockfiles.yml
@@ -4,10 +4,11 @@ name: Update lockfiles
 # installs are fully pinned (supply-chain hardening). Run manually to create the
 # initial lockfiles, and on a schedule to refresh them deliberately.
 #
-# The mise-action step installs every Ruby declared in .mise.toml; bin/relock
-# then sweeps every gem's test-matrix.json — the single source of truth, shared
-# with the *_test.yml workflows — resolving each cell against its matching Ruby
-# via `mise exec`. One invocation regenerates the whole lock set.
+# Under MISE_ENV=ci the mise-action step installs every Ruby declared in
+# .mise.ci.toml; bin/relock then sweeps every gem's test-matrix.json — the
+# single source of truth, shared with the *_test.yml workflows — resolving each
+# cell against its matching Ruby via `mise exec`. One invocation regenerates the
+# whole lock set.
 
 on:
   workflow_dispatch:
@@ -31,11 +32,14 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # mise installs every Ruby declared in .mise.toml (ruby.compile=false ->
+      # mise installs every Ruby declared in .mise.ci.toml (ruby.compile=false ->
       # prebuilt binaries where available); bin/relock then resolves each cell
-      # against its matching Ruby.
+      # against its matching Ruby. MISE_ENV scopes the install to the ci profile;
+      # it also keys the action's tool cache, so the matrix Rubies are cached and
+      # restored across runs.
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         env:
+          MISE_ENV: ci
           MISE_JOBS: "2"
         with:
           install: true

--- a/.mise.ci.toml
+++ b/.mise.ci.toml
@@ -1,0 +1,15 @@
+# Loaded only when MISE_ENV=ci. The full per-matrix Ruby set the lockfile CI job
+# and bin/relock resolve against; overrides the single Ruby in .mise.toml.
+[tools]
+# postinstall ensures latest bundlers possible on each version
+ruby = [
+  { version = "4.0", postinstall = "gem install bundler" },
+  { version = "3.4", postinstall = "gem install bundler" },
+  { version = "3.3", postinstall = "gem install bundler" },
+  { version = "3.2", postinstall = "gem install bundler" },
+  { version = "3.1", postinstall = "gem install bundler" },
+  { version = "3.0", postinstall = "gem install bundler" },
+  # 2.7 is pinned because latest bundler fails to resolve
+  { version = "2.7", postinstall = "gem install bundler -v 2.4.22" },
+  { version = "jruby-9.4.14.0", postinstall = "gem install bundler" },
+]

--- a/.mise.devcontainer.toml
+++ b/.mise.devcontainer.toml
@@ -1,4 +1,0 @@
-# Loaded only when MISE_ENV=devcontainer (set by .devcontainer/run). Pins Ruby to
-# the single version baked into the image, overriding the relock matrix in .mise.toml.
-[tools]
-ruby = "{{ env.RUBY_VERSION | default(value='latest') }}"

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,18 +2,7 @@
 ruby.compile = false
 
 [tools]
-# postinstall ensures latest bundlers possible on each version
-ruby = [
-  { version = "4.0", postinstall = "gem install bundler" },
-  { version = "3.4", postinstall = "gem install bundler" },
-  { version = "3.3", postinstall = "gem install bundler" },
-  { version = "3.2", postinstall = "gem install bundler" },
-  { version = "3.1", postinstall = "gem install bundler" },
-  { version = "3.0", postinstall = "gem install bundler" },
-  # 2.7 is pinned because latest bundler fails to resolve
-  { version = "2.7", postinstall = "gem install bundler -v 2.4.22" },
-  { version = "jruby-9.4.14.0", postinstall = "gem install bundler" },
-]
+ruby = "latest"
 node = "lts"
 java = "temurin-21"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,10 +52,10 @@ This file defines which specific image and Ruby version will be used to run the 
 
 CI installs against a committed, checksummed lockfile per test-matrix cell (`<gem>/gemfiles/<cell>.gemfile.lock`) to keep dependencies fully pinned against supply chain attacks. Each gem's `test-matrix.json` is the source of truth; `bin/relock` materializes the gemfiles and locks from it.
 
-We use [mise](https://mise.jdx.dev) for managing the ruby versions, so first install that by following official instructions. The required Rubies are declared in `.mise.toml`, so provision them once:
+We use [mise](https://mise.jdx.dev) for managing the ruby versions, so first install that by following official instructions. The required Rubies are declared in `.mise.ci.toml`, so provision them once:
 
 ```bash
-mise install            # installs every Ruby the matrix needs
+mise --env ci install            # installs every Ruby the matrix needs
 ```
 
 Then regenerate locks:

--- a/bin/relock
+++ b/bin/relock
@@ -13,9 +13,10 @@
 #
 # Each cell must resolve against its own Ruby (gemspecs gate on
 # required_ruby_version), so every cell runs under a matching Ruby provided by
-# mise (https://mise.jdx.dev). The required Rubies are declared in .mise.toml;
-# install them once with `mise install`. This script resolves against those
-# already-installed Rubies and aborts if any are missing.
+# mise (https://mise.jdx.dev). The required Rubies are declared in
+# .mise.ci.toml; install them once with `mise --env ci install`. This
+# script resolves against those already-installed Rubies and aborts if any are
+# missing.
 #
 #   bin/relock                         # refresh every cell
 #   bin/relock --gem sentry-ruby       # one gem
@@ -162,7 +163,7 @@ RESOLVE = <<~SH
 SH
 
 # Abort (don't auto-install) if any cell's Ruby is missing — the Rubies are
-# declared in .mise.toml and provisioned once via `mise install`.
+# declared in .mise.ci.toml and provisioned once via `mise --env ci install`.
 def ensure_installed(cells)
   missing = cells.map(&:ruby).uniq.reject do |spec|
     system(mise_bin, "where", "ruby@#{spec}", out: File::NULL, err: File::NULL)
@@ -170,7 +171,7 @@ def ensure_installed(cells)
   return if missing.empty?
 
   warn "Ruby not installed: #{missing.map { |s| "ruby@#{s}" }.join(', ')}."
-  abort "Run `mise install` first."
+  abort "Run `mise --env ci install` first."
 end
 
 def cell_env(cell, force: false)
@@ -236,7 +237,7 @@ if opts[:list]
   exit 0
 end
 
-# Resolve against already-installed Rubies (declared in .mise.toml) — never
+# Resolve against already-installed Rubies (declared in .mise.ci.toml) — never
 # auto-installs.
 ensure_installed(cells)
 


### PR DESCRIPTION
* revert devcontainer mise to previous state
* `bin/relock` now needs `mise --env ci install`
* normal dev env just needs one ruby unless others are needed
