### PR TITLE
feat(data-collection): Add sensitive key-value collection filter

### DIFF
--- a/sentry-ruby/lib/sentry/data_collection.rb
+++ b/sentry-ruby/lib/sentry/data_collection.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "sentry/data_collection/key_value_collection"
+
 module Sentry
   class DataCollection
     # Configuration for the categories of data collected by the SDK.
@@ -33,25 +35,6 @@ module Sentry
       incoming_response
       outgoing_response
     ].freeze
-
-    # Configuration for key-value data collection.
-    class KeyValueCollection
-      # `mode` controls whether values are collected:
-      # - `:off` disables collection.
-      # - `:deny_list` collects values except those matching `terms`.
-      # - `:allow_list` collects only values matching `terms`.
-      # @return [:off, :deny_list, :allow_list]
-      attr_accessor :mode
-
-      # `terms` contains the keys or patterns used by the selected mode.
-      # @return [Array<String>, nil]
-      attr_accessor :terms
-
-      def initialize(mode:, terms:)
-        @mode = mode
-        @terms = terms
-      end
-    end
 
     class HttpHeaders
       # @return [KeyValueCollection]

--- a/sentry-ruby/lib/sentry/data_collection/key_value_collection.rb
+++ b/sentry-ruby/lib/sentry/data_collection/key_value_collection.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Sentry
+  class DataCollection
+    # Configuration for key-value data collection.
+    class KeyValueCollection
+      FILTERED_VALUE = "[Filtered]"
+
+      # Keys from this list are ALWAYS filtered, regardless of :mode
+      # TODO-neel-data cookies have separate list, see JS
+      SENSITIVE_DENY_LIST = %w[
+        auth
+        token
+        secret
+        session
+        password
+        passwd
+        pwd
+        key
+        jwt
+        bearer
+        sso
+        saml
+        csrf
+        xsrf
+        credentials
+        sid
+        identity
+        cookie
+        set-cookie
+      ].freeze
+
+      # `mode` controls whether values are collected:
+      # - `:off` disables collection.
+      # - `:deny_list` collects values except those matching `terms`.
+      # - `:allow_list` collects only values matching `terms`.
+      # @return [:off, :deny_list, :allow_list]
+      attr_accessor :mode
+
+      # `terms` contains the keys or patterns used by the selected mode.
+      # @return [Array<String>, nil]
+      attr_reader :terms
+
+      def initialize(mode:, terms:)
+        @mode = mode
+        self.terms = terms
+      end
+
+      def terms=(terms)
+        @terms = terms&.map { |term| term.to_s.downcase }&.reject { |term| term.strip.empty? }
+      end
+
+      # Applies this collection configuration without changing the input hash.
+      # Keys are retained whenever the category is collected; values that are not
+      # safe to send are replaced with FILTERED_VALUE.
+      #
+      # @param values [Hash] key-value data to filter
+      # @return [Hash] a new filtered hash, or an empty hash when collection is off
+      def filter(values)
+        return {} if mode == :off
+
+        values.each_with_object({}) do |(key, value), filtered|
+          filtered[key] = safe_value?(key) ? value : FILTERED_VALUE
+        end
+      end
+
+      private
+
+      def safe_value?(key)
+        key_downcase = key.to_s.downcase
+        return false if sensitive?(key_downcase)
+
+        case mode
+        when :deny_list
+          !matches_any_term?(key_downcase)
+        when :allow_list
+          matches_any_term?(key_downcase)
+        else
+          false
+        end
+      end
+
+      def sensitive?(key)
+        SENSITIVE_DENY_LIST.any? { |term| key.include?(term) }
+      end
+
+      def matches_any_term?(key)
+        @terms&.any? { |term| key.include?(term) }
+      end
+    end
+  end
+end

--- a/sentry-ruby/spec/sentry/data_collection/key_value_collection_spec.rb
+++ b/sentry-ruby/spec/sentry/data_collection/key_value_collection_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "sentry/data_collection/key_value_collection"
+
+RSpec.describe Sentry::DataCollection::KeyValueCollection do
+  subject(:collection) { described_class.new(mode: mode, terms: terms) }
+
+  let(:values) do
+    {
+      "Authorization" => "secret-token",
+      "page" => "2",
+      "display_name" => "Ada",
+      42 => "numeric key"
+    }
+  end
+  let(:mode) { :deny_list }
+  let(:terms) { nil }
+
+  describe "#filter" do
+    it "uses the collection configuration" do
+      expect(collection.filter(values)).to eq(
+        "Authorization" => "[Filtered]",
+        "page" => "2",
+        "display_name" => "Ada",
+        42 => "numeric key"
+      )
+    end
+
+    context "when mode is :off" do
+      let(:mode) { :off }
+
+      it "does not collect keys or values" do
+        expect(collection.filter(values)).to eq({})
+      end
+    end
+
+    context "when mode is :deny_list" do
+      it "matches sensitive terms partially and case-insensitively" do
+        expect(described_class.new(mode: :deny_list, terms: nil).filter(
+          { "X-Auth-Token" => "a", "ACCESS_SECRET_VALUE" => "b", "random_field" => "c" }
+        )).to eq(
+          "X-Auth-Token" => "[Filtered]",
+          "ACCESS_SECRET_VALUE" => "[Filtered]",
+          "random_field" => "c"
+        )
+      end
+
+      it "applies additional deny terms" do
+        expect(described_class.new(mode: :deny_list, terms: ["USER", :internal]).filter(
+          { "user_id" => "1", "internal" => "value" }
+        )).to eq(
+          "user_id" => "[Filtered]",
+          "internal" => "[Filtered]"
+        )
+      end
+
+      it "normalizes terms assigned after initialization" do
+        collection.terms = ["USER"]
+
+        expect(collection.filter("user_id" => "1")).to eq("user_id" => "[Filtered]")
+      end
+
+      it "covers every built-in sensitive term (case insensitive) and leaves other keys unchanged" do
+        sensitive_values = Sentry::DataCollection::KeyValueCollection::SENSITIVE_DENY_LIST.flat_map do |term|
+          [
+            ["prefix-#{term}-suffix", "value"],
+            ["prefix-#{term.upcase}-suffix", "value"]
+          ]
+        end.to_h
+
+        values = sensitive_values.merge("page" => "2", "display_name" => "Ada")
+
+        expect(collection.filter(values)).to eq(
+          sensitive_values.transform_values { "[Filtered]" }.merge(
+            "page" => "2",
+            "display_name" => "Ada"
+          )
+        )
+      end
+    end
+
+    context "when mode is :allow_list" do
+      let(:mode) { :allow_list }
+      let(:terms) { ["page", "display"] }
+
+      it "filters values whose keys are not allowed" do
+        expect(collection.filter(values)).to eq(
+          "Authorization" => "[Filtered]",
+          "page" => "2",
+          "display_name" => "Ada",
+          42 => "[Filtered]"
+        )
+      end
+
+      it "still filters sensitive keys listed in the allow list" do
+        expect(described_class.new(mode: :allow_list, terms: ["token", "public"]).filter(
+          { "token" => "secret", "public" => "value" }
+        )).to eq("token" => "[Filtered]", "public" => "value")
+      end
+
+      it "does not allow every key when terms include nil or blank values" do
+        expect(described_class.new(mode: :allow_list, terms: [nil, "", "  "]).filter(
+          { "public" => "value", "page" => "2" }
+        )).to eq("public" => "[Filtered]", "page" => "[Filtered]")
+      end
+    end
+
+    it "does not mutate the input" do
+      original = values.dup
+      collection.filter(values)
+
+      expect(values).to eq(original)
+    end
+  end
+end


### PR DESCRIPTION
## Description

* Implement `KeyValueCollection` filtering behavior for `:off, :allow_list, :deny_list`
* Sensitive list is filtered regardless of mode

## Issues

* resolves: getsentry/sentry-ruby#3001
* resolves: RUBY-189

---

Stack created with [GitHub Stacks CLI](<https://github.com/github/gh-stack>) • [Give Feedback 💬](<https://gh.io/stacks-feedback>)