### PR TITLE
fix(rails): guard execution context with send_default_pii

### DIFF
--- a/sentry-rails/lib/sentry/rails/error_reporter_context.rb
+++ b/sentry-rails/lib/sentry/rails/error_reporter_context.rb
@@ -9,6 +9,8 @@ module Sentry
 
       if SUPPORTS_EXECUTION_CONTEXT
         def execution_context
+          return {} unless Sentry.configuration.send_default_pii
+
           context = ::ActiveSupport::ExecutionContext.to_h
           return {} if context.empty?
 

--- a/sentry-rails/spec/active_job/shared_examples/error_context.rb
+++ b/sentry-rails/spec/active_job/shared_examples/error_context.rb
@@ -37,33 +37,51 @@ RSpec.shared_examples "an ActiveJob backend that attaches job context to error e
     expect(last_frame.vars).to include(a: "1", b: "0")
   end
 
-  it "includes Rails.error.set_context data attached before the job raises", skip: RAILS_VERSION < 7.0 do
-    job_with_context = job_fixture do
-      def perform
-        Rails.error.set_context(
-          debug_key: "important_value",
-          timestamp: Time.utc(2026, 7, 21, 12, 34, 56),
-          zoned_timestamp: ActiveSupport::TimeZone["Eastern Time (US & Canada)"].parse("2026-07-21 12:34:56"),
-          date: Date.new(2026, 7, 21)
-        )
-        raise "boom with rails error context"
+  context "with Rails.error.set_context data attached before the job raises", skip: RAILS_VERSION < 7.0 do
+    let(:job_with_context) do
+      job_fixture do
+        def perform
+          Rails.error.set_context(
+            debug_key: "important_value",
+            timestamp: Time.utc(2026, 7, 21, 12, 34, 56),
+            zoned_timestamp: ActiveSupport::TimeZone["Eastern Time (US & Canada)"].parse("2026-07-21 12:34:56"),
+            date: Date.new(2026, 7, 21)
+          )
+          raise "boom with rails error context"
+        end
       end
     end
 
-    expect do
-      job_with_context.perform_later
-      drain
-    end.to raise_error(RuntimeError, /boom with rails error context/)
+    def capture_job_error
+      expect do
+        job_with_context.perform_later
+        drain
+      end.to raise_error(RuntimeError, /boom with rails error context/)
 
-    event = last_sentry_event
+      last_sentry_event
+    end
 
-    expect(event.contexts).to include(
-      "rails.error" => hash_including(
-        debug_key: "important_value",
-        timestamp: Time.utc(2026, 7, 21, 12, 34, 56),
-        zoned_timestamp: ActiveSupport::TimeZone["Eastern Time (US & Canada)"].parse("2026-07-21 12:34:56"),
-        date: Date.new(2026, 7, 21)
-      )
-    )
+    it "omits the context from the captured event" do
+      expect(capture_job_error.contexts).not_to have_key("rails.error")
+    end
+
+    context "when send_default_pii is enabled" do
+      let(:configure_sentry) do
+        proc do |config|
+          config.send_default_pii = true
+        end
+      end
+
+      it "includes the context in the captured event" do
+        expect(capture_job_error.contexts).to include(
+          "rails.error" => hash_including(
+            debug_key: "important_value",
+            timestamp: Time.utc(2026, 7, 21, 12, 34, 56),
+            zoned_timestamp: ActiveSupport::TimeZone["Eastern Time (US & Canada)"].parse("2026-07-21 12:34:56"),
+            date: Date.new(2026, 7, 21)
+          )
+        )
+      end
+    end
   end
 end

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -331,9 +331,12 @@ RSpec.describe Sentry::Rails, type: :request do
     end
 
     context "when config.register_error_subscriber = true" do
+      let(:send_default_pii) { false }
+
       before do
         make_basic_app do |config|
           config.rails.register_error_subscriber = true
+          config.send_default_pii = send_default_pii
         end
       end
 
@@ -374,20 +377,32 @@ RSpec.describe Sentry::Rails, type: :request do
         expect(transport.events.count).to eq(0)
       end
 
-      it "includes Rails.error.set_context data attached before an unhandled request exception" do
+      it "omits Rails.error.set_context data attached before an unhandled request exception" do
         get "/exception_with_error_context"
 
         expect(transport.events.count).to eq(1)
 
-        event = transport.events.first
-        expect(event.contexts).to include(
-          "rails.error" => hash_including(
-            debug_key: "important_value",
-            timestamp: Time.utc(2026, 7, 21, 12, 34, 56),
-            zoned_timestamp: ActiveSupport::TimeZone["Eastern Time (US & Canada)"].parse("2026-07-21 12:34:56"),
-            date: Date.new(2026, 7, 21)
+        expect(transport.events.first.contexts).not_to have_key("rails.error")
+      end
+
+      context "when send_default_pii is enabled" do
+        let(:send_default_pii) { true }
+
+        it "includes Rails.error.set_context data attached before an unhandled request exception" do
+          get "/exception_with_error_context"
+
+          expect(transport.events.count).to eq(1)
+
+          event = transport.events.first
+          expect(event.contexts).to include(
+            "rails.error" => hash_including(
+              debug_key: "important_value",
+              timestamp: Time.utc(2026, 7, 21, 12, 34, 56),
+              zoned_timestamp: ActiveSupport::TimeZone["Eastern Time (US & Canada)"].parse("2026-07-21 12:34:56"),
+              date: Date.new(2026, 7, 21)
+            )
           )
-        )
+        end
       end
     end
   end


### PR DESCRIPTION
Follow up after #3024 - we decided to just gate the execution context (which ends up under `rails.error`) with `send_default_pii` for now. Granular handling of this piece of data will be done along with the Data Collection feature.

---

Refs #2931