### PR TITLE
Fix trace_id mismatch for logs emitted before Sentry::Rails::CaptureExceptions runs

### DIFF
--- a/sentry-rails/lib/sentry/rails/capture_context.rb
+++ b/sentry-rails/lib/sentry/rails/capture_context.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Sentry
+  module Rails
+    # Establishes the propagation context as early as possible, so anything
+    # logged before +CaptureExceptions+ runs shares the request's trace_id.
+    class CaptureContext
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        return @app.call(env) unless Sentry.initialized?
+
+        Sentry.clone_hub_to_current_thread
+        Sentry.get_current_scope.generate_propagation_context(env)
+        env[Sentry::PropagationContext::ESTABLISHED_ENV_KEY] = true
+
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/sentry-rails/lib/sentry/rails/capture_exceptions.rb
+++ b/sentry-rails/lib/sentry/rails/capture_exceptions.rb
@@ -35,7 +35,7 @@ module Sentry
         end
       end
 
-      def start_transaction(env, scope)
+      def start_transaction(env, scope, established)
         options = {
           name: scope.transaction_name,
           source: scope.transaction_source,
@@ -45,8 +45,8 @@ module Sentry
 
         options.merge!(sampled: false) if @assets_regexp && scope.transaction_name.match?(@assets_regexp)
 
-        transaction = Sentry.continue_trace(env, **options)
-        transaction = Sentry.start_transaction(transaction: transaction, custom_sampling_context: { env: env }, **options)
+        transaction = Sentry.continue_trace(env, established: established, **options)
+        transaction = Sentry.start_transaction(transaction: transaction, custom_sampling_context: { env: env }, established: established, **options)
         attach_queue_time(transaction, env)
         transaction
       end

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "sentry/rails/capture_context"
 require "sentry/rails/capture_exceptions"
 require "sentry/rails/rescued_exception_interceptor"
 require "sentry/rails/backtrace_cleaner"
@@ -8,6 +9,8 @@ module Sentry
   class Railtie < ::Rails::Railtie
     # middlewares can't be injected after initialize
     initializer "sentry.use_rack_middleware" do |app|
+      # placed first so anything logged before CaptureExceptions shares the same trace context
+      app.config.middleware.unshift Sentry::Rails::CaptureContext
       # placed after all the file-sending middlewares so we can avoid unnecessary transactions
       app.config.middleware.insert_after ActionDispatch::ShowExceptions, Sentry::Rails::CaptureExceptions
       # need to place as close to DebugExceptions as possible to intercept most of the exceptions, including those raised by middlewares

--- a/sentry-rails/spec/sentry/rails/capture_context_spec.rb
+++ b/sentry-rails/spec/sentry/rails/capture_context_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Sentry::Rails::CaptureContext do
+  # Records the current scope's trace_id every time it's called, so specs can
+  # compare what a piece of middleware would see at different points in the stack.
+  class CaptureContextSpecProbe
+    def self.captured_trace_ids
+      @captured_trace_ids ||= []
+    end
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      self.class.captured_trace_ids << Sentry.get_current_scope.get_trace_context[:trace_id]
+      @app.call(env)
+    end
+  end
+
+  describe "#call" do
+    before do
+      make_basic_app
+    end
+
+    it "establishes a propagation context and flags the env" do
+      trace_id_in_app = nil
+
+      app = lambda do |env|
+        trace_id_in_app = Sentry.get_current_scope.get_trace_context[:trace_id]
+        [200, {}, ["ok"]]
+      end
+
+      env = Rack::MockRequest.env_for("/test")
+      described_class.new(app).call(env)
+
+      expect(env[Sentry::PropagationContext::ESTABLISHED_ENV_KEY]).to eq(true)
+      expect(trace_id_in_app).to be_a(String)
+    end
+
+    it "is a no-op when Sentry is not initialized" do
+      allow(Sentry).to receive(:initialized?).and_return(false)
+
+      called = false
+      app = lambda do |env|
+        called = true
+        [200, {}, ["ok"]]
+      end
+
+      env = Rack::MockRequest.env_for("/test")
+      described_class.new(app).call(env)
+
+      expect(called).to eq(true)
+      expect(env[Sentry::PropagationContext::ESTABLISHED_ENV_KEY]).to be_nil
+    end
+  end
+
+  context "when composed with CaptureExceptions", type: :request do
+    before do
+      CaptureContextSpecProbe.captured_trace_ids.clear
+    end
+
+    context "without tracing enabled" do
+      before do
+        make_basic_app do |config, app|
+          app.config.middleware.insert_before(Sentry::Rails::CaptureExceptions, CaptureContextSpecProbe)
+          app.config.middleware.insert_after(Sentry::Rails::CaptureExceptions, CaptureContextSpecProbe)
+        end
+      end
+
+      it "keeps the same trace_id before and after CaptureExceptions runs" do
+        get "/world"
+
+        early_trace_id, late_trace_id = CaptureContextSpecProbe.captured_trace_ids
+
+        expect(early_trace_id).to be_a(String)
+        expect(late_trace_id).to eq(early_trace_id)
+      end
+    end
+
+    context "with tracing enabled" do
+      before do
+        make_basic_app do |config, app|
+          config.traces_sample_rate = 1.0
+          app.config.middleware.insert_before(Sentry::Rails::CaptureExceptions, CaptureContextSpecProbe)
+          app.config.middleware.insert_after(Sentry::Rails::CaptureExceptions, CaptureContextSpecProbe)
+        end
+      end
+
+      it "keeps the same trace_id from before CaptureExceptions through the started transaction" do
+        get "/world"
+
+        early_trace_id, late_trace_id = CaptureContextSpecProbe.captured_trace_ids
+
+        expect(early_trace_id).to be_a(String)
+        # the "late" trace_id comes from the actual transaction CaptureExceptions started
+        expect(late_trace_id).to eq(early_trace_id)
+      end
+    end
+  end
+end

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Sentry::Rails, type: :request do
 
     it "inserts middleware to a correct position" do
       app = Rails.application
+      expect(app.middleware.first).to eq(Sentry::Rails::CaptureContext)
       index_of_executor = app.middleware.find_index { |m| m == ActionDispatch::ShowExceptions }
       expect(app.middleware.find_index(Sentry::Rails::CaptureExceptions)).to eq(index_of_executor + 1)
       index_of_debug_exceptions = app.middleware.find_index { |m| m == ActionDispatch::DebugExceptions }

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -118,9 +118,16 @@ module Sentry
       end
     end
 
-    def start_transaction(transaction: nil, custom_sampling_context: {}, instrumenter: :sentry, **options)
+    def start_transaction(transaction: nil, custom_sampling_context: {}, instrumenter: :sentry, established: false, **options)
       return unless configuration.tracing_enabled?
       return unless instrumenter == configuration.instrumenter
+
+      if transaction.nil? && !options.key?(:trace_id) && established
+        # reuse the already-established trace_id instead of generating an unrelated one
+        propagation_context = current_scope.propagation_context
+        options[:trace_id] = propagation_context.trace_id
+        options[:sample_rand] ||= propagation_context.sample_rand
+      end
 
       transaction ||= Transaction.new(**options)
 
@@ -373,8 +380,9 @@ module Sentry
       end.join("\n")
     end
 
-    def continue_trace(env, **options)
-      configure_scope { |s| s.generate_propagation_context(env) }
+    def continue_trace(env, established: false, **options)
+      # don't clobber context an earlier point in the stack already established
+      configure_scope { |s| s.generate_propagation_context(env) } unless established
 
       return nil unless configuration.tracing_enabled?
 

--- a/sentry-ruby/lib/sentry/propagation_context.rb
+++ b/sentry-ruby/lib/sentry/propagation_context.rb
@@ -13,6 +13,11 @@ module Sentry
       "-?([01])?\\z"         # sampled
     )
 
+    # Rack env key signaling that trace context was already established earlier in
+    # the middleware stack (e.g. by +Sentry::Rails::CaptureContext+); consumed once by
+    # +Sentry::Rack::CaptureExceptions+.
+    ESTABLISHED_ENV_KEY = "sentry.trace_context_established"
+
     # An uuid that can be used to identify a trace.
     # @return [String]
     attr_reader :trace_id

--- a/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "sentry/propagation_context"
+
 module Sentry
   module Rack
     class CaptureExceptions
@@ -14,8 +16,11 @@ module Sentry
       def call(env)
         return @app.call(env) unless Sentry.initialized?
 
-        # make sure the current thread has a clean hub
-        Sentry.clone_hub_to_current_thread
+        # consumed atomically, first, so it can't leak into later reuses of this env
+        established = env.delete(Sentry::PropagationContext::ESTABLISHED_ENV_KEY)
+
+        # make sure the current thread has a clean hub, unless it was already established
+        Sentry.clone_hub_to_current_thread unless established
 
         Sentry.with_scope do |scope|
           Sentry.with_session_tracking do
@@ -23,7 +28,7 @@ module Sentry
             scope.set_transaction_name(env["PATH_INFO"], source: :url) if env["PATH_INFO"]
             scope.set_rack_env(env)
 
-            transaction = start_transaction(env, scope)
+            transaction = start_transaction(env, scope, established)
             scope.set_span(transaction) if transaction
 
             begin
@@ -63,7 +68,7 @@ module Sentry
         end
       end
 
-      def start_transaction(env, scope)
+      def start_transaction(env, scope, established)
         options = {
           name: scope.transaction_name,
           source: scope.transaction_source,
@@ -71,8 +76,8 @@ module Sentry
           origin: SPAN_ORIGIN
         }
 
-        transaction = Sentry.continue_trace(env, **options)
-        transaction = Sentry.start_transaction(transaction: transaction, custom_sampling_context: { env: env }, **options)
+        transaction = Sentry.continue_trace(env, established: established, **options)
+        transaction = Sentry.start_transaction(transaction: transaction, custom_sampling_context: { env: env }, established: established, **options)
         attach_queue_time(transaction, env)
         transaction
       end

--- a/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/rack/capture_exceptions_spec.rb
@@ -93,6 +93,70 @@ RSpec.describe 'Sentry::Rack::CaptureExceptions', when: :rack_available? do
       expect(env.key?("sentry.error_event_id")).to eq(false)
     end
 
+    context "when trace context was already established earlier in the stack" do
+      it "does not re-clone the hub and reuses the existing propagation context" do
+        Sentry.clone_hub_to_current_thread
+        Sentry.get_current_scope.generate_propagation_context(env)
+        env[Sentry::PropagationContext::ESTABLISHED_ENV_KEY] = true
+
+        established_propagation_context = Sentry.get_current_scope.propagation_context
+
+        expect(Sentry).not_to receive(:clone_hub_to_current_thread)
+
+        trace_id_in_app = nil
+        app = lambda do |e|
+          trace_id_in_app = Sentry.get_current_scope.get_trace_context[:trace_id]
+          [200, {}, ['okay']]
+        end
+
+        stack = Sentry::Rack::CaptureExceptions.new(app)
+        stack.call(env)
+
+        expect(trace_id_in_app).to eq(established_propagation_context.trace_id)
+      end
+
+      it "deletes the established flag from env so it doesn't leak into later reuses of the same env" do
+        Sentry.clone_hub_to_current_thread
+        Sentry.get_current_scope.generate_propagation_context(env)
+        env[Sentry::PropagationContext::ESTABLISHED_ENV_KEY] = true
+
+        app = ->(_e) { [200, {}, ['okay']] }
+        stack = Sentry::Rack::CaptureExceptions.new(app)
+        stack.call(env)
+
+        expect(env.key?(Sentry::PropagationContext::ESTABLISHED_ENV_KEY)).to eq(false)
+      end
+
+      it "does not reuse a stale established context on a later, unrelated call with the same env" do
+        # Simulates a long-lived connection (e.g. Action Cable) that stores the handshake's
+        # env and reuses it for many separate operations over its lifetime - only the very
+        # first operation immediately following CaptureContext should honor the flag.
+        Sentry.clone_hub_to_current_thread
+        Sentry.get_current_scope.generate_propagation_context(env)
+        env[Sentry::PropagationContext::ESTABLISHED_ENV_KEY] = true
+
+        app = ->(_e) { [200, {}, ['okay']] }
+        stack = Sentry::Rack::CaptureExceptions.new(app)
+        stack.call(env)
+
+        Sentry.clone_hub_to_current_thread
+        propagation_context_before_second_call = Sentry.get_current_scope.propagation_context
+
+        trace_id_in_second_call = nil
+        second_app = lambda do |e|
+          trace_id_in_second_call = Sentry.get_current_scope.get_trace_context[:trace_id]
+          [200, {}, ['okay']]
+        end
+
+        expect(Sentry).to receive(:clone_hub_to_current_thread).and_call_original
+
+        second_stack = Sentry::Rack::CaptureExceptions.new(second_app)
+        second_stack.call(env)
+
+        expect(trace_id_in_second_call).not_to eq(propagation_context_before_second_call.trace_id)
+      end
+    end
+
     context "with config.include_local_variables = true" do
       before do
         perform_basic_setup do |config|

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -445,6 +445,61 @@ RSpec.describe Sentry do
   end
 
   describe ".start_transaction" do
+    describe "when not continuing an existing trace" do
+      before do
+        perform_basic_setup do |config|
+          config.traces_sample_rate = 1.0
+        end
+      end
+
+      it "does not adopt the scope's propagation context when it wasn't established for this call" do
+        propagation_context = Sentry.get_current_scope.propagation_context
+
+        transaction = described_class.start_transaction(name: "test", op: "test.op")
+
+        # each independent call gets its own, unrelated trace_id by default - only
+        # calls made with established: true (e.g. a Rack request that went through
+        # Sentry::Rails::CaptureContext) adopt the scope's propagation context
+        expect(transaction.trace_id).not_to eq(propagation_context.trace_id)
+      end
+
+      context "when the scope's propagation context was established for this call" do
+        before do
+          Sentry.get_current_scope.generate_propagation_context
+        end
+
+        it "adopts the scope's propagation context trace_id and sample_rand" do
+          propagation_context = Sentry.get_current_scope.propagation_context
+
+          transaction = described_class.start_transaction(
+            name: "test", op: "test.op", established: true
+          )
+
+          expect(transaction.trace_id).to eq(propagation_context.trace_id)
+          expect(transaction.sample_rand).to eq(propagation_context.sample_rand)
+        end
+
+        it "does not override an explicitly provided trace_id" do
+          transaction = described_class.start_transaction(
+            name: "test", op: "test.op", trace_id: "a" * 32, established: true
+          )
+
+          expect(transaction.trace_id).to eq("a" * 32)
+        end
+
+        it "does not override an explicitly provided sample_rand" do
+          propagation_context = Sentry.get_current_scope.propagation_context
+
+          transaction = described_class.start_transaction(
+            name: "test", op: "test.op", sample_rand: 0.999999, established: true
+          )
+
+          expect(transaction.trace_id).to eq(propagation_context.trace_id)
+          expect(transaction.sample_rand).to eq(0.999999)
+        end
+      end
+    end
+
     describe "sampler example" do
       before do
         perform_basic_setup do |config|
@@ -1037,6 +1092,17 @@ RSpec.describe Sentry do
 
         propagation_context = Sentry.get_current_scope.propagation_context
         expect(propagation_context.incoming_trace).to eq(false)
+      end
+
+      context "when trace context was already established for this call" do
+        it "does not regenerate the scope's propagation context" do
+          existing_propagation_context = Sentry.get_current_scope.propagation_context
+
+          expect(Sentry.get_current_scope).not_to receive(:generate_propagation_context)
+          described_class.continue_trace(env, established: true)
+
+          expect(Sentry.get_current_scope.propagation_context).to eq(existing_propagation_context)
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #3015

### Problem

`Sentry::Rails::CaptureExceptions` is deliberately positioned right after `ActionDispatch::ShowExceptions` (to skip transaction creation for static asset requests). That means anything logged *before* it runs - most notably Rails' own `Rails::Rack::Logger` "Started ..." line - gets a `trace_id`/`span_id` unrelated to the rest of the request, because no trace context has been established yet.

There's also a second, compounding issue: even once `CaptureExceptions` does run, if the request isn't continuing an incoming distributed trace, `Hub#start_transaction`'s fallback (`Transaction.new(**options)`) generates its own independent `trace_id`, ignoring whatever was already on the scope's propagation context.

### Fix

- New `Sentry::Rails::CaptureContext` middleware, unshifted to the very front of the Rails middleware stack. It only establishes the propagation context (from incoming `sentry-trace`/`baggage` headers, if present) as early as possible - it doesn't start a transaction or capture exceptions, so `CaptureExceptions`'s existing position/behavior is untouched.
- `Sentry::PropagationContext::ESTABLISHED_ENV_KEY` - a new env flag signaling that trace context was already established for this exact request.
- `Sentry::Rack::CaptureExceptions` reads and deletes this flag from `env` atomically, as the very first thing it does (before anything else that could raise), so it can never leak into later, unrelated reuses of the same `env` (e.g. Action Cable holding onto the handshake env for a connection's lifetime). It skips re-cloning the hub when the flag was present, and passes the result explicitly as an `established:` argument to `Hub#continue_trace` and `Hub#start_transaction`.
- `Hub#continue_trace` skips regenerating the propagation context when `established: true`, instead of clobbering what `CaptureContext` set up.
- `Hub#start_transaction`, when not continuing a distributed trace and `established: true`, builds the new transaction with the already-established trace_id/sample_rand instead of generating an unrelated one.

The `start_transaction` change is intentionally scoped to only apply when the `established:` flag is passed (rather than always reusing whatever's on the scope), to avoid incorrectly linking together unrelated transactions that happen to share a thread (e.g. separate background jobs) - each of those still gets its own independent trace_id as before. This was verified against a regression in `sentry-rails`' ActiveJob distributed-tracing specs during development.

### Testing

- Added `sentry-rails/spec/sentry/rails/capture_context_spec.rb`, including an integration-style test that reproduces the original bug (probe middleware inserted before/after `CaptureExceptions`) both with and without tracing enabled.
- Added unit coverage in `sentry-ruby`'s `hub`/`capture_exceptions` specs for the new established-context guard behavior.
- Updated `sentry-rails`' existing middleware-ordering spec to assert `CaptureContext` is the first middleware.
- Ran the full `sentry-ruby` and `sentry-rails` suites locally; no regressions (Redis-dependent specs fail identically with/without this change due to no local Redis server, pre-existing/environment-only).