### PR TITLE
fix(test): kill threaded global workers before clearing Sentry globals

### DIFF
--- a/sentry-ruby/lib/sentry/test_helper.rb
+++ b/sentry-ruby/lib/sentry/test_helper.rb
@@ -159,6 +159,9 @@ module Sentry
         # Don't check initialized? because sometimes we stub it in tests
         if Sentry.instance_variable_defined?(:@main_hub)
           Sentry::GLOBALS.each do |var|
+            worker = Sentry.instance_variable_get(:"@#{var}")
+            worker.kill if worker.respond_to?(:kill)
+
             Sentry.instance_variable_set(:"@#{var}", nil)
           end
 

--- a/sentry-ruby/lib/sentry/threaded_periodic_worker.rb
+++ b/sentry-ruby/lib/sentry/threaded_periodic_worker.rb
@@ -30,10 +30,15 @@ module Sentry
     end
 
     def kill
-      log_debug("[#{self.class.name}] thread killed")
-
       @exited = true
-      @thread&.kill
+
+      # Only a started worker has a thread to kill (and to log about).
+      # Guarding here keeps a never-started worker's teardown silent, so
+      # killing one during test reset can't emit a stray debug line.
+      return unless @thread
+
+      log_debug("[#{self.class.name}] thread killed")
+      @thread.kill
     end
   end
 end

--- a/sentry-ruby/spec/sentry/session_flusher_spec.rb
+++ b/sentry-ruby/spec/sentry/session_flusher_spec.rb
@@ -172,8 +172,14 @@ RSpec.describe Sentry::SessionFlusher do
 
   describe "#kill" do
     it "logs message when killing the thread" do
+      subject.ensure_thread
       subject.kill
       expect(string_io.string).to include("[#{described_class.name}] thread killed")
+    end
+
+    it "stays silent when no thread was ever started" do
+      subject.kill
+      expect(string_io.string).not_to include("thread killed")
     end
   end
 end


### PR DESCRIPTION
Something that came up during ActiveJob PR testing.