### PR TITLE
meta: [sentry-sidekiq] README.md: Drop broken Dependabot version compatibility badge

### DIFF
--- a/sentry-sidekiq/README.md
+++ b/sentry-sidekiq/README.md
@@ -14,8 +14,6 @@
 ![Build Status](https://github.com/getsentry/sentry-ruby/actions/workflows/tests.yml/badge.svg)
 [![Coverage Status](https://img.shields.io/codecov/c/github/getsentry/sentry-ruby/master?logo=codecov)](https://codecov.io/gh/getsentry/sentry-ruby/branch/master)
 [![Gem](https://img.shields.io/gem/dt/sentry-sidekiq.svg)](https://rubygems.org/gems/sentry-sidekiq/)
-[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=sentry-sidekiq&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=sentry-sidekiq&package-manager=bundler&version-scheme=semver)
-
 
 [Documentation](https://docs.sentry.io/platforms/ruby/guides/sidekiq/) | [Bug Tracker](https://github.com/getsentry/sentry-ruby/issues) | [Forum](https://forum.sentry.io/) | IRC: irc.freenode.net, #sentry
 


### PR DESCRIPTION
The README badge list ended with a now-defunct one, from Dependabot. This PR removes it, without a replacement.

I didn't go through each neighboring gem's README for the same issue.