### PR TITLE
feat!: Remove enable_logs

### DIFF
--- a/sentry-rails/lib/sentry/rails/configuration.rb
+++ b/sentry-rails/lib/sentry/rails/configuration.rb
@@ -35,8 +35,6 @@ module Sentry
     end
 
     after(:configured) do
-      rails.structured_logging.enabled = enable_logs if rails.structured_logging.enabled.nil?
-
       collection = data_collection.url_query_params
       if collection.mode == :deny_list
         filter_parameters = ::Rails.application.config.filter_parameters.select do |filter|
@@ -226,7 +224,7 @@ module Sentry
       }.freeze
 
       def initialize
-        @enabled = nil
+        @enabled = true
         @subscribers = DEFAULT_SUBSCRIBERS.dup
       end
 

--- a/sentry-rails/lib/sentry/rails/log_subscribers/action_controller_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/log_subscribers/action_controller_subscriber.rb
@@ -15,7 +15,6 @@ module Sentry
       # @example Usage
       #   # Enable structured logging for ActionController
       #   Sentry.init do |config|
-      #     config.enable_logs = true
       #     config.rails.structured_logging = true
       #     config.rails.structured_logging.subscribers = { action_controller: Sentry::Rails::LogSubscribers::ActionControllerSubscriber }
       #   end

--- a/sentry-rails/lib/sentry/rails/log_subscribers/action_mailer_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/log_subscribers/action_mailer_subscriber.rb
@@ -14,7 +14,6 @@ module Sentry
       # @example Usage
       #   # Enable structured logging for ActionMailer
       #   Sentry.init do |config|
-      #     config.enable_logs = true
       #     config.rails.structured_logging = true
       #     config.rails.structured_logging.subscribers = { action_mailer: Sentry::Rails::LogSubscribers::ActionMailerSubscriber }
       #   end

--- a/sentry-rails/lib/sentry/rails/log_subscribers/active_job_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/log_subscribers/active_job_subscriber.rb
@@ -14,7 +14,6 @@ module Sentry
       # @example Usage
       #   # Enable structured logging for ActiveJob
       #   Sentry.init do |config|
-      #     config.enable_logs = true
       #     config.rails.structured_logging = true
       #     config.rails.structured_logging.subscribers = { active_job: Sentry::Rails::LogSubscribers::ActiveJobSubscriber }
       #   end

--- a/sentry-rails/lib/sentry/rails/log_subscribers/active_record_subscriber.rb
+++ b/sentry-rails/lib/sentry/rails/log_subscribers/active_record_subscriber.rb
@@ -15,7 +15,6 @@ module Sentry
       # @example Usage
       #   # Automatically attached when structured logging is enabled for :active_record
       #   Sentry.init do |config|
-      #     config.enable_logs = true
       #     config.rails.structured_logging = true
       #     config.rails.structured_logging.subscribers = { active_record: Sentry::Rails::LogSubscribers::ActiveRecordSubscriber }
       #   end

--- a/sentry-rails/lib/sentry/rails/railtie.rb
+++ b/sentry-rails/lib/sentry/rails/railtie.rb
@@ -142,7 +142,7 @@ module Sentry
     end
 
     def activate_structured_logging
-      if Sentry.configuration.rails.structured_logging.enabled? && Sentry.configuration.enable_logs
+      if Sentry.configuration.rails.structured_logging.enabled?
         Sentry::Rails::StructuredLogging.attach(Sentry.configuration.rails.structured_logging)
       end
     end

--- a/sentry-rails/spec/active_job/shared_examples/structured_logging.rb
+++ b/sentry-rails/spec/active_job/shared_examples/structured_logging.rb
@@ -3,7 +3,6 @@
 RSpec.shared_examples "an ActiveJob backend that produces structured logs" do
   let(:configure_sentry) do
     proc do |config, _app|
-      config.enable_logs = true
       config.rails.structured_logging.enabled = true
       config.rails.structured_logging.subscribers = {
         active_job: Sentry::Rails::LogSubscribers::ActiveJobSubscriber

--- a/sentry-rails/spec/active_job/shared_examples/tracing/user_propagation.rb
+++ b/sentry-rails/spec/active_job/shared_examples/tracing/user_propagation.rb
@@ -63,7 +63,6 @@ RSpec.shared_examples "an ActiveJob backend that propagates Sentry user context 
       proc do |config|
         config.traces_sample_rate = 1.0
         config.send_default_pii = true
-        config.enable_logs = true
       end
     end
 

--- a/sentry-rails/spec/active_job/support/harness.rb
+++ b/sentry-rails/spec/active_job/support/harness.rb
@@ -48,7 +48,11 @@ RSpec.shared_context "active_job backend harness" do |adapter:|
   # re-activate tracing/structured logging, re-register AJ event
   # handlers) so each example still gets a fresh Sentry configuration.
   before(:all) do
-    make_basic_app
+    make_basic_app do |config|
+      # The app is booted once to set up shared Rails infrastructure. Structured
+      # logging is configured and attached separately for each example below.
+      config.rails.structured_logging.enabled = false
+    end
   end
 
   around do |example|
@@ -73,7 +77,7 @@ RSpec.shared_context "active_job backend harness" do |adapter:|
       Sentry::Rails::Tracing.patch_active_support_notifications
     end
 
-    if Sentry.configuration.rails.structured_logging.enabled? && Sentry.configuration.enable_logs
+    if Sentry.configuration.rails.structured_logging.enabled?
       Sentry::Rails::StructuredLogging.attach(Sentry.configuration.rails.structured_logging)
     end
 

--- a/sentry-rails/spec/isolated/rails_logger_patch_spec.rb
+++ b/sentry-rails/spec/isolated/rails_logger_patch_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "Rails.logger with :logger patch" do
   context "when :logger patch is enabled" do
     before do
       make_basic_app do |config, app|
-        config.enable_logs = true
         config.enabled_patches = [:logger]
         config.max_log_events = 10
         config.sdk_logger = Logger.new(nil)
@@ -202,7 +201,6 @@ RSpec.describe "Rails.logger with :logger patch" do
     let(:broadcast_logger) { ActiveSupport::BroadcastLogger.new(logger1, logger2) }
     let(:broadcast_app) do
       make_basic_app do |config|
-        config.enable_logs = true
         config.enabled_patches = [:logger]
         config.max_log_events = 10
         config.sdk_logger = Logger.new(nil)

--- a/sentry-rails/spec/sentry/rails/configuration_spec.rb
+++ b/sentry-rails/spec/sentry/rails/configuration_spec.rb
@@ -99,26 +99,15 @@ RSpec.describe Sentry::Rails::Configuration do
       expect(config.structured_logging.subscribers).to be_a(Hash)
     end
 
-    it "auto-enables when enable_logs is true and not explicitly set" do
-      make_basic_app do |config|
-        config.enable_logs = true
-      end
+    it "enables structured logging by default" do
+      make_basic_app
 
       expect(config.structured_logging.enabled?).to be(true)
     end
 
-    it "remains disabled when enable_logs is false" do
-      make_basic_app do |config|
-        config.enable_logs = false
-      end
-
-      expect(config.structured_logging.enabled?).to be(false)
-    end
-
-    it "respects explicit disable even when enable_logs is true" do
+    it "respects explicit disable" do
       make_basic_app do |config|
         config.rails.structured_logging.enabled = false
-        config.enable_logs = true
       end
 
       expect(config.structured_logging.enabled?).to be(false)

--- a/sentry-rails/spec/sentry/rails/log_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/log_subscriber_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe Sentry::Rails::LogSubscriber, type: :request do
 
     before do
       make_basic_app do |config|
-        config.enable_logs = true
         config.structured_logging.logger_class = Sentry::DebugStructuredLogger
         # Disable default structured logging subscribers to avoid interference
         config.rails.structured_logging.enabled = false
@@ -240,7 +239,6 @@ RSpec.describe Sentry::Rails::LogSubscriber, type: :request do
 
     before do
       make_basic_app do |config, app|
-        config.enable_logs = true
         config.structured_logging.logger_class = Sentry::DebugStructuredLogger
         config.data_collection.url_query_params.mode = :deny_list
       end

--- a/sentry-rails/spec/sentry/rails/log_subscribers/action_controller_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/log_subscribers/action_controller_subscriber_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Sentry::Rails::LogSubscribers::ActionControllerSubscriber, type: 
 
     before do
       make_basic_app do |config, app|
-        config.enable_logs = true
         config.send_default_pii = send_default_pii
-
         config.rails.structured_logging.enabled = true
         config.rails.structured_logging.subscribers = { action_controller: Sentry::Rails::LogSubscribers::ActionControllerSubscriber }
       end
@@ -377,9 +375,7 @@ RSpec.describe Sentry::Rails::LogSubscribers::ActionControllerSubscriber, type: 
   context "when logging is disabled" do
     before do
       make_basic_app do |config|
-        config.enable_logs = false
-
-        config.rails.structured_logging.enabled = true
+        config.rails.structured_logging.enabled = false
         config.rails.structured_logging.subscribers = { action_controller: Sentry::Rails::LogSubscribers::ActionControllerSubscriber }
       end
     end

--- a/sentry-rails/spec/sentry/rails/log_subscribers/action_mailer_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/log_subscribers/action_mailer_subscriber_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Sentry::Rails::LogSubscribers::ActionMailerSubscriber do
 
     before do
       make_basic_app do |config|
-        config.enable_logs = true
         config.send_default_pii = send_default_pii
-
         config.rails.structured_logging.enabled = true
         config.rails.structured_logging.subscribers = { action_mailer: Sentry::Rails::LogSubscribers::ActionMailerSubscriber }
       end
@@ -227,9 +225,7 @@ RSpec.describe Sentry::Rails::LogSubscribers::ActionMailerSubscriber do
   context "when logging is disabled" do
     before do
       make_basic_app do |config|
-        config.enable_logs = false
-
-        config.rails.structured_logging.enabled = true
+        config.rails.structured_logging.enabled = false
         config.rails.structured_logging.subscribers = { action_mailer: Sentry::Rails::LogSubscribers::ActionMailerSubscriber }
       end
     end

--- a/sentry-rails/spec/sentry/rails/log_subscribers/active_job_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/log_subscribers/active_job_subscriber_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Sentry::Rails::LogSubscribers::ActiveJobSubscriber, skip: Rails.v
 
     before do
       make_basic_app do |config|
-        config.enable_logs = true
         config.send_default_pii = send_default_pii
-
         config.rails.structured_logging.enabled = true
         config.rails.structured_logging.subscribers = { active_job: Sentry::Rails::LogSubscribers::ActiveJobSubscriber }
       end
@@ -344,9 +342,7 @@ RSpec.describe Sentry::Rails::LogSubscribers::ActiveJobSubscriber, skip: Rails.v
   context "when logging is disabled" do
     before do
       make_basic_app do |config|
-        config.enable_logs = false
-
-        config.rails.structured_logging.enabled = true
+        config.rails.structured_logging.enabled = false
         config.rails.structured_logging.subscribers = { active_job: Sentry::Rails::LogSubscribers::ActiveJobSubscriber }
       end
     end

--- a/sentry-rails/spec/sentry/rails/log_subscribers/active_record_subscriber_spec.rb
+++ b/sentry-rails/spec/sentry/rails/log_subscribers/active_record_subscriber_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Sentry::Rails::LogSubscribers::ActiveRecordSubscriber do
 
     before do
       make_basic_app do |config|
-        config.enable_logs = true
         config.send_default_pii = send_default_pii
-
         config.rails.structured_logging.enabled = true
         config.rails.structured_logging.subscribers = { active_record: Sentry::Rails::LogSubscribers::ActiveRecordSubscriber }
       end
@@ -59,7 +57,7 @@ RSpec.describe Sentry::Rails::LogSubscribers::ActiveRecordSubscriber do
           sentry_transport.events.clear
           sentry_transport.envelopes.clear
 
-          created_at = Time.new(2025, 10, 28, 13, 11, 44)
+          created_at = Time.utc(2025, 10, 28, 13, 11, 44)
           Post.where(id: post.id, title: post.title, created_at: created_at).to_a
 
           Sentry.get_current_client.flush
@@ -347,8 +345,6 @@ RSpec.describe Sentry::Rails::LogSubscribers::ActiveRecordSubscriber do
   context "when logger is silenced" do
     before do
       make_basic_app do |config, app|
-        config.enable_logs = true
-
         config.rails.structured_logging.enabled = true
         config.rails.structured_logging.subscribers = {
           active_record: Sentry::Rails::LogSubscribers::ActiveRecordSubscriber
@@ -377,9 +373,7 @@ RSpec.describe Sentry::Rails::LogSubscribers::ActiveRecordSubscriber do
   context "when logging is disabled" do
     before do
       make_basic_app do |config|
-        config.enable_logs = false
-
-        config.rails.structured_logging.enabled = true
+        config.rails.structured_logging.enabled = false
         config.rails.structured_logging.subscribers = { active_record: Sentry::Rails::LogSubscribers::ActiveRecordSubscriber }
       end
     end

--- a/sentry-rails/spec/sentry/rails/structured_logging_spec.rb
+++ b/sentry-rails/spec/sentry/rails/structured_logging_spec.rb
@@ -3,29 +3,9 @@
 require "spec_helper"
 
 RSpec.describe Sentry::Rails::StructuredLogging, type: :request do
-  context "when sentry structured logging is disabled" do
-    before do
-      make_basic_app do |config|
-        config.enable_logs = false
-        config.rails.structured_logging.enabled = true
-      end
-    end
-
-    it "does not capture structured logs" do
-      get "/posts"
-
-      Post.first
-
-      Sentry.get_current_client.flush
-
-      expect(sentry_logs).to be_empty
-    end
-  end
-
   context "when rails structured logging is disabled" do
     before do
       make_basic_app do |config|
-        config.enable_logs = true
         config.rails.structured_logging.enabled = false
       end
     end
@@ -41,14 +21,14 @@ RSpec.describe Sentry::Rails::StructuredLogging, type: :request do
     end
   end
 
-  context "when enable_logs is true and structured logging is auto-enabled" do
+  context "when structured logging is enabled" do
     before do
       make_basic_app do |config|
-        config.enable_logs = true
+        config.rails.structured_logging.enabled = true
       end
     end
 
-    it "captures structured logs automatically" do
+    it "captures structured logs" do
       get "/posts"
 
       Post.first

--- a/sentry-rails/spec/sentry/rails_spec.rb
+++ b/sentry-rails/spec/sentry/rails_spec.rb
@@ -64,11 +64,14 @@ RSpec.describe Sentry::Rails, type: :request do
       end
 
       it "doesn't cause error if Rails::Logger is not present during SDK initialization" do
+        rails_logger = Rails.logger
         Rails.logger = nil
 
         Sentry.init
 
         expect(Sentry.configuration.sdk_logger).to be_a(Sentry::Logger)
+      ensure
+        Rails.logger = rails_logger
       end
     end
 

--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -527,7 +527,7 @@ module Sentry
     #   Sentry.capture_log("User logged in", level: :info, user_id: 123)
     #
     # @see https://develop.sentry.dev/sdk/telemetry/logs/ Sentry SDK Telemetry Logs Protocol
-    # @return [LogEvent, nil] The created log event or nil if logging is disabled
+    # @return [LogEvent, nil] The created log event or nil if Sentry is not initialized
     def capture_log(message, **options)
       return unless initialized?
       get_current_hub.capture_log_event(message, **options)
@@ -639,14 +639,6 @@ module Sentry
 
     # Returns the structured logger instance that implements Sentry's SDK telemetry logs protocol.
     #
-    # This logger is only available when logs are enabled in the configuration.
-    #
-    # @example Enable logs in configuration
-    #   Sentry.init do |config|
-    #     config.dsn = "YOUR_DSN"
-    #     config.enable_logs = true
-    #   end
-    #
     # @example Basic usage
     #   Sentry.logger.info("User logged in successfully", user_id: 123)
     #   Sentry.logger.error("Failed to process payment",
@@ -656,7 +648,7 @@ module Sentry
     #
     # @see https://develop.sentry.dev/sdk/telemetry/logs/ Sentry SDK Telemetry Logs Protocol
     #
-    # @return [StructuredLogger] The structured logger instance or nil if logs are disabled
+    # @return [StructuredLogger] The structured logger instance
     def logger
       @logger ||= configuration.structured_logging.logger_class.new(configuration)
     end

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -48,9 +48,7 @@ module Sentry
 
       @spotlight_transport = SpotlightTransport.new(configuration) if configuration.spotlight
 
-      if configuration.enable_logs
-        @log_event_buffer = LogEventBuffer.new(configuration, self)
-      end
+      @log_event_buffer = LogEventBuffer.new(configuration, self)
 
       if configuration.enable_metrics
         @metric_event_buffer = MetricEventBuffer.new(configuration, self)

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -283,10 +283,6 @@ module Sentry
     # @return [Proc]
     attr_accessor :traces_sampler
 
-    # Enable Structured Logging
-    # @return [Boolean]
-    attr_accessor :enable_logs
-
     # Structured logging configuration.
     # @return [StructuredLoggingConfiguration]
     attr_reader :structured_logging
@@ -590,7 +586,6 @@ module Sentry
       self.std_lib_logger_filter = nil
       self.rack_env_whitelist = RACK_ENV_WHITELIST_DEFAULT
       self.traces_sampler = nil
-      self.enable_logs = false
       self.enable_metrics = true
 
       self.profiler_class = Sentry::Profiler

--- a/sentry-ruby/lib/sentry/debug_structured_logger.rb
+++ b/sentry-ruby/lib/sentry/debug_structured_logger.rb
@@ -8,8 +8,7 @@ require "delegate"
 module Sentry
   # DebugStructuredLogger is a logger that captures structured log events to a file for debugging purposes.
   #
-  # It can optionally also send log events to Sentry via the normal structured logger if logging
-  # is enabled.
+  # It also sends log events to Sentry via the normal structured logger.
   class DebugStructuredLogger < SimpleDelegator
     DEFAULT_LOG_FILE_PATH = File.join("log", "sentry_debug_logs.log")
 
@@ -68,12 +67,7 @@ module Sentry
     private
 
     def initialize_backend(configuration)
-      if configuration.enable_logs
-        StructuredLogger.new(configuration)
-      else
-        # Create a no-op logger if logging is disabled
-        NoOpLogger.new
-      end
+      StructuredLogger.new(configuration)
     end
 
     def initialize_log_file(log_file_path)
@@ -82,13 +76,6 @@ module Sentry
       FileUtils.mkdir_p(log_file.dirname) unless log_file.dirname.exist?
 
       log_file
-    end
-
-    # No-op logger for when structured logging is disabled
-    class NoOpLogger
-      %i[trace debug info warn error fatal log].each do |method|
-        define_method(method) { |*args, **kwargs| nil }
-      end
     end
   end
 end

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -224,7 +224,7 @@ module Sentry
     end
 
     def capture_log_event(message, **options)
-      return unless current_client && current_client.configuration.enable_logs
+      return unless current_client
 
       event = current_client.event_from_log(message, **options)
 

--- a/sentry-ruby/lib/sentry/std_lib_logger.rb
+++ b/sentry-ruby/lib/sentry/std_lib_logger.rb
@@ -50,10 +50,6 @@ module Sentry
   end
 end
 
-Sentry.register_patch(:logger) do |config|
-  if config.enable_logs
-    ::Logger.prepend(Sentry::StdLibLogger)
-  else
-    config.sdk_logger.warn(":logger patch enabled but `enable_logs` is turned off - skipping applying patch")
-  end
+Sentry.register_patch(:logger) do
+  ::Logger.prepend(Sentry::StdLibLogger)
 end

--- a/sentry-ruby/lib/sentry/test_helper.rb
+++ b/sentry-ruby/lib/sentry/test_helper.rb
@@ -90,9 +90,7 @@ module Sentry
         transport.clear if transport.respond_to?(:clear)
       end
 
-      if Sentry.configuration.enable_logs && sentry_logger.respond_to?(:clear)
-        sentry_logger.clear
-      end
+      sentry_logger.clear if sentry_logger.respond_to?(:clear)
     end
 
     # @return [Sentry::StructuredLogger, Sentry::DebugStructuredLogger]

--- a/sentry-ruby/spec/isolated/sentry_logger_spec.rb
+++ b/sentry-ruby/spec/isolated/sentry_logger_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "Sentry::Breadcrumbs::SentryLogger" do
   before do
     perform_basic_setup do |config|
       config.breadcrumbs_logger = [:sentry_logger]
-      config.enable_logs = true
       config.max_log_events = 1
       config.enabled_patches = [:logger]
     end

--- a/sentry-ruby/spec/isolated/std_lib_logger_spec.rb
+++ b/sentry-ruby/spec/isolated/std_lib_logger_spec.rb
@@ -5,25 +5,9 @@ SimpleCov.command_name "StdLibLogger"
 RSpec.describe Sentry::StdLibLogger do
   let(:logger) { ::Logger.new($stdout) }
 
-  context "when logger patch is enabled but enable_logs is turned off" do
-    it "logs a warning message" do
-      string_io = StringIO.new
-
-      perform_basic_setup do |config|
-        config.enable_logs = false
-        config.enabled_patches = [:logger]
-        config.sdk_logger = ::Logger.new(string_io)
-      end
-
-      expect(string_io.string).to include("WARN -- : :logger patch enabled but `enable_logs` is turned off - skipping applying patch")
-    end
-  end
-
-  context "when enable_logs is set to true but logger patch is not enabled" do
+  context "when logger patch is not enabled" do
     before do
-      perform_basic_setup do |config|
-        config.enable_logs = true
-      end
+      perform_basic_setup
     end
 
     it "does not send log using stdlib logger" do
@@ -35,11 +19,10 @@ RSpec.describe Sentry::StdLibLogger do
     end
   end
 
-  context "when enable_logs is set to true and logger patch is set" do
+  context "when logger patch is enabled" do
     before do
       perform_basic_setup do |config|
         config.max_log_events = 1
-        config.enable_logs = true
         config.enabled_patches = [:redis, :puma, :http, :logger]
       end
     end

--- a/sentry-ruby/spec/sentry/debug_structured_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/debug_structured_logger_spec.rb
@@ -3,7 +3,6 @@
 RSpec.describe Sentry::DebugStructuredLogger do
   let(:configuration) do
     config = Sentry::Configuration.new
-    config.enable_logs = true
     config.dsn = Sentry::TestHelper::DUMMY_DSN
     config
   end
@@ -25,19 +24,6 @@ RSpec.describe Sentry::DebugStructuredLogger do
 
     it "creates a log file" do
       expect(debug_logger.log_file).to be_a(Pathname)
-    end
-
-    context "when logs are disabled" do
-      let(:configuration) do
-        config = Sentry::Configuration.new
-        config.enable_logs = false
-        config.dsn = Sentry::TestHelper::DUMMY_DSN
-        config
-      end
-
-      it "creates a no-op logger backend" do
-        expect(debug_logger.backend).to be_a(Sentry::DebugStructuredLogger::NoOpLogger)
-      end
     end
   end
 

--- a/sentry-ruby/spec/sentry/log_event_buffer_spec.rb
+++ b/sentry-ruby/spec/sentry/log_event_buffer_spec.rb
@@ -12,6 +12,5 @@ RSpec.describe Sentry::LogEventBuffer do
         body: "Test message"
       )
     },
-    max_items_config: :max_log_events,
-    enable_config: :enable_logs
+    max_items_config: :max_log_events
 end

--- a/sentry-ruby/spec/sentry/metric_event_buffer_spec.rb
+++ b/sentry-ruby/spec/sentry/metric_event_buffer_spec.rb
@@ -13,6 +13,5 @@ RSpec.describe Sentry::MetricEventBuffer do
         value: 1
       )
     },
-    max_items_config: :max_metric_events,
-    enable_config: :enable_metrics
+    max_items_config: :max_metric_events
 end

--- a/sentry-ruby/spec/sentry/structured_logger_spec.rb
+++ b/sentry-ruby/spec/sentry/structured_logger_spec.rb
@@ -1,23 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe Sentry::StructuredLogger do
-  context "when enable_logs is set to false" do
-    before do
-      perform_basic_setup do |config|
-        config.enable_logs = false
-      end
-    end
-
-    it "initializes" do
-      expect(Sentry.logger).to be_a(described_class)
-    end
-  end
-
   context "when log events are enabled" do
     before do
       perform_basic_setup do |config|
         config.max_log_events = 1
-        config.enable_logs = true
       end
     end
 
@@ -220,7 +207,6 @@ RSpec.describe Sentry::StructuredLogger do
 
       before do
         perform_basic_setup do |config|
-          config.enable_logs = true
           config.send_client_reports = send_client_reports
           config.max_log_events = 1
           config.before_send_log = before_send_log

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -483,7 +483,6 @@ RSpec.describe Sentry do
   describe ".capture_log" do
     before do
       perform_basic_setup do |config|
-        config.enable_logs = true
         config.traces_sample_rate = 1.0
         config.max_log_events = 1
       end

--- a/sentry-ruby/spec/support/shared_examples_for_telemetry_event_buffers.rb
+++ b/sentry-ruby/spec/support/shared_examples_for_telemetry_event_buffers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "telemetry event buffer" do |event_factory:, max_items_config:, enable_config:|
+RSpec.shared_examples "telemetry event buffer" do |event_factory:, max_items_config:|
   let(:string_io) { StringIO.new }
   let(:sdk_logger) { ::Logger.new(string_io) }
   let(:client) { Sentry.get_current_client }
@@ -11,7 +11,6 @@ RSpec.shared_examples "telemetry event buffer" do |event_factory:, max_items_con
       config.sdk_logger = sdk_logger
       config.background_worker_threads = 0
       config.public_send(:"#{max_items_config}=", max_items)
-      config.public_send(:"#{enable_config}=", true)
     end
 
     Sentry.background_worker = Sentry::BackgroundWorker.new(Sentry.configuration)

--- a/spec/apps/rails-mini/app.rb
+++ b/spec/apps/rails-mini/app.rb
@@ -74,7 +74,6 @@ class RailsMiniApp < Rails::Application
       config.sdk_debug_transport_log_file = debug_log_path.join("sentry_debug_events.log")
       config.background_worker_threads = 0
 
-      config.enable_logs = true
       config.structured_logging.logger_class = Sentry::DebugStructuredLogger
       config.structured_logging.file_path = debug_log_path.join("sentry_e2e_tests.log")
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,7 +49,6 @@ RSpec.configure do |config|
   config.before(:suite) do
     Test::Helper.perform_basic_setup do |config|
       config.transport.transport_class = Sentry::DebugTransport
-      config.enable_logs = true
       config.structured_logging.logger_class = Sentry::DebugStructuredLogger
       config.structured_logging.file_path = Test::Helper.debug_log_path.join("sentry_e2e_tests.log")
     end


### PR DESCRIPTION
### Changelog Entry

[Logs](https://docs.sentry.io/product/logs/) are now enabled by default and `enable_logs` is removed.
Using `sentry-rails` will automatically turn on automatic structured logging from Rails. if you want to turn it off, use:

```ruby
Sentry.init do |config
  # ...
  config.rails.structured_logging.enabled = false
end
```

#### Issues

* Resolves: #2943
* Resolves: RUBY-177