### PR TITLE
feat(data-collection): Port redis, net:http, faraday and excon

### DIFF
--- a/sentry-ruby/lib/sentry/data_collection.rb
+++ b/sentry-ruby/lib/sentry/data_collection.rb
@@ -157,9 +157,15 @@ module Sentry
     end
 
     # Returns whether incoming HTTP request bodies should be collected.
-    # nil imples all BODY_TYPES according to spec
+    # nil implies all BODY_TYPES according to spec
     def collect_incoming_http_body?
       http_bodies.nil? || http_bodies.include?(:incoming_request)
+    end
+
+    # Returns whether outgoing HTTP request bodies should be collected.
+    # nil implies all BODY_TYPES according to spec
+    def collect_outgoing_http_body?
+      http_bodies.nil? || http_bodies.include?(:outgoing_request)
     end
   end
 end

--- a/sentry-ruby/lib/sentry/excon/middleware.rb
+++ b/sentry-ruby/lib/sentry/excon/middleware.rb
@@ -61,14 +61,9 @@ module Sentry
         url = env[:scheme] + "://" + env[:hostname] + env[:path]
         result = { method: env[:method].to_s.upcase, url: url }
 
-        if Sentry.configuration.send_default_pii
-          result[:query] = env[:query]
-
-          # Handle excon 1.0.0+
-          result[:query] = build_nested_query(result[:query]) unless result[:query].is_a?(String)
-
-          result[:body] = env[:body]
-        end
+        query = filter_query_params(env[:query])
+        result[:query] = query if query
+        result[:body] = env[:body] if Sentry.configuration.data_collection.collect_outgoing_http_body?
 
         result
       end

--- a/sentry-ruby/lib/sentry/faraday.rb
+++ b/sentry-ruby/lib/sentry/faraday.rb
@@ -59,10 +59,9 @@ module Sentry
         url = env[:url].scheme + "://" + env[:url].host + env[:url].path
         result = { method: env[:method].to_s.upcase, url: url }
 
-        if Sentry.configuration.send_default_pii
-          result[:query] = env[:url].query
-          result[:body] = env[:body]
-        end
+        query = filter_query_params(env[:url].query)
+        result[:query] = query if query
+        result[:body] = env[:body] if Sentry.configuration.data_collection.collect_outgoing_http_body?
 
         result
       end

--- a/sentry-ruby/lib/sentry/net/http.rb
+++ b/sentry-ruby/lib/sentry/net/http.rb
@@ -72,10 +72,9 @@ module Sentry
 
         result = { method: req.method, url: url }
 
-        if Sentry.configuration.send_default_pii
-          result[:query] = uri.query
-          result[:body] = req.body
-        end
+        query = filter_query_params(uri.query)
+        result[:query] = query if query
+        result[:body] = req.body if Sentry.configuration.data_collection.collect_outgoing_http_body?
 
         result
       end

--- a/sentry-ruby/lib/sentry/redis.rb
+++ b/sentry-ruby/lib/sentry/redis.rb
@@ -62,7 +62,7 @@ module Sentry
         command_set = { command: command.to_s.upcase }
         command_set[:key] = key if Utils::EncodingHelper.valid_utf_8?(key)
 
-        if Sentry.configuration.send_default_pii
+        if Sentry.configuration.data_collection.database_query_data
           command_set[:arguments] = arguments
                                     .select { |a| Utils::EncodingHelper.valid_utf_8?(a) }
                                     .join(" ")

--- a/sentry-ruby/lib/sentry/utils/http_tracing.rb
+++ b/sentry-ruby/lib/sentry/utils/http_tracing.rb
@@ -1,11 +1,39 @@
 # frozen_string_literal: true
 
+require "uri"
+
 module Sentry
   module Utils
     module HttpTracing
+      def filter_query_params(query)
+        return nil unless query
+        return nil unless query.is_a?(String) || query.is_a?(Hash)
+
+        query_hash = if query.is_a?(String)
+          URI.decode_www_form(query).each_with_object({}) do |(key, value), params|
+            params[key] = params.key?(key) ? Array(params[key]) + [value] : value
+          end
+        else
+          query
+        end
+
+        filtered_query_hash = Sentry.configuration.data_collection.url_query_params.filter(query_hash)
+        return nil if filtered_query_hash.empty?
+
+        format_query(filtered_query_hash)
+      rescue
+        nil
+      end
+
+      def format_query(query)
+        query.flat_map do |key, value|
+          Array(value).map { |item| "#{key}=#{item}" }
+        end.join("&")
+      end
+
       def set_span_info(sentry_span, request_info, response_status)
         sentry_span.set_description("#{request_info[:method]} #{request_info[:url]}")
-        sentry_span.set_data(Span::DataConventions::URL, request_info[:url])
+        sentry_span.set_data(Span::DataConventions::URL, url_with_query(request_info))
         sentry_span.set_data(Span::DataConventions::HTTP_METHOD, request_info[:method])
         sentry_span.set_data(Span::DataConventions::HTTP_QUERY, request_info[:query]) if request_info[:query]
         sentry_span.set_data(Span::DataConventions::HTTP_STATUS_CODE, response_status)
@@ -43,37 +71,25 @@ module Sentry
           Sentry.configuration.trace_propagation_targets.any? { |target| url.match?(target) }
       end
 
-      # Kindly borrowed from Rack::Utils
-      def build_nested_query(value, prefix = nil)
-        case value
-        when Array
-          value.map { |v|
-            build_nested_query(v, "#{prefix}[]")
-          }.join("&")
-        when Hash
-          value.map { |k, v|
-            build_nested_query(v, prefix ? "#{prefix}[#{k}]" : k)
-          }.delete_if(&:empty?).join("&")
-        when nil
-          URI.encode_www_form_component(prefix)
-        else
-          raise ArgumentError, "value must be a Hash" if prefix.nil?
-          "#{URI.encode_www_form_component(prefix)}=#{URI.encode_www_form_component(value)}"
-        end
-      end
 
       private
+
+      def url_with_query(request_info)
+        return request_info[:url] unless request_info[:query]
+
+        "#{request_info[:url]}?#{request_info[:query]}"
+      end
 
       def get_level(status)
         return :info unless status && status.is_a?(Integer)
 
-if status >= 500
-  :error
-elsif status >= 400
-  :warning
-else
-  :info
-end
+        if status >= 500
+          :error
+        elsif status >= 400
+          :warning
+        else
+          :info
+        end
       end
     end
   end

--- a/sentry-ruby/spec/sentry/excon_spec.rb
+++ b/sentry-ruby/spec/sentry/excon_spec.rb
@@ -56,6 +56,85 @@ RSpec.describe "Sentry::Excon" do
       end
     end
 
+    describe "data collection" do
+      describe "query parameters" do
+        def perform_get_request(query: "token=secret&page=5")
+          transaction = Sentry.start_transaction
+          Sentry.get_current_scope.set_span(transaction)
+          Excon.stub({}, { body: "", status: 200 })
+          Excon.get("http://example.com/path?#{query}", mock: true)
+          transaction
+        end
+
+        it "does not collect them when the mode is off" do
+          Sentry.configuration.data_collection.url_query_params.mode = :off
+          transaction = perform_get_request
+
+          expect(transaction.span_recorder.spans.last.data).not_to have_key("http.query")
+          expect(transaction.span_recorder.spans.last.data["url"]).to eq("http://example.com/path")
+        end
+
+        it "filters sensitive values in deny-list mode" do
+          Sentry.configuration.data_collection.url_query_params.mode = :deny_list
+          transaction = perform_get_request
+
+          expect(transaction.span_recorder.spans.last.data["http.query"]).to eq(
+            "token=[Filtered]&page=5"
+          )
+          expect(transaction.span_recorder.spans.last.data["url"]).to eq(
+            "http://example.com/path?token=[Filtered]&page=5"
+          )
+        end
+
+        it "collects only allowed values in allow-list mode" do
+          Sentry.configuration.data_collection.url_query_params.mode = :allow_list
+          Sentry.configuration.data_collection.url_query_params.terms = ["page"]
+          transaction = perform_get_request(query: "another=value&page=5")
+
+          expect(transaction.span_recorder.spans.last.data["http.query"]).to eq(
+            "another=[Filtered]&page=5"
+          )
+          expect(transaction.span_recorder.spans.last.data["url"]).to eq(
+            "http://example.com/path?another=[Filtered]&page=5"
+          )
+        end
+      end
+
+      describe "request bodies" do
+        before do
+          Sentry.configuration.breadcrumbs_logger = [:http_logger]
+        end
+
+        def perform_post_request
+          transaction = Sentry.start_transaction
+          Sentry.get_current_scope.set_span(transaction)
+          Excon.stub({}, { body: "", status: 200 })
+          Excon.post("http://example.com/path", body: "secret body", mock: true)
+        end
+
+        it "collects them when all body types are enabled" do
+          Sentry.configuration.data_collection.http_bodies = nil
+          perform_post_request
+
+          expect(Sentry.get_current_scope.breadcrumbs.peek.data[:body]).to eq("secret body")
+        end
+
+        it "collects them when outgoing requests are enabled" do
+          Sentry.configuration.data_collection.http_bodies = [:outgoing_request]
+          perform_post_request
+
+          expect(Sentry.get_current_scope.breadcrumbs.peek.data[:body]).to eq("secret body")
+        end
+
+        it "does not collect them when body types are disabled" do
+          Sentry.configuration.data_collection.http_bodies = []
+          perform_post_request
+
+          expect(Sentry.get_current_scope.breadcrumbs.peek.data).not_to have_key(:body)
+        end
+      end
+    end
+
     context "with config.send_default_pii = true" do
       before do
         Sentry.configuration.send_default_pii = true
@@ -82,7 +161,7 @@ RSpec.describe "Sentry::Excon" do
         expect(request_span.description).to eq("GET http://example.com/path")
         expect(request_span.data).to eq({
           "http.response.status_code" => 200,
-          "url" => "http://example.com/path",
+          "url" => "http://example.com/path?foo=bar",
           "http.request.method" => "GET",
           "http.query" => "foo=bar"
         })
@@ -95,7 +174,7 @@ RSpec.describe "Sentry::Excon" do
         Sentry.get_current_scope.set_span(transaction)
 
         connection = Excon.new("http://example.com/path")
-        response = connection.get(mock: true, query: build_nested_query({ foo: "bar", baz: [1, 2], qux: { a: 1, b: 2 } }))
+        response = connection.get(mock: true, query: "foo=bar&baz[]=1&baz[]=2&qux[a]=1&qux[b]=2")
 
         expect(response.status).to eq(200)
         expect(transaction.span_recorder.spans.count).to eq(2)
@@ -109,9 +188,9 @@ RSpec.describe "Sentry::Excon" do
         expect(request_span.description).to eq("GET http://example.com/path")
         expect(request_span.data).to eq({
           "http.response.status_code" => 200,
-          "url" => "http://example.com/path",
+          "url" => "http://example.com/path?foo=bar&baz[]=1&baz[]=2&qux[a]=1&qux[b]=2",
           "http.request.method" => "GET",
-          "http.query" => "foo=bar&baz%5B%5D=1&baz%5B%5D=2&qux%5Ba%5D=1&qux%5Bb%5D=2"
+          "http.query" => "foo=bar&baz[]=1&baz[]=2&qux[a]=1&qux[b]=2"
         })
       end
 

--- a/sentry-ruby/spec/sentry/faraday_spec.rb
+++ b/sentry-ruby/spec/sentry/faraday_spec.rb
@@ -57,6 +57,95 @@ RSpec.describe Sentry::Faraday do
       end
     end
 
+    describe "data collection" do
+      describe "query parameters" do
+        let(:http) do
+          Faraday.new("http://example.com") do |f|
+            f.adapter Faraday::Adapter::Test do |stub|
+              stub.get("/test") { [200, {}, ""] }
+            end
+          end
+        end
+
+        it "does not collect them when the mode is off" do
+          Sentry.configuration.data_collection.url_query_params.mode = :off
+          transaction = Sentry.start_transaction
+          Sentry.get_current_scope.set_span(transaction)
+
+          http.get("/test?token=secret&page=5")
+
+          expect(transaction.span_recorder.spans.last.data).not_to have_key("http.query")
+          expect(transaction.span_recorder.spans.last.data["url"]).to eq("http://example.com/test")
+        end
+
+        it "filters sensitive values in deny-list mode" do
+          Sentry.configuration.data_collection.url_query_params.mode = :deny_list
+          transaction = Sentry.start_transaction
+          Sentry.get_current_scope.set_span(transaction)
+
+          http.get("/test?token=secret&page=5")
+
+          expect(transaction.span_recorder.spans.last.data["http.query"]).to eq(
+            "page=5&token=[Filtered]"
+          )
+          expect(transaction.span_recorder.spans.last.data["url"]).to eq(
+            "http://example.com/test?page=5&token=[Filtered]"
+          )
+        end
+
+        it "collects only allowed values in allow-list mode" do
+          Sentry.configuration.data_collection.url_query_params.mode = :allow_list
+          Sentry.configuration.data_collection.url_query_params.terms = ["page"]
+          transaction = Sentry.start_transaction
+          Sentry.get_current_scope.set_span(transaction)
+
+          http.get("/test?another=value&page=5")
+
+          expect(transaction.span_recorder.spans.last.data["http.query"]).to eq(
+            "another=[Filtered]&page=5"
+          )
+          expect(transaction.span_recorder.spans.last.data["url"]).to eq(
+            "http://example.com/test?another=[Filtered]&page=5"
+          )
+        end
+      end
+
+      describe "request bodies" do
+        let(:http) do
+          Faraday.new("http://example.com") do |f|
+            f.adapter Faraday::Adapter::Test do |stub|
+              stub.post("/test") { [200, {}, ""] }
+            end
+          end
+        end
+
+        before do
+          Sentry.configuration.breadcrumbs_logger = [:http_logger]
+        end
+
+        it "collects them when all body types are enabled" do
+          Sentry.configuration.data_collection.http_bodies = nil
+          http.post("/test", "secret body")
+
+          expect(Sentry.get_current_scope.breadcrumbs.peek.data[:body]).to eq("secret body")
+        end
+
+        it "collects them when outgoing requests are enabled" do
+          Sentry.configuration.data_collection.http_bodies = [:outgoing_request]
+          http.post("/test", "secret body")
+
+          expect(Sentry.get_current_scope.breadcrumbs.peek.data[:body]).to eq("secret body")
+        end
+
+        it "does not collect them when body types are disabled" do
+          Sentry.configuration.data_collection.http_bodies = []
+          http.post("/test", "secret body")
+
+          expect(Sentry.get_current_scope.breadcrumbs.peek.data).not_to have_key(:body)
+        end
+      end
+    end
+
     context "with config.send_default_pii = true" do
       let(:http) do
         Faraday.new(url) do |f|
@@ -103,7 +192,7 @@ RSpec.describe Sentry::Faraday do
 
         expect(request_span.data).to eq({
           "http.response.status_code" => 200,
-          "url" => "http://example.com/test",
+          "url" => "http://example.com/test?foo=bar",
           "http.request.method" => "GET",
           "http.query" => "foo=bar"
         })
@@ -157,7 +246,7 @@ RSpec.describe Sentry::Faraday do
 
         expect(request_span.data).to eq({
           "http.response.status_code" => 200,
-          "url" => "http://example.com/test",
+          "url" => "http://example.com/test?foo=bar",
           "http.request.method" => "POST",
           "http.query" => "foo=bar"
         })

--- a/sentry-ruby/spec/sentry/net/http_spec.rb
+++ b/sentry-ruby/spec/sentry/net/http_spec.rb
@@ -39,6 +39,90 @@ RSpec.describe Sentry::Net::HTTP do
       end
     end
 
+    describe "data collection" do
+      describe "query parameters" do
+        it "does not collect them when the mode is off" do
+          Sentry.configuration.data_collection.url_query_params.mode = :off
+          stub_normal_response
+
+          transaction = Sentry.start_transaction
+          Sentry.get_current_scope.set_span(transaction)
+          Net::HTTP.get_response(URI("http://example.com/path?token=secret&page=5"))
+
+          expect(transaction.span_recorder.spans.last.data).not_to have_key("http.query")
+          expect(transaction.span_recorder.spans.last.data["url"]).to eq("http://example.com/path")
+        end
+
+        it "filters sensitive values in deny-list mode" do
+          Sentry.configuration.data_collection.url_query_params.mode = :deny_list
+          stub_normal_response
+          transaction = Sentry.start_transaction
+          Sentry.get_current_scope.set_span(transaction)
+
+          Net::HTTP.get_response(URI("http://example.com/path?token=secret&page=5"))
+
+          expect(transaction.span_recorder.spans.last.data["http.query"]).to eq(
+            "token=[Filtered]&page=5"
+          )
+          expect(transaction.span_recorder.spans.last.data["url"]).to eq(
+            "http://example.com/path?token=[Filtered]&page=5"
+          )
+        end
+
+        it "collects only allowed values in allow-list mode" do
+          Sentry.configuration.data_collection.url_query_params.mode = :allow_list
+          Sentry.configuration.data_collection.url_query_params.terms = ["page"]
+          stub_normal_response
+          transaction = Sentry.start_transaction
+          Sentry.get_current_scope.set_span(transaction)
+
+          Net::HTTP.get_response(URI("http://example.com/path?another=value&page=5"))
+
+          expect(transaction.span_recorder.spans.last.data["http.query"]).to eq(
+            "another=[Filtered]&page=5"
+          )
+          expect(transaction.span_recorder.spans.last.data["url"]).to eq(
+            "http://example.com/path?another=[Filtered]&page=5"
+          )
+        end
+      end
+
+      describe "request bodies" do
+        before do
+          Sentry.configuration.breadcrumbs_logger = [:http_logger]
+        end
+
+        def perform_post_request
+          stub_normal_response
+          http = Net::HTTP.new("example.com")
+          request = Net::HTTP::Post.new("/path")
+          request.body = "secret body"
+          http.request(request)
+        end
+
+        it "collects them when all body types are enabled" do
+          Sentry.configuration.data_collection.http_bodies = nil
+          perform_post_request
+
+          expect(Sentry.get_current_scope.breadcrumbs.peek.data[:body]).to eq("secret body")
+        end
+
+        it "collects them when outgoing requests are enabled" do
+          Sentry.configuration.data_collection.http_bodies = [:outgoing_request]
+          perform_post_request
+
+          expect(Sentry.get_current_scope.breadcrumbs.peek.data[:body]).to eq("secret body")
+        end
+
+        it "does not collect them when body types are disabled" do
+          Sentry.configuration.data_collection.http_bodies = []
+          perform_post_request
+
+          expect(Sentry.get_current_scope.breadcrumbs.peek.data).not_to have_key(:body)
+        end
+      end
+    end
+
     context "with config.send_default_pii = true" do
       before do
         Sentry.configuration.send_default_pii = true
@@ -64,7 +148,7 @@ RSpec.describe Sentry::Net::HTTP do
         expect(request_span.description).to eq("GET http://example.com/path")
         expect(request_span.data).to eq({
           "http.response.status_code" => 200,
-          "url" => "http://example.com/path",
+          "url" => "http://example.com/path?foo=bar",
           "http.request.method" => "GET",
           "http.query" => "foo=bar"
         })

--- a/sentry-ruby/spec/sentry/redis_spec.rb
+++ b/sentry-ruby/spec/sentry/redis_spec.rb
@@ -10,6 +10,28 @@ RSpec.describe Sentry::Redis do
       end
     end
 
+    describe "data collection" do
+      describe "database query data" do
+        it "collects Redis arguments when database query data is enabled" do
+        Sentry.configuration.data_collection.database_query_data = true
+        transaction = Sentry.start_transaction
+        Sentry.get_current_scope.set_span(transaction)
+
+        expect(redis.set("key", "value")).to eq("OK")
+        expect(transaction.span_recorder.spans.last.description).to eq("SET key value")
+      end
+
+        it "does not collect Redis arguments when database query data is disabled" do
+          Sentry.configuration.data_collection.database_query_data = false
+          transaction = Sentry.start_transaction
+          Sentry.get_current_scope.set_span(transaction)
+
+          expect(redis.set("key", "value")).to eq("OK")
+          expect(transaction.span_recorder.spans.last.description).to eq("SET key")
+        end
+      end
+    end
+
     context "config.send_default_pii = true" do
       before { Sentry.configuration.send_default_pii = true }
 

--- a/sentry-ruby/spec/sentry/utils/http_tracing_spec.rb
+++ b/sentry-ruby/spec/sentry/utils/http_tracing_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.describe Sentry::Utils::HttpTracing do
+  subject(:http_tracing) do
+    tracing_class = Class.new
+    tracing_class.include(Sentry::Utils::HttpTracing)
+    tracing_class.new
+  end
+
+  before do
+    perform_basic_setup do |config|
+      config.data_collection.url_query_params.mode = :deny_list
+    end
+  end
+
+  describe "#format_query" do
+    it "formats scalar and array values without encoding them" do
+      query = {
+        "token" => "[Filtered]",
+        "page" => "5",
+        "tags[]" => ["ruby", "sentry"]
+      }
+
+      expect(http_tracing.format_query(query)).to eq(
+        "token=[Filtered]&page=5&tags[]=ruby&tags[]=sentry"
+      )
+    end
+  end
+
+  describe "#filter_query_params" do
+    it "filters sensitive values while preserving parameter names" do
+      expect(http_tracing.filter_query_params("token=abc123&page=5")).to eq(
+        "token=[Filtered]&page=5"
+      )
+    end
+
+    it "preserves array query parameters" do
+      expect(http_tracing.filter_query_params("foo=bar&baz[]=1&baz[]=2")).to eq(
+        "foo=bar&baz[]=1&baz[]=2"
+      )
+    end
+
+    it "does not collect query params when the mode is off" do
+      Sentry.configuration.data_collection.url_query_params.mode = :off
+
+      expect(http_tracing.filter_query_params("token=abc123&page=5")).to be_nil
+    end
+
+    it "returns nil for a missing query" do
+      expect(http_tracing.filter_query_params(nil)).to be_nil
+    end
+
+    it "returns nil when a query cannot be converted to a query string" do
+      expect(http_tracing.filter_query_params(Object.new)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Makes url collection close to the table [here](https://develop.sentry.dev/sdk/foundations/client/data-collection/#urls). Note that we haven't renamed `url` to `url.full` yet, that will be done in the major.

#### Issues

* Resolves: #3004
* Resolves: RUBY-192