### PR TITLE
fix(tracing): use established propagation context's span_id

### DIFF
--- a/sentry-rails/spec/sentry/rails/capture_context_spec.rb
+++ b/sentry-rails/spec/sentry/rails/capture_context_spec.rb
@@ -3,11 +3,15 @@
 require "spec_helper"
 
 RSpec.describe Sentry::Rails::CaptureContext do
-  # Records the current scope's trace_id every time it's called, so specs can
+  # Records the current scope's trace context every time it's called, so specs can
   # compare what a piece of middleware would see at different points in the stack.
   class CaptureContextSpecProbe
     def self.captured_trace_ids
       @captured_trace_ids ||= []
+    end
+
+    def self.captured_span_ids
+      @captured_span_ids ||= []
     end
 
     def initialize(app)
@@ -15,7 +19,9 @@ RSpec.describe Sentry::Rails::CaptureContext do
     end
 
     def call(env)
-      self.class.captured_trace_ids << Sentry.get_current_scope.get_trace_context[:trace_id]
+      trace_context = Sentry.get_current_scope.get_trace_context
+      self.class.captured_trace_ids << trace_context[:trace_id]
+      self.class.captured_span_ids << trace_context[:span_id]
       @app.call(env)
     end
   end
@@ -103,6 +109,7 @@ RSpec.describe Sentry::Rails::CaptureContext do
   context "when composed with CaptureExceptions", type: :request do
     before do
       CaptureContextSpecProbe.captured_trace_ids.clear
+      CaptureContextSpecProbe.captured_span_ids.clear
     end
 
     context "without tracing enabled" do
@@ -130,6 +137,15 @@ RSpec.describe Sentry::Rails::CaptureContext do
           app.config.middleware.insert_before(Sentry::Rails::CaptureExceptions, CaptureContextSpecProbe)
           app.config.middleware.insert_after(Sentry::Rails::CaptureExceptions, CaptureContextSpecProbe)
         end
+      end
+
+      it "points a span_id captured before CaptureExceptions at the started transaction" do
+        get "/world"
+
+        transaction = Sentry.get_current_client.transport.events.last
+        early_span_id = CaptureContextSpecProbe.captured_span_ids.first
+
+        expect(early_span_id).to eq(transaction.contexts.dig(:trace, :span_id))
       end
 
       it "keeps the same trace_id from before CaptureExceptions through the started transaction" do

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -123,9 +123,11 @@ module Sentry
       return unless instrumenter == configuration.instrumenter
 
       if transaction.nil? && !options.key?(:trace_id) && established
-        # reuse the already-established trace_id instead of generating an unrelated one
+        # adopt the already-established trace and span rather than generating unrelated
+        # ones, so anything already logged against them resolves to this transaction
         propagation_context = current_scope.propagation_context
         options[:trace_id] = propagation_context.trace_id
+        options[:span_id] ||= propagation_context.span_id
         options[:sample_rand] ||= propagation_context.sample_rand
       end
 
@@ -393,6 +395,7 @@ module Sentry
 
       Transaction.new(
         trace_id: propagation_context.trace_id,
+        span_id: propagation_context.span_id,
         parent_span_id: propagation_context.parent_span_id,
         parent_sampled: propagation_context.parent_sampled,
         baggage: propagation_context.baggage,

--- a/sentry-ruby/spec/sentry_spec.rb
+++ b/sentry-ruby/spec/sentry_spec.rb
@@ -597,6 +597,24 @@ RSpec.describe Sentry do
           expect(transaction.sample_rand).to eq(propagation_context.sample_rand)
         end
 
+        it "adopts the scope's propagation context span_id" do
+          propagation_context = Sentry.get_current_scope.propagation_context
+
+          transaction = described_class.start_transaction(
+            name: "test", op: "test.op", established: true
+          )
+
+          expect(transaction.span_id).to eq(propagation_context.span_id)
+        end
+
+        it "does not override an explicitly provided span_id" do
+          transaction = described_class.start_transaction(
+            name: "test", op: "test.op", span_id: "b" * 16, established: true
+          )
+
+          expect(transaction.span_id).to eq("b" * 16)
+        end
+
         it "does not override an explicitly provided trace_id" do
           transaction = described_class.start_transaction(
             name: "test", op: "test.op", trace_id: "a" * 32, established: true
@@ -1260,6 +1278,14 @@ RSpec.describe Sentry do
         expect(transaction.parent_span_id).to eq(incoming_prop_context.span_id)
         expect(transaction.baggage.items).to eq(incoming_prop_context.get_baggage.items)
         expect(transaction.baggage.mutable).to eq(false)
+      end
+
+      it "gives the Transaction the propagation context's span_id" do
+        Sentry.configuration.traces_sample_rate = 1.0
+
+        transaction = described_class.continue_trace(env, name: "foobar")
+
+        expect(transaction.span_id).to eq(Sentry.get_current_scope.propagation_context.span_id)
       end
 
       describe "sample_rand propagation" do

--- a/spec/features/trace_context_spec.rb
+++ b/spec/features/trace_context_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe "Trace context", type: :e2e do
       .to eq(request_transaction.dig("contexts", "trace", "trace_id"))
   end
 
+  it "points a log emitted before CaptureExceptions at the transaction's span" do
+    without_trace_propagation { make_request("/trace_context") }
+
+    expect(early_middleware_logs.first["span_id"])
+      .to eq(request_transaction.dig("contexts", "trace", "span_id"))
+  end
+
   it "continues an incoming distributed trace in a log emitted before CaptureExceptions" do
     incoming_trace_id = propagated_trace_id
 


### PR DESCRIPTION
This fixes setting proper span id in logs taken from the propagation context.

### Screenshot

Here's how it manifests itself in the UI:

#### Before

<img width="2050" height="1408" alt="Arc 2026-09-04 14 27 07" src="https://github.com/user-attachments/assets/7094ed4c-1637-48db-bb93-487fa6981bf4" />

#### After

<img width="2056" height="1421" alt="Arc 2026-09-04 14 27 05" src="https://github.com/user-attachments/assets/24b5a9b1-7312-41da-ad7d-9bba6d9ece19" />

Notice that span ids only match between the log and the trace in the `After` screenshot.

---

Fixes #3015 