### PR TITLE
feat: New set_attribute api

### DIFF
--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -220,6 +220,35 @@ module Sentry
       get_current_scope.set_context(*args)
     end
 
+    # @!method set_attributes
+    #   Updates the current scope's attributes by merging with the old value.
+    #   @param attributes_hash [Hash]
+    #   @return [Hash]
+    def set_attributes(attributes_hash)
+      return unless initialized?
+      get_current_scope.set_attributes(attributes_hash)
+    end
+
+    # @!method set_attribute
+    #   Sets a single attribute on the current scope.
+    #   @param key [String, Symbol]
+    #   @param value [Object]
+    #   @param unit [String, Symbol, nil] an optional measurement unit for the value
+    #   @return [Hash]
+    def set_attribute(key, value, unit: nil)
+      return unless initialized?
+      get_current_scope.set_attribute(key, value, unit: unit)
+    end
+
+    # @!method remove_attribute
+    #   Removes a single attribute from the current scope.
+    #   @param key [String, Symbol]
+    #   @return [void]
+    def remove_attribute(key)
+      return unless initialized?
+      get_current_scope.remove_attribute(key)
+    end
+
     # @!method add_attachment
     #   @!macro add_attachment
     def add_attachment(**opts)

--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "set"
 require "sentry/breadcrumb_buffer"
 require "sentry/propagation_context"
 require "sentry/attachment"
@@ -24,7 +25,8 @@ module Sentry
       :span,
       :session,
       :attachments,
-      :propagation_context
+      :propagation_context,
+      :attributes
     ]
 
     attr_reader(*ATTRIBUTES)
@@ -84,7 +86,15 @@ module Sentry
     # @param telemetry [MetricEvent, LogEvent] the telemetry event to apply scope context to
     # @return [MetricEvent, LogEvent] the telemetry event with scope context applied
     def apply_to_telemetry(telemetry)
-      # TODO-neel when new scope set_attribute api is added: add them here
+      # Compare as strings since String and Symbol keys serialize to the same wire key.
+      existing_keys = telemetry.attributes.keys.map(&:to_s).to_set
+
+      attributes.each do |key, value|
+        next if existing_keys.include?(key)
+
+        telemetry.attributes[key] = value
+      end
+
       trace_context = get_trace_context
       telemetry.trace_id = trace_context[:trace_id]
       telemetry.span_id = trace_context[:span_id]
@@ -136,6 +146,7 @@ module Sentry
       copy.propagation_context = propagation_context.deep_dup
       copy.attachments = attachments.dup
       copy.event_processors = event_processors.dup
+      copy.attributes = attributes.deep_dup
       copy
     end
 
@@ -154,6 +165,7 @@ module Sentry
       self.span = scope.span
       self.propagation_context = scope.propagation_context
       self.attachments = scope.attachments
+      self.attributes = scope.attributes
     end
 
     # Updates the scope's data from the given options.
@@ -254,6 +266,32 @@ module Sentry
     def set_context(key, value)
       check_argument_type!(value, Hash)
       set_contexts(key => value)
+    end
+
+    # Updates the scope's attributes by merging with the old value.
+    # @param attributes_hash [Hash]
+    # @return [Hash]
+    def set_attributes(attributes_hash)
+      check_argument_type!(attributes_hash, Hash)
+      attributes_hash.each { |key, value| @attributes[key.to_s] = value }
+      @attributes
+    end
+
+    # Sets a single attribute on the scope.
+    # @param key [String, Symbol]
+    # @param value [Object]
+    # @param unit [String, Symbol, nil] an optional measurement unit for the value
+    # @return [Hash]
+    def set_attribute(key, value, unit: nil)
+      value = { value: value, unit: unit } unless unit.nil?
+      set_attributes(key => value)
+    end
+
+    # Removes a single attribute from the scope. No-op if the attribute is not set.
+    # @param key [String, Symbol]
+    # @return [void]
+    def remove_attribute(key)
+      @attributes.delete(key.to_s)
     end
 
     # Sets the scope's level attribute.
@@ -361,6 +399,7 @@ module Sentry
       @span = nil
       @session = nil
       @attachments = []
+      @attributes = {}
       generate_propagation_context
       set_new_breadcrumb_buffer
     end

--- a/sentry-ruby/lib/sentry/utils/telemetry_attributes.rb
+++ b/sentry-ruby/lib/sentry/utils/telemetry_attributes.rb
@@ -7,23 +7,35 @@ module Sentry
     module TelemetryAttributes
       private
 
-      def attribute_hash(value)
-        case value
-        when String
-          { value: value, type: "string" }
-        when TrueClass, FalseClass
-          { value: value, type: "boolean" }
-        when Integer
-          { value: value, type: "integer" }
-        when Float
-          { value: value, type: "double" }
+      def attribute_hash(raw_value)
+        if raw_value.is_a?(Hash) && (raw_value.key?(:value) || raw_value.key?("value"))
+          value = raw_value.key?(:value) ? raw_value[:value] : raw_value["value"]
+          unit = raw_value.key?(:unit) ? raw_value[:unit] : raw_value["unit"]
         else
-          begin
-            { value: JSON.generate(value), type: "string" }
-          rescue
-            { value: value, type: "string" }
-          end
+          value = raw_value
+          unit = nil
         end
+
+        result =
+          case value
+          when String
+            { value: value, type: "string" }
+          when TrueClass, FalseClass
+            { value: value, type: "boolean" }
+          when Integer
+            { value: value, type: "integer" }
+          when Float
+            { value: value, type: "double" }
+          else
+            begin
+              { value: JSON.generate(value), type: "string" }
+            rescue
+              { value: value, type: "string" }
+            end
+          end
+
+        result[:unit] = unit.to_s if unit.is_a?(String) || unit.is_a?(Symbol)
+        result
       end
     end
   end

--- a/sentry-ruby/spec/sentry/metric_event_spec.rb
+++ b/sentry-ruby/spec/sentry/metric_event_spec.rb
@@ -117,6 +117,59 @@ RSpec.describe Sentry::MetricEvent do
       expect(attributes["unknown"][:value]).to include("Object")
     end
 
+    it "carries units through the object form" do
+      event = described_class.new(
+        name: "test.metric",
+        type: "counter",
+        value: 1.0,
+        attributes: {
+          "duration_int" => { value: 3600, unit: "second" },
+          "duration_float" => { value: 1.5, unit: "millisecond" },
+          "version" => { value: "v1", unit: "version" },
+          "symbol_unit" => { value: 3600, unit: :second },
+          "invalid_unit" => { value: 1, unit: 5 }
+        }
+      )
+
+      attributes = event.to_h[:attributes]
+
+      expect(attributes["duration_int"]).to eq({ type: "integer", value: 3600, unit: "second" })
+      expect(attributes["duration_float"]).to eq({ type: "double", value: 1.5, unit: "millisecond" })
+      expect(attributes["version"]).to eq({ type: "string", value: "v1", unit: "version" })
+      expect(attributes["symbol_unit"]).to eq({ type: "integer", value: 3600, unit: "second" })
+      expect(attributes["invalid_unit"]).to eq({ type: "integer", value: 1 })
+    end
+
+    it "carries units through the object form with string keys" do
+      event = described_class.new(
+        name: "test.metric",
+        type: "counter",
+        value: 1.0,
+        attributes: {
+          "duration" => { "value" => 3600, "unit" => "second" },
+          "version" => { "value" => "v1" }
+        }
+      )
+
+      attributes = event.to_h[:attributes]
+
+      expect(attributes["duration"]).to eq({ type: "integer", value: 3600, unit: "second" })
+      expect(attributes["version"]).to eq({ type: "string", value: "v1" })
+    end
+
+    it "treats a hash without a value key as a plain JSON string value" do
+      event = described_class.new(
+        name: "test.metric",
+        type: "counter",
+        value: 1.0,
+        attributes: { "obj" => { "foo" => "bar" } }
+      )
+
+      attributes = event.to_h[:attributes]
+
+      expect(attributes["obj"]).to eq({ type: "string", value: "{\"foo\":\"bar\"}" })
+    end
+
     it "does not mutate the original attributes hash" do
       attributes = { "foo" => "bar" }
       event1 = described_class.new(name: "test.metric", type: :counter, value: 1, attributes: attributes)

--- a/sentry-ruby/spec/sentry/metrics_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics_spec.rb
@@ -188,6 +188,34 @@ RSpec.describe "Sentry Metrics" do
         end
       end
 
+      context "with attributes on scope" do
+        it "includes scope attributes with inferred types in the metric" do
+          Sentry.set_attribute("app.flag", true)
+          Sentry.set_attribute("app.duration", 3600, unit: "second")
+
+          Sentry.metrics.count("test.counter")
+
+          Sentry.get_current_client.flush
+
+          attributes = sentry_metrics.first[:attributes]
+
+          expect(attributes["app.flag"]).to eq({ type: "boolean", value: true })
+          expect(attributes["app.duration"]).to eq({ type: "integer", value: 3600, unit: "second" })
+        end
+
+        it "lets metric attributes take precedence over scope attributes" do
+          Sentry.set_attribute("shared", "from_scope")
+
+          Sentry.metrics.count("test.counter", attributes: { "shared" => "from_metric" })
+
+          Sentry.get_current_client.flush
+
+          attributes = sentry_metrics.first[:attributes]
+
+          expect(attributes["shared"]).to eq({ type: "string", value: "from_metric" })
+        end
+      end
+
       it "includes default attributes from configuration" do
         Sentry.metrics.count("test.counter")
 

--- a/sentry-ruby/spec/sentry/scope/setters_spec.rb
+++ b/sentry-ruby/spec/sentry/scope/setters_spec.rb
@@ -228,4 +228,85 @@ RSpec.describe Sentry::Scope do
       expect(subject.fingerprint).to eq(["bar"])
     end
   end
+
+  describe "#set_attributes" do
+    it "merges the given attributes into the scope" do
+      subject.set_attributes("foo" => "bar")
+      subject.set_attributes("baz" => 42)
+
+      expect(subject.attributes).to eq({ "foo" => "bar", "baz" => 42 })
+    end
+
+    it "overwrites an existing attribute with the same key" do
+      subject.set_attributes("foo" => "bar")
+      subject.set_attributes("foo" => "qux")
+
+      expect(subject.attributes).to eq({ "foo" => "qux" })
+    end
+
+    it "normalizes symbol keys to strings" do
+      subject.set_attributes(foo: "bar")
+      subject.set_attributes("foo" => "qux")
+
+      expect(subject.attributes).to eq({ "foo" => "qux" })
+    end
+
+    it "raises when the argument is not a Hash" do
+      expect { subject.set_attributes("foo") }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#set_attribute" do
+    it "sets a single attribute" do
+      subject.set_attribute("foo", "bar")
+
+      expect(subject.attributes).to eq({ "foo" => "bar" })
+    end
+
+    it "overwrites an existing attribute" do
+      subject.set_attribute("foo", "bar")
+      subject.set_attribute("foo", "qux")
+
+      expect(subject.attributes).to eq({ "foo" => "qux" })
+    end
+
+    it "supports the object form with a unit" do
+      subject.set_attribute("duration", { value: 3600, unit: "second" })
+
+      expect(subject.attributes).to eq({ "duration" => { value: 3600, unit: "second" } })
+    end
+
+    it "wraps the value when given the optional unit: param" do
+      subject.set_attribute("duration", 3600, unit: "second")
+
+      expect(subject.attributes).to eq({ "duration" => { value: 3600, unit: "second" } })
+    end
+
+    it "normalizes a symbol key to a string" do
+      subject.set_attribute(:foo, "bar")
+
+      expect(subject.attributes).to eq({ "foo" => "bar" })
+    end
+  end
+
+  describe "#remove_attribute" do
+    it "removes the attribute" do
+      subject.set_attribute("foo", "bar")
+      subject.remove_attribute("foo")
+
+      expect(subject.attributes).to eq({})
+    end
+
+    it "is a no-op when the attribute is not set" do
+      expect { subject.remove_attribute("missing") }.not_to raise_error
+      expect(subject.attributes).to eq({})
+    end
+
+    it "removes an attribute set with a symbol key" do
+      subject.set_attribute(:foo, "bar")
+      subject.remove_attribute(:foo)
+
+      expect(subject.attributes).to eq({})
+    end
+  end
 end

--- a/sentry-ruby/spec/sentry/scope_spec.rb
+++ b/sentry-ruby/spec/sentry/scope_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Sentry::Scope do
       copy.user.merge!(foo: "bar")
       copy.set_transaction_name("foo", source: :url)
       copy.fingerprint << "bar"
+      copy.set_attribute("foo", "bar")
 
       expect(subject.breadcrumbs.to_h).to eq({ values: [] })
       expect(subject.contexts[:os].keys).to match_array([:name, :version, :build, :kernel_version, :machine])
@@ -55,6 +56,7 @@ RSpec.describe Sentry::Scope do
       expect(subject.transaction_name).to eq(nil)
       expect(subject.transaction_source).to eq(nil)
       expect(subject.span).to eq(nil)
+      expect(subject.attributes).to eq({})
     end
 
     it "copies event_processors so mutations don't affect the original" do
@@ -140,6 +142,7 @@ RSpec.describe Sentry::Scope do
       subject.set_transaction_name("WelcomeController#index")
       subject.set_span(Sentry::Transaction.new(op: "foo"))
       subject.set_fingerprint(["foo"])
+      subject.set_attribute("foo", "bar")
       scope_id = subject.object_id
 
       subject.clear
@@ -155,6 +158,7 @@ RSpec.describe Sentry::Scope do
       expect(subject.transaction_name).to eq(nil)
       expect(subject.transaction_source).to eq(nil)
       expect(subject.span).to eq(nil)
+      expect(subject.attributes).to eq({})
     end
   end
 
@@ -543,6 +547,58 @@ RSpec.describe Sentry::Scope do
       end
     end
 
+    shared_examples "telemetry event scope attributes" do
+      it "applies scope attributes with inferred types" do
+        subject.set_attribute("app.flag", true)
+        subject.set_attribute("app.count", 3)
+
+        subject.apply_to_telemetry(telemetry_event)
+        attributes = telemetry_event.to_h[:attributes]
+
+        expect(attributes["app.flag"]).to eq({ value: true, type: "boolean" })
+        expect(attributes["app.count"]).to eq({ value: 3, type: "integer" })
+      end
+
+      it "carries the unit through when set via the object form" do
+        subject.set_attribute("app.duration", { value: 3600, unit: "second" })
+
+        subject.apply_to_telemetry(telemetry_event)
+        attributes = telemetry_event.to_h[:attributes]
+
+        expect(attributes["app.duration"]).to eq({ value: 3600, type: "integer", unit: "second" })
+      end
+
+      it "carries the unit through when set via the unit: param" do
+        subject.set_attribute("app.duration", 3600, unit: "second")
+
+        subject.apply_to_telemetry(telemetry_event)
+        attributes = telemetry_event.to_h[:attributes]
+
+        expect(attributes["app.duration"]).to eq({ value: 3600, type: "integer", unit: "second" })
+      end
+
+      it "does not overwrite an attribute already set on the telemetry item" do
+        telemetry_event.attributes["app.flag"] = false
+        subject.set_attribute("app.flag", true)
+
+        subject.apply_to_telemetry(telemetry_event)
+        attributes = telemetry_event.to_h[:attributes]
+
+        expect(attributes["app.flag"]).to eq({ value: false, type: "boolean" })
+      end
+
+      it "treats String and Symbol keys as the same when applying precedence" do
+        telemetry_event.attributes[:user_id] = 1
+        subject.set_attribute("user_id", 2)
+
+        subject.apply_to_telemetry(telemetry_event)
+        attributes = telemetry_event.to_h[:attributes]
+
+        expect(attributes.keys.map(&:to_s).count("user_id")).to eq(1)
+        expect(attributes[:user_id]).to eq({ value: 1, type: "integer" })
+      end
+    end
+
     context "with MetricEvent" do
       let(:telemetry_event) do
         Sentry::MetricEvent.new(name: "test.metric", type: :counter, value: 1)
@@ -551,6 +607,7 @@ RSpec.describe Sentry::Scope do
       include_examples "telemetry event user data"
       include_examples "telemetry event trace data"
       include_examples "telemetry event default attributes"
+      include_examples "telemetry event scope attributes"
     end
 
     context "with LogEvent" do
@@ -561,6 +618,7 @@ RSpec.describe Sentry::Scope do
       include_examples "telemetry event user data"
       include_examples "telemetry event trace data"
       include_examples "telemetry event default attributes"
+      include_examples "telemetry event scope attributes"
     end
   end
 end

--- a/sentry-ruby/spec/sentry/structured_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/structured_logger_spec.rb
@@ -185,6 +185,34 @@ RSpec.describe Sentry::StructuredLogger do
       end
     end
 
+    describe "with attributes on scope" do
+      it "includes scope attributes with inferred types in the log" do
+        Sentry.set_attribute("app.flag", true)
+        Sentry.set_attribute("app.duration", 3600, unit: "second")
+
+        Sentry.logger.info("Hello World")
+
+        expect(sentry_logs).to_not be_empty
+
+        attributes = sentry_logs.last[:attributes]
+
+        expect(attributes["app.flag"]).to eql({ value: true, type: "boolean" })
+        expect(attributes["app.duration"]).to eql({ value: 3600, type: "integer", unit: "second" })
+      end
+
+      it "lets log attributes take precedence over scope attributes" do
+        Sentry.set_attribute(:shared, "from_scope")
+
+        Sentry.logger.info("Hello World", shared: "from_log")
+
+        expect(sentry_logs).to_not be_empty
+
+        attributes = sentry_logs.last[:attributes]
+
+        expect(attributes[:shared]).to eql({ value: "from_log", type: "string" })
+      end
+    end
+
     describe "using config.before_send_log" do
       let(:transport) do
         Sentry.get_current_client.transport

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -791,6 +791,37 @@ RSpec.describe Sentry do
     end
   end
 
+  describe ".set_attributes" do
+    it "adds attributes to the current scope" do
+      described_class.set_attributes("foo" => "bar", "baz" => 42)
+
+      expect(described_class.get_current_scope.attributes).to eq("foo" => "bar", "baz" => 42)
+    end
+  end
+
+  describe ".set_attribute" do
+    it "adds a single attribute to the current scope" do
+      described_class.set_attribute("foo", "bar")
+
+      expect(described_class.get_current_scope.attributes).to eq("foo" => "bar")
+    end
+
+    it "wraps the value when given the optional unit: param" do
+      described_class.set_attribute("duration", 3600, unit: "second")
+
+      expect(described_class.get_current_scope.attributes).to eq("duration" => { value: 3600, unit: "second" })
+    end
+  end
+
+  describe ".remove_attribute" do
+    it "removes an attribute from the current scope" do
+      described_class.set_attribute("foo", "bar")
+      described_class.remove_attribute("foo")
+
+      expect(described_class.get_current_scope.attributes).to eq({})
+    end
+  end
+
   describe ".add_attachment" do
     it "adds a new attachment to the current scope with provided filename and bytes" do
       described_class.add_attachment(filename: "test.txt", bytes: "test")


### PR DESCRIPTION
Implements the spec at [https://develop.sentry.dev/sdk/foundations/state-management/scopes/attributes/](<https://develop.sentry.dev/sdk/foundations/state-management/scopes/attributes/>)

* `set_attribute(key, value, unit: nil)`
* `set_attributes(attributes_hash)`
* `remove_attribute(key)`
* attributes added to telemetry (logs and metrics for now)

#### Issues

* Resolves: getsentry/sentry-ruby#2992
* Resolves: getsentry/sentry-ruby#2992

Co-Authored-By: Claude Opus 4.8 (1M context) [noreply@anthropic.com](<mailto:noreply@anthropic.com>)