### PR TITLE
ci: Replace secrets: inherit with explicit CODECOV_TOKEN pass

### DIFF
--- a/.github/workflows/gem_test.yml
+++ b/.github/workflows/gem_test.yml
@@ -17,6 +17,9 @@ on:
         description: Space-separated apt packages to install before testing.
         type: string
         default: ""
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 jobs:
   matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,8 @@ jobs:
     with:
       gem: ${{ matrix.gem }}
       apt: ${{ matrix.apt || '' }}
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   codecov:
     name: CodeCov


### PR DESCRIPTION
## Summary
- The `test` job in `tests.yml` used `secrets: inherit` when calling `gem_test.yml`, exposing every repository secret to that workflow.
- `gem_test.yml` only reads `secrets.CODECOV_TOKEN` (to upload coverage) but never declared it under `workflow_call.secrets`.
- Declared it explicitly in `gem_test.yml` and updated `tests.yml` to pass only that secret by name.

## Test plan
- [x] Confirmed `gem_test.yml` only references `secrets.CODECOV_TOKEN`
- [x] Validated workflow YAML parses correctly
- [ ] Verify the `test` job still uploads coverage correctly on this PR

Fixes VULN-2296

🤖 Generated with [Claude Code](https://claude.com/claude-code)