### PR TITLE
chore(ci): temporarly increase timeout

### DIFF
--- a/.github/workflows/gem_test.yml
+++ b/.github/workflows/gem_test.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: ${{ inputs.gem }}
     name: ${{ toJson(matrix) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     services:
       redis:
         image: ghcr.io/getsentry/image-mirror-library-redis:7.0.8-bullseye


### PR DESCRIPTION
This should decrease the flaky failures from the problematic AJ spec. I'll figure out why it so sluggish in a follow-up PR and address it there properly w/o increasing the timeout.

---

#skip-changelog