### PR TITLE
feat! Remove enable_metrics

### DIFF
--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -655,12 +655,6 @@ module Sentry
 
     # Returns the metrics API for capturing custom metrics.
     #
-    # @example Enable metrics
-    #   Sentry.init do |config|
-    #     config.dsn = "YOUR_DSN"
-    #     config.enable_metrics = true
-    #   end
-    #
     # @example Usage
     #   Sentry.metrics.count("button.click", 1, attributes: { button_id: "submit" })
     #   Sentry.metrics.distribution("response.time", 120.5, unit: "millisecond")

--- a/sentry-ruby/lib/sentry/client.rb
+++ b/sentry-ruby/lib/sentry/client.rb
@@ -50,9 +50,7 @@ module Sentry
 
       @log_event_buffer = LogEventBuffer.new(configuration, self)
 
-      if configuration.enable_metrics
-        @metric_event_buffer = MetricEventBuffer.new(configuration, self)
-      end
+      @metric_event_buffer = MetricEventBuffer.new(configuration, self)
     end
 
     # Applies the given scope's data to the event and sends it to Sentry.

--- a/sentry-ruby/lib/sentry/configuration.rb
+++ b/sentry-ruby/lib/sentry/configuration.rb
@@ -351,10 +351,6 @@ module Sentry
     # @return [Integer]
     attr_accessor :max_log_events
 
-    # Enable metrics collection, defaults to true
-    # @return [Boolean]
-    attr_accessor :enable_metrics
-
     # Maximum number of metric events to buffer before sending
     # @return [Integer]
     attr_accessor :max_metric_events
@@ -586,7 +582,6 @@ module Sentry
       self.std_lib_logger_filter = nil
       self.rack_env_whitelist = RACK_ENV_WHITELIST_DEFAULT
       self.traces_sampler = nil
-      self.enable_metrics = true
 
       self.profiler_class = Sentry::Profiler
       self.profiles_sample_interval = DEFAULT_PROFILES_SAMPLE_INTERVAL

--- a/sentry-ruby/lib/sentry/hub.rb
+++ b/sentry-ruby/lib/sentry/hub.rb
@@ -242,7 +242,7 @@ module Sentry
     # @param attributes [Hash, nil] (optional) additional attributes for the metric
     # @return [void]
     def capture_metric(name:, type:, value:, unit: nil, attributes: nil)
-      return unless current_client&.configuration.enable_metrics
+      return unless current_client
 
       metric = MetricEvent.new(
         name: name,

--- a/sentry-ruby/spec/sentry/configuration_spec.rb
+++ b/sentry-ruby/spec/sentry/configuration_spec.rb
@@ -868,17 +868,6 @@ RSpec.describe Sentry::Configuration do
     end
   end
 
-  describe "#enable_metrics" do
-    it "returns true by default" do
-      expect(subject.enable_metrics).to eq(true)
-    end
-
-    it "can be set to false" do
-      subject.enable_metrics = false
-      expect(subject.enable_metrics).to eq(false)
-    end
-  end
-
   describe "#max_metric_events" do
     it "returns 1000 by default" do
       expect(subject.max_metric_events).to eq(1000)

--- a/sentry-ruby/spec/sentry/hub_spec.rb
+++ b/sentry-ruby/spec/sentry/hub_spec.rb
@@ -684,28 +684,11 @@ RSpec.describe Sentry::Hub do
   end
 
   describe "#capture_metric" do
-    context "when metrics are disabled" do
-      before do
-        configuration.enable_metrics = false
-      end
-
-      it "doesn't buffer the metric" do
-        expect(subject.current_client).not_to receive(:buffer_metric_event)
+    it "creates and buffers a MetricEvent" do
+      expect(subject.current_client).to receive(:buffer_metric_event).and_call_original
+      expect do
         subject.capture_metric(name: "test", type: :counter, value: 1)
-      end
-    end
-
-    context "when metrics are enabled" do
-      before do
-        configuration.enable_metrics = true
-      end
-
-      it "creates and buffers a MetricEvent" do
-        expect(subject.current_client).to receive(:buffer_metric_event).and_call_original
-        expect do
-          subject.capture_metric(name: "test", type: :counter, value: 1)
-        end.to change { subject.current_client.metric_event_buffer.size }.by(1)
-      end
+      end.to change { subject.current_client.metric_event_buffer.size }.by(1)
     end
   end
 

--- a/sentry-ruby/spec/sentry/metrics_spec.rb
+++ b/sentry-ruby/spec/sentry/metrics_spec.rb
@@ -11,212 +11,154 @@ RSpec.describe "Sentry Metrics" do
   end
 
   describe "Sentry.metrics" do
-    context "when metrics are disabled" do
-      before do
-        Sentry.configuration.enable_metrics = false
-      end
-
-      it "doesn't send metrics" do
+    describe ".count" do
+      it "sends a counter metric with default value" do
         Sentry.metrics.count("test.counter")
-        Sentry.metrics.gauge("test.gauge", 42.5, unit: "seconds")
-        Sentry.metrics.distribution("test.gauge", 42.5, attributes: { foo: "bar" })
+
         Sentry.get_current_client.flush
 
-        expect(sentry_metrics).to be_empty
+        expect(sentry_envelopes.count).to eq(1)
+        expect(sentry_metrics.count).to eq(1)
+
+        metric = sentry_metrics.first
+        expect(metric[:name]).to eq("test.counter")
+        expect(metric[:type]).to eq(:counter)
+        expect(metric[:value]).to eq(1)
+      end
+
+      it "sends a counter metric with custom value" do
+        Sentry.metrics.count("test.counter", value: 5)
+
+        Sentry.get_current_client.flush
+
+        metric = sentry_metrics.first
+        expect(metric[:name]).to eq("test.counter")
+        expect(metric[:type]).to eq(:counter)
+        expect(metric[:value]).to eq(5)
+      end
+
+      it "includes custom attributes" do
+        Sentry.metrics.count("test.counter", attributes: { "foo" => "bar", "count" => 42 })
+
+        Sentry.get_current_client.flush
+
+        metric = sentry_metrics.first
+        attributes = metric[:attributes]
+
+        expect(attributes["foo"]).to eq({ type: "string", value: "bar" })
+        expect(attributes["count"]).to eq({ type: "integer", value: 42 })
       end
     end
 
-    context "when metrics are enabled" do
-      describe ".count" do
-        it "sends a counter metric with default value" do
-          Sentry.metrics.count("test.counter")
-
-          Sentry.get_current_client.flush
-
-          expect(sentry_envelopes.count).to eq(1)
-          expect(sentry_metrics.count).to eq(1)
-
-          metric = sentry_metrics.first
-          expect(metric[:name]).to eq("test.counter")
-          expect(metric[:type]).to eq(:counter)
-          expect(metric[:value]).to eq(1)
-        end
-
-        it "sends a counter metric with custom value" do
-          Sentry.metrics.count("test.counter", value: 5)
-
-          Sentry.get_current_client.flush
-
-          metric = sentry_metrics.first
-          expect(metric[:name]).to eq("test.counter")
-          expect(metric[:type]).to eq(:counter)
-          expect(metric[:value]).to eq(5)
-        end
-
-        it "includes custom attributes" do
-          Sentry.metrics.count("test.counter", attributes: { "foo" => "bar", "count" => 42 })
-
-          Sentry.get_current_client.flush
-
-          metric = sentry_metrics.first
-          attributes = metric[:attributes]
-
-          expect(attributes["foo"]).to eq({ type: "string", value: "bar" })
-          expect(attributes["count"]).to eq({ type: "integer", value: 42 })
-        end
-      end
-
-      describe ".gauge" do
-        it "sends a gauge metric" do
-          Sentry.metrics.gauge("test.gauge", 42.5)
-
-          Sentry.get_current_client.flush
-
-          metric = sentry_metrics.first
-          expect(metric[:name]).to eq("test.gauge")
-          expect(metric[:type]).to eq(:gauge)
-          expect(metric[:value]).to eq(42.5)
-        end
-
-        it "includes custom unit" do
-          Sentry.metrics.gauge("test.memory", 1024, unit: "bytes")
-
-          Sentry.get_current_client.flush
-
-          metric = sentry_metrics.first
-          expect(metric[:unit]).to eq("bytes")
-        end
-
-        it "includes custom attributes" do
-          Sentry.metrics.gauge("test.gauge", 100, attributes: { "region" => "us-west" })
-
-          Sentry.get_current_client.flush
-
-          metric = sentry_metrics.first
-          attributes = metric[:attributes]
-
-          expect(attributes["region"]).to eq({ type: "string", value: "us-west" })
-        end
-      end
-
-      describe ".distribution" do
-        it "sends a distribution metric" do
-          Sentry.metrics.distribution("test.distribution", 3.14)
-
-          Sentry.get_current_client.flush
-
-          metric = sentry_metrics.first
-          expect(metric[:name]).to eq("test.distribution")
-          expect(metric[:type]).to eq(:distribution)
-          expect(metric[:value]).to eq(3.14)
-        end
-
-        it "includes custom unit" do
-          Sentry.metrics.distribution("test.duration", 1.5, unit: "seconds")
-
-          Sentry.get_current_client.flush
-
-          metric = sentry_metrics.first
-          expect(metric[:unit]).to eq("seconds")
-        end
-
-        it "includes custom attributes" do
-          Sentry.metrics.distribution("test.latency", 250, unit: "milliseconds", attributes: { "endpoint" => "/api/users" })
-
-          Sentry.get_current_client.flush
-
-          metric = sentry_metrics.first
-          attributes = metric[:attributes]
-
-          expect(attributes["endpoint"]).to eq({ type: "string", value: "/api/users" })
-        end
-      end
-
-      it "includes trace_id from the scope's propagation context when no span is set" do
-        Sentry.metrics.count("test.counter")
+    describe ".gauge" do
+      it "sends a gauge metric" do
+        Sentry.metrics.gauge("test.gauge", 42.5)
 
         Sentry.get_current_client.flush
 
-        propagation_context = Sentry.get_current_scope.propagation_context
+        metric = sentry_metrics.first
+        expect(metric[:name]).to eq("test.gauge")
+        expect(metric[:type]).to eq(:gauge)
+        expect(metric[:value]).to eq(42.5)
+      end
+
+      it "includes custom unit" do
+        Sentry.metrics.gauge("test.memory", 1024, unit: "bytes")
+
+        Sentry.get_current_client.flush
 
         metric = sentry_metrics.first
-        expect(metric[:trace_id]).to eq(propagation_context.trace_id)
-        expect(metric[:span_id]).to eq(propagation_context.span_id)
+        expect(metric[:unit]).to eq("bytes")
       end
 
-      context "with active transaction" do
-        it "includes trace_id and span_id from the active span" do
-          transaction = Sentry.start_transaction(name: "test_transaction", op: "test.op")
-          span = transaction.start_child(op: "child span")
+      it "includes custom attributes" do
+        Sentry.metrics.gauge("test.gauge", 100, attributes: { "region" => "us-west" })
 
-          Sentry.get_current_scope.set_span(span)
+        Sentry.get_current_client.flush
 
-          Sentry.metrics.count("test.counter")
+        metric = sentry_metrics.first
+        attributes = metric[:attributes]
 
-          transaction.finish
+        expect(attributes["region"]).to eq({ type: "string", value: "us-west" })
+      end
+    end
 
-          Sentry.get_current_client.flush
+    describe ".distribution" do
+      it "sends a distribution metric" do
+        Sentry.metrics.distribution("test.distribution", 3.14)
 
-          # 2 envelopes: metric and transaction
-          expect(sentry_envelopes.size).to eq(2)
+        Sentry.get_current_client.flush
 
-          metric = sentry_metrics.first
+        metric = sentry_metrics.first
+        expect(metric[:name]).to eq("test.distribution")
+        expect(metric[:type]).to eq(:distribution)
+        expect(metric[:value]).to eq(3.14)
+      end
 
-          expect(metric[:trace_id]).to eq(span.trace_id)
-          expect(metric[:span_id]).to eq(span.span_id)
+      it "includes custom unit" do
+        Sentry.metrics.distribution("test.duration", 1.5, unit: "seconds")
+
+        Sentry.get_current_client.flush
+
+        metric = sentry_metrics.first
+        expect(metric[:unit]).to eq("seconds")
+      end
+
+      it "includes custom attributes" do
+        Sentry.metrics.distribution("test.latency", 250, unit: "milliseconds", attributes: { "endpoint" => "/api/users" })
+
+        Sentry.get_current_client.flush
+
+        metric = sentry_metrics.first
+        attributes = metric[:attributes]
+
+        expect(attributes["endpoint"]).to eq({ type: "string", value: "/api/users" })
+      end
+    end
+
+    it "includes trace_id from the scope's propagation context when no span is set" do
+      Sentry.metrics.count("test.counter")
+
+      Sentry.get_current_client.flush
+
+      propagation_context = Sentry.get_current_scope.propagation_context
+
+      metric = sentry_metrics.first
+      expect(metric[:trace_id]).to eq(propagation_context.trace_id)
+      expect(metric[:span_id]).to eq(propagation_context.span_id)
+    end
+
+    context "with active transaction" do
+      it "includes trace_id and span_id from the active span" do
+        transaction = Sentry.start_transaction(name: "test_transaction", op: "test.op")
+        span = transaction.start_child(op: "child span")
+
+        Sentry.get_current_scope.set_span(span)
+
+        Sentry.metrics.count("test.counter")
+
+        transaction.finish
+
+        Sentry.get_current_client.flush
+
+        # 2 envelopes: metric and transaction
+        expect(sentry_envelopes.size).to eq(2)
+
+        metric = sentry_metrics.first
+
+        expect(metric[:trace_id]).to eq(span.trace_id)
+        expect(metric[:span_id]).to eq(span.span_id)
+      end
+    end
+
+    context "with user data on scope" do
+      before do
+        Sentry.configure_scope do |scope|
+          scope.set_user({ id: 123, username: "jane", email: "jane@example.com" })
         end
       end
 
-      context "with user data on scope" do
-        before do
-          Sentry.configure_scope do |scope|
-            scope.set_user({ id: 123, username: "jane", email: "jane@example.com" })
-          end
-        end
-
-        it "includes user attributes in the metric" do
-          Sentry.metrics.count("test.counter")
-
-          Sentry.get_current_client.flush
-
-          metric = sentry_metrics.first
-          attributes = metric[:attributes]
-
-          expect(attributes["user.id"]).to eq({ type: "integer", value: 123 })
-          expect(attributes["user.name"]).to eq({ type: "string", value: "jane" })
-          expect(attributes["user.email"]).to eq({ type: "string", value: "jane@example.com" })
-        end
-      end
-
-      context "with attributes on scope" do
-        it "includes scope attributes with inferred types in the metric" do
-          Sentry.set_attribute("app.flag", true)
-          Sentry.set_attribute("app.duration", 3600, unit: "second")
-
-          Sentry.metrics.count("test.counter")
-
-          Sentry.get_current_client.flush
-
-          attributes = sentry_metrics.first[:attributes]
-
-          expect(attributes["app.flag"]).to eq({ type: "boolean", value: true })
-          expect(attributes["app.duration"]).to eq({ type: "integer", value: 3600, unit: "second" })
-        end
-
-        it "lets metric attributes take precedence over scope attributes" do
-          Sentry.set_attribute("shared", "from_scope")
-
-          Sentry.metrics.count("test.counter", attributes: { "shared" => "from_metric" })
-
-          Sentry.get_current_client.flush
-
-          attributes = sentry_metrics.first[:attributes]
-
-          expect(attributes["shared"]).to eq({ type: "string", value: "from_metric" })
-        end
-      end
-
-      it "includes default attributes from configuration" do
+      it "includes user attributes in the metric" do
         Sentry.metrics.count("test.counter")
 
         Sentry.get_current_client.flush
@@ -224,125 +166,166 @@ RSpec.describe "Sentry Metrics" do
         metric = sentry_metrics.first
         attributes = metric[:attributes]
 
-        expect(attributes["sentry.environment"]).to eq({ type: "string", value: "test" })
-        expect(attributes["sentry.release"]).to eq({ type: "string", value: "test-release" })
-        expect(attributes["server.address"]).to eq({ type: "string", value: "my-server" })
-        expect(attributes["sentry.sdk.name"]).to eq({ type: "string", value: Sentry.sdk_meta["name"] })
-        expect(attributes["sentry.sdk.version"]).to eq({ type: "string", value: Sentry.sdk_meta["version"] })
+        expect(attributes["user.id"]).to eq({ type: "integer", value: 123 })
+        expect(attributes["user.name"]).to eq({ type: "string", value: "jane" })
+        expect(attributes["user.email"]).to eq({ type: "string", value: "jane@example.com" })
       end
+    end
 
-      it "batches multiple metrics into a single envelope" do
-        Sentry.metrics.count("test.counter1", value: 1)
-        Sentry.metrics.count("test.counter2", value: 2)
-        Sentry.metrics.gauge("test.gauge", 42)
+    context "with attributes on scope" do
+      it "includes scope attributes with inferred types in the metric" do
+        Sentry.set_attribute("app.flag", true)
+        Sentry.set_attribute("app.duration", 3600, unit: "second")
+
+        Sentry.metrics.count("test.counter")
 
         Sentry.get_current_client.flush
 
-        expect(sentry_envelopes.count).to eq(1)
-        expect(sentry_metrics.count).to eq(3)
+        attributes = sentry_metrics.first[:attributes]
 
-        metric_names = sentry_metrics.map { |m| m[:name] }
-        expect(metric_names).to contain_exactly("test.counter1", "test.counter2", "test.gauge")
+        expect(attributes["app.flag"]).to eq({ type: "boolean", value: true })
+        expect(attributes["app.duration"]).to eq({ type: "integer", value: 3600, unit: "second" })
       end
 
-      describe "envelope structure" do
-        it "includes correct envelope headers" do
-          Sentry.metrics.count("test.counter")
-          Sentry.get_current_client.flush
+      it "lets metric attributes take precedence over scope attributes" do
+        Sentry.set_attribute("shared", "from_scope")
 
-          envelope = sentry_envelopes.first
-          headers = envelope.headers
+        Sentry.metrics.count("test.counter", attributes: { "shared" => "from_metric" })
 
-          expect(headers[:event_id]).to match(/\A[0-9a-f]{32}\z/) # UUID format
-          expect(headers[:sent_at]).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/) # ISO8601 timestamp
-          expect(headers[:dsn]).to eq(Sentry.configuration.dsn)
-          expect(headers[:sdk]).to eq(Sentry.sdk_meta)
-        end
+        Sentry.get_current_client.flush
 
-        it "includes correct envelope item headers" do
-          Sentry.metrics.count("test.counter1")
-          Sentry.metrics.gauge("test.gauge", 42)
-          Sentry.get_current_client.flush
+        attributes = sentry_metrics.first[:attributes]
 
-          envelope = sentry_envelopes.first
-          item = envelope.items.first
+        expect(attributes["shared"]).to eq({ type: "string", value: "from_metric" })
+      end
+    end
 
-          # Verify envelope item headers
-          expect(item.headers[:type]).to eq("trace_metric")
-          expect(item.headers[:item_count]).to eq(2)
-          expect(item.headers[:content_type]).to eq("application/vnd.sentry.items.trace-metric+json")
-        end
+    it "includes default attributes from configuration" do
+      Sentry.metrics.count("test.counter")
 
-        it "includes correct payload structure" do
-          Sentry.metrics.count("test.counter")
-          Sentry.get_current_client.flush
+      Sentry.get_current_client.flush
 
-          envelope = sentry_envelopes.first
-          item = envelope.items.first
-          payload = item.payload
+      metric = sentry_metrics.first
+      attributes = metric[:attributes]
 
-          # Verify payload structure
-          expect(payload).to have_key(:items)
-          expect(payload[:items]).to be_an(Array)
-          expect(payload[:items].size).to eq(1)
+      expect(attributes["sentry.environment"]).to eq({ type: "string", value: "test" })
+      expect(attributes["sentry.release"]).to eq({ type: "string", value: "test-release" })
+      expect(attributes["server.address"]).to eq({ type: "string", value: "my-server" })
+      expect(attributes["sentry.sdk.name"]).to eq({ type: "string", value: Sentry.sdk_meta["name"] })
+      expect(attributes["sentry.sdk.version"]).to eq({ type: "string", value: Sentry.sdk_meta["version"] })
+    end
 
-          metric_item = payload[:items].first
-          expect(metric_item).to be_a(Hash)
-          expect(metric_item).to have_key(:name)
-          expect(metric_item).to have_key(:type)
-          expect(metric_item).to have_key(:value)
-          expect(metric_item).to have_key(:attributes)
-          expect(metric_item).to have_key(:trace_id)
-          expect(metric_item).to have_key(:span_id)
-        end
+    it "batches multiple metrics into a single envelope" do
+      Sentry.metrics.count("test.counter1", value: 1)
+      Sentry.metrics.count("test.counter2", value: 2)
+      Sentry.metrics.gauge("test.gauge", 42)
+
+      Sentry.get_current_client.flush
+
+      expect(sentry_envelopes.count).to eq(1)
+      expect(sentry_metrics.count).to eq(3)
+
+      metric_names = sentry_metrics.map { |m| m[:name] }
+      expect(metric_names).to contain_exactly("test.counter1", "test.counter2", "test.gauge")
+    end
+
+    describe "envelope structure" do
+      it "includes correct envelope headers" do
+        Sentry.metrics.count("test.counter")
+        Sentry.get_current_client.flush
+
+        envelope = sentry_envelopes.first
+        headers = envelope.headers
+
+        expect(headers[:event_id]).to match(/\A[0-9a-f]{32}\z/) # UUID format
+        expect(headers[:sent_at]).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/) # ISO8601 timestamp
+        expect(headers[:dsn]).to eq(Sentry.configuration.dsn)
+        expect(headers[:sdk]).to eq(Sentry.sdk_meta)
       end
 
-      context "with before_send_metric callback" do
-        it "receives MetricEvent" do
-          perform_basic_setup do |config|
-            config.before_send_metric = lambda do |metric|
-              expect(metric).to be_a(Sentry::MetricEvent)
-              metric
-            end
-          end
+      it "includes correct envelope item headers" do
+        Sentry.metrics.count("test.counter1")
+        Sentry.metrics.gauge("test.gauge", 42)
+        Sentry.get_current_client.flush
 
-          Sentry.metrics.gauge("test.gauge", 42.5, unit: "seconds", attributes: { "foo" => "bar" })
-          Sentry.get_current_client.flush
+        envelope = sentry_envelopes.first
+        item = envelope.items.first
+
+        # Verify envelope item headers
+        expect(item.headers[:type]).to eq("trace_metric")
+        expect(item.headers[:item_count]).to eq(2)
+        expect(item.headers[:content_type]).to eq("application/vnd.sentry.items.trace-metric+json")
+      end
+
+      it "includes correct payload structure" do
+        Sentry.metrics.count("test.counter")
+        Sentry.get_current_client.flush
+
+        envelope = sentry_envelopes.first
+        item = envelope.items.first
+        payload = item.payload
+
+        # Verify payload structure
+        expect(payload).to have_key(:items)
+        expect(payload[:items]).to be_an(Array)
+        expect(payload[:items].size).to eq(1)
+
+        metric_item = payload[:items].first
+        expect(metric_item).to be_a(Hash)
+        expect(metric_item).to have_key(:name)
+        expect(metric_item).to have_key(:type)
+        expect(metric_item).to have_key(:value)
+        expect(metric_item).to have_key(:attributes)
+        expect(metric_item).to have_key(:trace_id)
+        expect(metric_item).to have_key(:span_id)
+      end
+    end
+
+    context "with before_send_metric callback" do
+      it "receives MetricEvent" do
+        perform_basic_setup do |config|
+          config.before_send_metric = lambda do |metric|
+            expect(metric).to be_a(Sentry::MetricEvent)
+            metric
+          end
         end
 
-        it "allows modifying metrics before sending" do
-          perform_basic_setup do |config|
-            config.before_send_metric = lambda do |metric|
-              metric.attributes["modified"] = true
-              metric
-            end
+        Sentry.metrics.gauge("test.gauge", 42.5, unit: "seconds", attributes: { "foo" => "bar" })
+        Sentry.get_current_client.flush
+      end
+
+      it "allows modifying metrics before sending" do
+        perform_basic_setup do |config|
+          config.before_send_metric = lambda do |metric|
+            metric.attributes["modified"] = true
+            metric
           end
-
-          Sentry.metrics.count("test.counter")
-
-          Sentry.get_current_client.flush
-
-          metric = sentry_metrics.first
-          expect(metric[:attributes]["modified"]).to eq({ type: "boolean", value: true })
         end
 
-        it "filters out metrics when callback returns nil" do
-          perform_basic_setup do |config|
-            config.before_send_metric = lambda do |metric|
-              metric.name == "test.filtered" ? nil : metric
-            end
+        Sentry.metrics.count("test.counter")
+
+        Sentry.get_current_client.flush
+
+        metric = sentry_metrics.first
+        expect(metric[:attributes]["modified"]).to eq({ type: "boolean", value: true })
+      end
+
+      it "filters out metrics when callback returns nil" do
+        perform_basic_setup do |config|
+          config.before_send_metric = lambda do |metric|
+            metric.name == "test.filtered" ? nil : metric
           end
-
-          Sentry.metrics.count("test.filtered")
-          Sentry.metrics.gauge("test.filtered", 42)
-          Sentry.metrics.count("test.allowed")
-
-          Sentry.get_current_client.flush
-
-          expect(sentry_metrics.count).to eq(1)
-          expect(sentry_metrics.first[:name]).to eq("test.allowed")
-          expect(Sentry.get_current_client.transport).to have_recorded_lost_event(:before_send, 'trace_metric', num: 2, num_bytes: a_value > 0)
         end
+
+        Sentry.metrics.count("test.filtered")
+        Sentry.metrics.gauge("test.filtered", 42)
+        Sentry.metrics.count("test.allowed")
+
+        Sentry.get_current_client.flush
+
+        expect(sentry_metrics.count).to eq(1)
+        expect(sentry_metrics.first[:name]).to eq("test.allowed")
+        expect(Sentry.get_current_client.transport).to have_recorded_lost_event(:before_send, 'trace_metric', num: 2, num_bytes: a_value > 0)
       end
     end
   end

--- a/sentry-yabeda/README.md
+++ b/sentry-yabeda/README.md
@@ -29,12 +29,11 @@ gem "sentry-ruby"
 gem "sentry-yabeda"
 ```
 
-Then initialize Sentry with metrics enabled:
+Then initialize Sentry:
 
 ```ruby
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
-  config.enable_metrics = true
 end
 ```
 

--- a/sentry-yabeda/lib/sentry/yabeda/adapter.rb
+++ b/sentry-yabeda/lib/sentry/yabeda/adapter.rb
@@ -57,7 +57,7 @@ module Sentry
       private
 
       def enabled?
-        Sentry.initialized? && Sentry.configuration.enable_metrics
+        Sentry.initialized?
       end
 
       def attributes_for(tags)

--- a/sentry-yabeda/lib/sentry/yabeda/configuration.rb
+++ b/sentry-yabeda/lib/sentry/yabeda/configuration.rb
@@ -3,10 +3,8 @@
 module Sentry
   class Configuration
     after(:configured) do
-      if enable_metrics
-        Sentry::Yabeda.collector&.kill
-        Sentry::Yabeda.collector = Sentry::Yabeda::Collector.new(self)
-      end
+      Sentry::Yabeda.collector&.kill
+      Sentry::Yabeda.collector = Sentry::Yabeda::Collector.new(self)
     end
 
     after(:closed) do

--- a/sentry-yabeda/spec/sentry/yabeda/adapter_spec.rb
+++ b/sentry-yabeda/spec/sentry/yabeda/adapter_spec.rb
@@ -196,44 +196,6 @@ RSpec.describe Sentry::Yabeda::Adapter do
       counter = build_metric(:counter, name: :requests, group: :rails)
       adapter.perform_counter_increment!(counter, {}, 1)
     end
-
-    it "does not emit metrics when metrics are disabled" do
-      perform_basic_setup do |config|
-        config.enable_metrics = false
-      end
-
-      expect(Sentry.metrics).not_to receive(:count)
-
-      counter = build_metric(:counter, name: :requests, group: :rails)
-      adapter.perform_counter_increment!(counter, {}, 1)
-    end
-
-    it "does not emit gauge when metrics are disabled" do
-      perform_basic_setup { |c| c.enable_metrics = false }
-
-      expect(Sentry.metrics).not_to receive(:gauge)
-
-      gauge = build_metric(:gauge, name: :queue_depth)
-      adapter.perform_gauge_set!(gauge, {}, 1)
-    end
-
-    it "does not emit histogram when metrics are disabled" do
-      perform_basic_setup { |c| c.enable_metrics = false }
-
-      expect(Sentry.metrics).not_to receive(:distribution)
-
-      histogram = build_metric(:histogram, name: :duration)
-      adapter.perform_histogram_measure!(histogram, {}, 1.0)
-    end
-
-    it "does not emit summary when metrics are disabled" do
-      perform_basic_setup { |c| c.enable_metrics = false }
-
-      expect(Sentry.metrics).not_to receive(:distribution)
-
-      summary = build_metric(:summary, name: :response_size)
-      adapter.perform_summary_observe!(summary, {}, 100)
-    end
   end
 
   describe "tag passthrough" do

--- a/sentry-yabeda/spec/sentry/yabeda/collector_spec.rb
+++ b/sentry-yabeda/spec/sentry/yabeda/collector_spec.rb
@@ -41,21 +41,8 @@ RSpec.describe Sentry::Yabeda::Collector do
   end
 
   describe "auto-start" do
-    it "starts automatically when Sentry is initialized with enable_metrics" do
+    it "starts automatically when Sentry is initialized" do
       expect(Sentry::Yabeda.collector).to be_a(described_class)
-    end
-
-    it "does not start when enable_metrics is false" do
-      Sentry.close
-
-      Sentry.init do |config|
-        config.dsn = DUMMY_DSN
-        config.sdk_logger = ::Logger.new(nil)
-        config.transport.transport_class = Sentry::DummyTransport
-        config.enable_metrics = false
-      end
-
-      expect(Sentry::Yabeda.collector).to be_nil
     end
 
     it "replaces an existing collector on re-initialization via close" do

--- a/sentry-yabeda/spec/sentry/yabeda/integration_spec.rb
+++ b/sentry-yabeda/spec/sentry/yabeda/integration_spec.rb
@@ -123,20 +123,6 @@ RSpec.describe "Yabeda-Sentry integration" do
     metric = sentry_metrics.first
     expect(metric[:trace_id]).to eq(transaction.trace_id)
   end
-
-  context "when metrics are disabled" do
-    before do
-      Sentry.configuration.enable_metrics = false
-    end
-
-    it "does not send metrics to Sentry" do
-      ::Yabeda.myapp.orders_created.increment({ region: "us-east" })
-
-      Sentry.get_current_client.flush
-
-      expect(sentry_metrics).to be_empty
-    end
-  end
 end
 
 RSpec.describe "Yabeda-Sentry integration when Sentry is not initialized" do

--- a/sentry-yabeda/spec/spec_helper.rb
+++ b/sentry-yabeda/spec/spec_helper.rb
@@ -56,7 +56,6 @@ def perform_basic_setup
     config.sdk_logger = ::Logger.new(nil)
     config.background_worker_threads = 0
     config.transport.transport_class = Sentry::DummyTransport
-    config.enable_metrics = true
 
     yield config if block_given?
   end


### PR DESCRIPTION
### Changelog Entry

[Metrics](https://docs.sentry.io/product/metrics/) are now enabled by default and `enable_metrics` is removed.