### PR TITLE
fix: Correct typo in Scope#update_from_options parameter documentation

### DIFF
--- a/sentry-ruby/lib/sentry/scope.rb
+++ b/sentry-ruby/lib/sentry/scope.rb
@@ -170,7 +170,7 @@ module Sentry
 
     # Updates the scope's data from the given options.
     # @param contexts [Hash]
-    # @param extras [Hash]
+    # @param extra [Hash]
     # @param tags [Hash]
     # @param user [Hash]
     # @param level [String, Symbol]


### PR DESCRIPTION
## Description

Corrects the YARD documentation for `Scope#update_from_options` to use the actual `extra` keyword parameter instead of `extras`.

I found the typo while digging in the source code, trying to understand how the `extra` argument works.

## Tests

Not run (documentation-only change).

#skip-changelog