### PR TITLE
fix(rails): set dummy rails app before calling initializers

### DIFF
--- a/sentry-rails/spec/dummy/test_rails_app/config/application.rb
+++ b/sentry-rails/spec/dummy/test_rails_app/config/application.rb
@@ -24,11 +24,11 @@ module Sentry
 
           yield(klass) if block_given?
 
+          ::Rails.application = klass
+
           klass.before_initialize!
           klass.initialize!
           klass.after_initialize!
-
-          ::Rails.application = klass
 
           klass
         end


### PR DESCRIPTION
I noticed a flaky failure in the new DC specs and it turned out to be an issue with our Rails dummy app init process - this should fix it.

With the fix this and most likely other specs will not be flaky:

```
Failures:

  1) Sentry::Rails data collection adds Rails filter parameters to URL query parameter data collection
     Failure/Error:
       expect(Sentry.configuration.data_collection.url_query_params.terms).to include(
         "password",
         "custom_secret"
       )

       expected [] to include "password" and "custom_secret"
     # ./spec/sentry/rails_spec.rb:117:in `block (3 levels) in <top (required)>'

Finished in 37.38 seconds (files took 1.18 seconds to load)
290 examples, 1 failure, 34 pending

Failed examples:

rspec ./spec/sentry/rails_spec.rb:116 # Sentry::Rails data collection adds Rails filter parameters to URL query parameter data collection

Randomized with seed 19348
```

---

#skip-changelog